### PR TITLE
Add worker and resource costing to construction projects

### DIFF
--- a/ConstructionProject.cs
+++ b/ConstructionProject.cs
@@ -26,12 +26,16 @@ namespace StrategyGame
         public int Cost {  get; private set; } // Cost per day of construction
         public string RequiredResource { get; private set; }
         public int ResourcePerDay { get; private set; }
+        public int WorkersRequired { get; private set; }
+        public decimal WorkerWagePerDay { get; private set; }
+        public decimal WorkerCostPerDay => WorkersRequired * WorkerWagePerDay;
+        public bool GovernmentSponsored { get; private set; }
 
         public ConstructionCompany AssignedCompany { get; set; }
 
         public const decimal MinimumDailyBudget = 100m;
 
-        public ConstructionProject(ProjectType type, decimal budget, int duration, double output, string requiredResource, int resourcePerDay)
+        public ConstructionProject(ProjectType type, decimal budget, int duration, double output, string requiredResource, int resourcePerDay, int workersRequired = 0, decimal workerWagePerDay = 0m, bool governmentSponsored = false)
         {
             Type = type;
             Budget = budget;
@@ -40,6 +44,9 @@ namespace StrategyGame
             Output = output;
             RequiredResource = requiredResource;
             ResourcePerDay = resourcePerDay;
+            WorkersRequired = workersRequired;
+            WorkerWagePerDay = workerWagePerDay;
+            GovernmentSponsored = governmentSponsored;
             Progress = 0;
         }
 


### PR DESCRIPTION
## Summary
- add worker budgeting fields to `ConstructionProject`
- add helper `ConstructionCompany.StartProject`
- account for resource and worker costs during construction
- halt projects when the budget runs out and note TODO for government-sponsored works

## Testing
- `dotnet build 'economy sim.sln' -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d8cfdd33c8323879a105fe07517ad