### PR TITLE
Fix budget setter accessibility

### DIFF
--- a/ConstructionProject.cs
+++ b/ConstructionProject.cs
@@ -15,9 +15,10 @@ namespace StrategyGame
         // Budget is the total amount allocated for the project. It is spent
         // gradually during construction rather than paid up front.
         public decimal Budget { get; private set; }
-        // Allow other classes to update the remaining budget as costs are paid
-        // over time. Previously the setter was private which caused a compiler
-        // error when other classes attempted to deduct costs.
+        // Allow other classes such as ConstructionCompany to deduct expenses
+        // from the project's budget as work progresses. Without a public
+        // setter the compiler would raise CS0272 when those classes attempted
+        // to decrease the remaining budget.
         public decimal BudgetRemaining { get; set; }
         public int Duration { get; private set; } // Duration in days
         public int Progress { get; private set; } // Progress in days completed


### PR DESCRIPTION
## Summary
- clarify accessibility of `BudgetRemaining` setter in `ConstructionProject`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ad91544fc832395f5c8458cc5cab5