### PR TITLE
Add designer file for PolicyManagerForm

### DIFF
--- a/Country.cs
+++ b/Country.cs
@@ -13,6 +13,7 @@ namespace StrategyGame
         public double NationalExpenses { get; set; } // General national expenses
         public Dictionary<string, double> Resources { get; private set; }
         public NationalFinancialSystem FinancialSystem { get; private set; }
+        public Government Government { get; private set; }
 
         public Country(string name)
         {
@@ -23,6 +24,10 @@ namespace StrategyGame
             Resources = new Dictionary<string, double>();
             // Initialize the financial system for the country
             FinancialSystem = new NationalFinancialSystem(name, (decimal)Budget, 50000m, CurrencyStandard.Fiat);
+            // Initialize basic government structure
+            Government = new Government();
+            Government.Parties.Add(new PoliticalParty { Name = $"{name} Conservative Party", ShareOfGovernment = 0.5 });
+            Government.Parties.Add(new PoliticalParty { Name = $"{name} Liberal Party", ShareOfGovernment = 0.5 });
         }
 
         public void AddResource(string resourceName, double amount)

--- a/Government.cs
+++ b/Government.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+
+namespace StrategyGame
+{
+    public class PoliticalParty
+    {
+        public string Name { get; set; }
+        public double ShareOfGovernment { get; set; } // 0-1 range
+    }
+
+    public enum PolicyType
+    {
+        Economic,
+        Financial,
+        Political
+    }
+
+    public class Policy
+    {
+        public string Name { get; set; }
+        public PolicyType Type { get; set; }
+        public string Description { get; set; }
+        public bool IsActive { get; set; }
+
+        public Policy(string name, PolicyType type, string description = "")
+        {
+            Name = name;
+            Type = type;
+            Description = description;
+            IsActive = true;
+        }
+    }
+
+    public class Department
+    {
+        public string Name { get; set; }
+        public decimal BudgetAllocation { get; set; }
+        // TODO: Add control logic for department actions
+    }
+
+    public class Government
+    {
+        public List<PoliticalParty> Parties { get; set; }
+        public List<Policy> Policies { get; set; }
+        public List<Department> Departments { get; set; }
+
+        public Government()
+        {
+            Parties = new List<PoliticalParty>();
+            Policies = new List<Policy>();
+            Departments = new List<Department>();
+            // Default department is a state bank
+            Departments.Add(new Department { Name = "State Bank", BudgetAllocation = 0 });
+        }
+
+        public void AddPolicy(Policy policy) => Policies.Add(policy);
+        public void AddDepartment(Department dept) => Departments.Add(dept);
+    }
+}

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -18,6 +18,11 @@ namespace economy_sim
         private Random random = new Random(); // Add a Random instance for AI and other uses
         private StrategyGame.DiplomacyManager diplomacyManager; // Added DiplomacyManager field
         private ListView listViewDiplomacy; // Added ListView for diplomacy
+        // Government UI fields
+        private TabPage tabPageGovernment;
+        private ListView listViewParties;
+        private Button buttonOpenPolicyManager;
+        private PolicyManagerForm policyManagerForm;
 
         // Fields to store previous values for change tracking
         private Dictionary<string, double> prevCityMetrics = new Dictionary<string, double>();
@@ -90,10 +95,13 @@ namespace economy_sim
 
             // Initialize the Debug tab
             InitializeDebugTab();
-            
+
             // Initialize and populate Finance tab
             InitializeFinanceTab();
             UpdateFinanceTab();
+            // Initialize Government tab
+            InitializeGovernmentTab();
+            UpdateGovernmentTab();
 
             UpdateOrderLists();
             timerSim.Tick += TimerSim_Tick;
@@ -957,6 +965,10 @@ namespace economy_sim
             {
                 UpdateFinanceTab();
             }
+            if (tabControlMain.SelectedTab == tabPageGovernment)
+            {
+                UpdateGovernmentTab();
+            }
 
             // Process AI trade proposals (temporary simple logic)
             if (diplomacyManager != null && playerCountry != null && random.Next(100) < 20) // 20% chance each turn
@@ -1281,9 +1293,13 @@ namespace economy_sim
             {
                 UpdateFinanceTab();
             }
+            if (tabControlMain.SelectedTab == tabPageGovernment)
+            {
+                UpdateGovernmentTab();
+            }
 
             // Debug and diplomacy handled similarly
-            
+
         }
 
         private void ListBox_DrawItemShared(object sender, DrawItemEventArgs e)
@@ -1735,6 +1751,62 @@ namespace economy_sim
             listViewFinance.Columns.Add("Credit Rating", 80);
 
             // Bond UI removed
+        }
+
+        // --- Government Tab ---
+        private void InitializeGovernmentTab()
+        {
+            tabPageGovernment = new TabPage("Government");
+
+            listViewParties = new ListView
+            {
+                View = View.Details,
+                FullRowSelect = true,
+                GridLines = true,
+                Location = new System.Drawing.Point(10, 10),
+                Size = new System.Drawing.Size(400, 200)
+            };
+            listViewParties.Columns.Add("Party", 200);
+            listViewParties.Columns.Add("Share", 80);
+
+            buttonOpenPolicyManager = new Button
+            {
+                Text = "Open Policy Manager",
+                Location = new System.Drawing.Point(10, 220),
+                Size = new System.Drawing.Size(150, 30)
+            };
+            buttonOpenPolicyManager.Click += ButtonOpenPolicyManager_Click;
+
+            tabPageGovernment.Controls.Add(listViewParties);
+            tabPageGovernment.Controls.Add(buttonOpenPolicyManager);
+
+            tabControlMain.Controls.Add(tabPageGovernment);
+
+            policyManagerForm = new PolicyManagerForm(playerCountry?.Government);
+        }
+
+        private void UpdateGovernmentTab()
+        {
+            if (playerCountry?.Government == null) return;
+            listViewParties.Items.Clear();
+            foreach (var party in playerCountry.Government.Parties)
+            {
+                var item = new ListViewItem(party.Name);
+                item.SubItems.Add($"{party.ShareOfGovernment:P0}");
+                listViewParties.Items.Add(item);
+            }
+        }
+
+        private void ButtonOpenPolicyManager_Click(object sender, EventArgs e)
+        {
+            if (playerCountry?.Government == null) return;
+            if (policyManagerForm == null || policyManagerForm.IsDisposed)
+            {
+                policyManagerForm = new PolicyManagerForm(playerCountry.Government);
+            }
+            policyManagerForm.RefreshData();
+            policyManagerForm.Show();
+            policyManagerForm.BringToFront();
         }
 
     }

