### PR TITLE
Add zoom feature for map

### DIFF
--- a/MainGame.Designer.cs
+++ b/MainGame.Designer.cs
@@ -74,7 +74,9 @@
             this.labelCountryStats = new System.Windows.Forms.Label();
             this.comboBoxCountry = new System.Windows.Forms.ComboBox();
             this.tabPageCountry = new System.Windows.Forms.TabPage();
+            this.panelMap = new System.Windows.Forms.Panel();
             this.pictureBox1 = new System.Windows.Forms.PictureBox();
+            this.trackBarZoom = new System.Windows.Forms.TrackBar();
             this.tabControlMain = new System.Windows.Forms.TabControl();
             this.tabPageCompanies.SuspendLayout();
             this.tabPageFinance.SuspendLayout();
@@ -83,6 +85,7 @@
             this.tabPageCity.SuspendLayout();
             this.tabPageCountry.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.trackBarZoom)).BeginInit();
             this.tabControlMain.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -474,23 +477,43 @@
             this.comboBoxCountry.TabIndex = 0;
             // 
             // tabPageCountry
-            // 
-            this.tabPageCountry.Controls.Add(this.pictureBox1);
+            //
+            this.tabPageCountry.Controls.Add(this.panelMap);
+            this.tabPageCountry.Controls.Add(this.trackBarZoom);
             this.tabPageCountry.Location = new System.Drawing.Point(4, 22);
             this.tabPageCountry.Name = "tabPageCountry";
             this.tabPageCountry.Size = new System.Drawing.Size(822, 454);
             this.tabPageCountry.TabIndex = 0;
             this.tabPageCountry.Text = "Map";
-            // 
+            //
+            // panelMap
+            //
+            this.panelMap.AutoScroll = true;
+            this.panelMap.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panelMap.Location = new System.Drawing.Point(0, 0);
+            this.panelMap.Name = "panelMap";
+            this.panelMap.Size = new System.Drawing.Size(822, 429);
+            this.panelMap.TabIndex = 1;
+            this.panelMap.Controls.Add(this.pictureBox1);
+            //
             // pictureBox1
-            // 
-            this.pictureBox1.Dock = System.Windows.Forms.DockStyle.Fill;
+            //
             this.pictureBox1.Location = new System.Drawing.Point(0, 0);
             this.pictureBox1.Name = "pictureBox1";
-            this.pictureBox1.Size = new System.Drawing.Size(822, 454);
-            this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
+            this.pictureBox1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.AutoSize;
             this.pictureBox1.TabIndex = 0;
             this.pictureBox1.TabStop = false;
+            //
+            // trackBarZoom
+            //
+            this.trackBarZoom.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.trackBarZoom.Location = new System.Drawing.Point(0, 429);
+            this.trackBarZoom.Minimum = 1;
+            this.trackBarZoom.Maximum = 5;
+            this.trackBarZoom.Name = "trackBarZoom";
+            this.trackBarZoom.Size = new System.Drawing.Size(822, 25);
+            this.trackBarZoom.TabIndex = 2;
+            this.trackBarZoom.Value = 1;
             // 
             // tabControlMain
             // 
@@ -524,6 +547,7 @@
             this.tabPageCity.ResumeLayout(false);
             this.tabPageCountry.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.trackBarZoom)).EndInit();
             this.tabControlMain.ResumeLayout(false);
             this.ResumeLayout(false);
 
@@ -567,6 +591,8 @@
         private System.Windows.Forms.ListBox listBoxFactoryStats;
         private System.Windows.Forms.TabPage tabPageCountry;
         private System.Windows.Forms.PictureBox pictureBox1;
+        private System.Windows.Forms.Panel panelMap;
+        private System.Windows.Forms.TrackBar trackBarZoom;
         private System.Windows.Forms.TabControl tabControlMain;
     }
 }

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -54,6 +54,8 @@ namespace economy_sim
 
         private bool isDetailedDebugMode = false; // Flag to track the current debug mode
 
+        private int mapZoom = 1;
+
         public MainGame()
         {
             InitializeComponent();
@@ -72,6 +74,7 @@ namespace economy_sim
             comboBoxStates.SelectedIndexChanged += ComboBoxStates_SelectedIndexChanged;
             comboBoxCities.SelectedIndexChanged += ComboBoxCities_SelectedIndexChanged;
             comboBoxCountry.SelectedIndexChanged += ComboBoxCountry_SelectedIndexChanged;
+            trackBarZoom.ValueChanged += trackBarZoom_ValueChanged;
 
             InitializeGameData();
             
@@ -259,12 +262,18 @@ namespace economy_sim
         }
         private void RefreshAsciiMap()
         {
-            // Generate the map sized to the PictureBox dimensions
-            int width = pictureBox1.Width;
-            int height = pictureBox1.Height;
+            // Generate the map sized according to the zoom level
+            if (panelMap.Width == 0 || panelMap.Height == 0)
+                return;
+
+            int baseWidth = panelMap.ClientSize.Width;
+            int baseHeight = panelMap.ClientSize.Height;
+            int width = baseWidth * mapZoom;
+            int height = baseHeight * mapZoom;
 
             pictureBox1.Image?.Dispose();
             pictureBox1.Image = PixelMapGenerator.GeneratePixelArtMapWithCountries(width, height);
+            pictureBox1.Size = new Size(width, height);
           //  pictureBox1.Image = PixelMapGenerator.GenerateTerrainPixelArtMap(width, height,5); // Use the new terrain map generator
 
 
@@ -1832,6 +1841,12 @@ namespace economy_sim
             policyManagerForm.RefreshData();
             policyManagerForm.Show();
             policyManagerForm.BringToFront();
+        }
+
+        private void trackBarZoom_ValueChanged(object sender, EventArgs e)
+        {
+            mapZoom = trackBarZoom.Value;
+            RefreshAsciiMap();
         }
 
     }


### PR DESCRIPTION
## Summary
- add scrollable panel and trackbar for zoom control in map tab
- regenerate pixel map based on zoom level

## Testing
- `dotnet build "economy sim.csproj"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d8bdd8484832385bc7e1626154399