### PR TITLE
Integrate country overlay on map

### DIFF
--- a/MainGame.cs
+++ b/MainGame.cs
@@ -255,7 +255,7 @@ namespace economy_sim
             int height = pictureBox1.Height;
 
             pictureBox1.Image?.Dispose();
-            pictureBox1.Image = PixelMapGenerator.GeneratePixelArtMap(width, height);
+            pictureBox1.Image = PixelMapGenerator.GeneratePixelArtMapWithCountries(width, height);
 
 
         }

--- a/PixelMapGenerator.cs
+++ b/PixelMapGenerator.cs
@@ -15,6 +15,8 @@ namespace StrategyGame
     {
         private static readonly string TifPath =
      @"C:\Users\kayla\source\repos\bitzy06\resources\ETOPO1_Bed_g_geotiff.tif";
+        private static readonly string ShpPath =
+     @"C:\Users\kayla\source\repos\bitzy06\economy-sim\data\ne_10m_admin_0_countries.shp";
 
         /// <summary>
         /// Ensures the GeoTIFF file exists by invoking fetch_etopo1.py if needed.
@@ -79,8 +81,37 @@ namespace StrategyGame
                     }
                 }
 
-                return dest;
+               return dest;
+           }
+       }
+
+        /// <summary>
+        /// Generates a terrain map and overlays country borders.
+        /// </summary>
+        public static Bitmap GeneratePixelArtMapWithCountries(int width, int height)
+        {
+            Bitmap baseMap = GeneratePixelArtMap(width, height);
+            try
+            {
+                int[,] mask = CountryMaskGenerator.CreateCountryMask(TifPath, ShpPath, width, height);
+                for (int y = 1; y < height - 1; y++)
+                {
+                    for (int x = 1; x < width - 1; x++)
+                    {
+                        int code = mask[y, x];
+                        if (code != mask[y - 1, x] || code != mask[y + 1, x] ||
+                            code != mask[y, x - 1] || code != mask[y, x + 1])
+                        {
+                            baseMap.SetPixel(x, y, Color.Black);
+                        }
+                    }
+                }
             }
+            catch (Exception ex)
+            {
+                DebugLogger.Log("Country overlay failed: " + ex.Message);
+            }
+            return baseMap;
         }
 
         private static Color GetAltitudeColor(float value)


### PR DESCRIPTION
## Summary
- add numeric ISO field to CountryMaskGenerator and allow custom output size
- overlay country borders on map using new `GeneratePixelArtMapWithCountries`
- update `MainGame` to display the new map

## Testing
- `msbuild` *(fails: command not found)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d5a848398832389044722556c6cd7