--- a/PolicyManagerForm.Designer.cs
+++ b/PolicyManagerForm.Designer.cs
@@ -1,0 +1,48 @@
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace economy_sim
+{
+    public partial class PolicyManagerForm : Form
+    {
+        private ListView listViewPolicies;
+        private ListView listViewDepartments;
+
+        private void InitializeComponent()
+        {
+            this.listViewPolicies = new System.Windows.Forms.ListView();
+            this.listViewDepartments = new System.Windows.Forms.ListView();
+            this.SuspendLayout();
+            // 
+            // listViewPolicies
+            // 
+            this.listViewPolicies.View = System.Windows.Forms.View.Details;
+            this.listViewPolicies.FullRowSelect = true;
+            this.listViewPolicies.GridLines = true;
+            this.listViewPolicies.Location = new System.Drawing.Point(10, 10);
+            this.listViewPolicies.Size = new System.Drawing.Size(560, 200);
+            this.listViewPolicies.Columns.Add("Policy", 200);
+            this.listViewPolicies.Columns.Add("Type", 100);
+            this.listViewPolicies.Columns.Add("Active", 80);
+            // 
+            // listViewDepartments
+            // 
+            this.listViewDepartments.View = System.Windows.Forms.View.Details;
+            this.listViewDepartments.FullRowSelect = true;
+            this.listViewDepartments.GridLines = true;
+            this.listViewDepartments.Location = new System.Drawing.Point(10, 220);
+            this.listViewDepartments.Size = new System.Drawing.Size(560, 120);
+            this.listViewDepartments.Columns.Add("Department", 200);
+            this.listViewDepartments.Columns.Add("Budget", 100);
+            // 
+            // PolicyManagerForm
+            // 
+            this.ClientSize = new System.Drawing.Size(600, 400);
+            this.Controls.Add(this.listViewPolicies);
+            this.Controls.Add(this.listViewDepartments);
+            this.Name = "PolicyManagerForm";
+            this.Text = "Policy Manager";
+            this.ResumeLayout(false);
+        }
+    }
+}

--- a/PolicyManagerForm.cs
+++ b/PolicyManagerForm.cs
@@ -1,0 +1,42 @@
+using System.Windows.Forms;
+
+namespace economy_sim
+{
+    public partial class PolicyManagerForm : Form
+    {
+        private StrategyGame.Government government;
+
+        public PolicyManagerForm(StrategyGame.Government gov)
+        {
+            government = gov;
+            InitializeComponent();
+        }
+
+        public void RefreshData()
+        {
+            if (government == null) return;
+            listViewPolicies.Items.Clear();
+            foreach (var policy in government.Policies)
+            {
+                var item = new ListViewItem(policy.Name);
+                item.SubItems.Add(policy.Type.ToString());
+                item.SubItems.Add(policy.IsActive ? "Yes" : "No");
+                listViewPolicies.Items.Add(item);
+            }
+
+            listViewDepartments.Items.Clear();
+            foreach (var dept in government.Departments)
+            {
+                var item = new ListViewItem(dept.Name);
+                item.SubItems.Add(dept.BudgetAllocation.ToString("N0"));
+                listViewDepartments.Items.Add(item);
+            }
+        }
+
+        protected override void OnFormClosing(FormClosingEventArgs e)
+        {
+            e.Cancel = true;
+            this.Hide();
+        }
+    }
+}

--- a/economy sim.csproj
+++ b/economy sim.csproj
@@ -120,6 +120,13 @@
     </Compile>
     <Compile Include="Suburb.cs" />
     <Compile Include="DebugLogger.cs" />
+    <Compile Include="Government.cs" />
+    <Compile Include="PolicyManagerForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="PolicyManagerForm.Designer.cs">
+      <DependentUpon>PolicyManagerForm.cs</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />

--- a/government_features_report.md
+++ b/government_features_report.md
@@ -1,0 +1,16 @@
+# Government Features Implementation
+
+This update introduces a basic government system with political parties, policies and departments.
+
+## Key Elements
+- **Government class** with lists of parties, policies and departments.
+- **PoliticalParty** records party name and share of power.
+- **Policy** objects store policy name, type and status. Types include `Economic`, `Financial` and `Political`.
+- **Department** class defines government departments (state bank is created by default).
+
+## User Interface
+- Added a **Government** tab to the main game window. It lists political parties and their share of government.
+- A **Policy Manager** button opens a new window displaying existing policies and departments.
+
+## Notes
+The Department class currently only stores a name and budget allocation; behaviour for AI or player control is left as a future task.


### PR DESCRIPTION
## Summary
- move PolicyManagerForm layout code to a new Designer file
- update PolicyManagerForm.cs to use InitializeComponent
- include designer file in project

## Testing
- `dotnet build "economy sim.csproj" -nologo` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d339ea2588323b578e24e918d647a