### PR TITLE
Fix map interaction and enhance pixel cell resolution

### DIFF
--- a/MainGame.Designer.cs
+++ b/MainGame.Designer.cs
@@ -540,14 +540,15 @@
             // 
             // pictureBox1
             // 
-            pictureBox1.Dock = DockStyle.Fill;
+            pictureBox1.Dock = DockStyle.None;
             pictureBox1.Location = new Point(0, 0);
             pictureBox1.Margin = new Padding(4, 3, 4, 3);
             pictureBox1.Name = "pictureBox1";
             pictureBox1.Size = new Size(960, 526);
-            pictureBox1.SizeMode = PictureBoxSizeMode.AutoSize;
+            pictureBox1.SizeMode = PictureBoxSizeMode.Normal;
             pictureBox1.TabIndex = 0;
             pictureBox1.TabStop = false;
+            pictureBox1.MouseWheel += new System.Windows.Forms.MouseEventHandler(this.PictureBox1_MouseWheel);
             // 
             // tabControlMain
             // 

--- a/PixelMapGenerator.cs
+++ b/PixelMapGenerator.cs
@@ -93,7 +93,7 @@ namespace StrategyGame
         public static Bitmap GeneratePixelArtMapWithCountries(int width, int height)
         {
             GdalBase.ConfigureAll();
-            Bitmap baseMap = GenerateTerrainPixelArtMap(width, height, 5);
+            Bitmap baseMap = GenerateTerrainPixelArtMap(width, height, 8);
 
             // mask dimensions == pixel dimensions
             int fullW = baseMap.Width;


### PR DESCRIPTION
This commit addresses issues with map mouse interaction and adjusts the visual representation of map cells.

Changes include:
- Modified mouse wheel event handling for zooming to target the PictureBox directly, ensuring consistency with panning events.
- Increased 'pixelsPerCell' from 5 to 8 in the PixelMapGenerator, causing data cells to be rendered as larger 8x8 textured blocks. This enhances the 'pixel art' feel by making individual cells appear chunkier and allowing for more sub-pixel variation.
- Updated PictureBox properties (Dock=None, SizeMode=Normal) to prevent interference with manual positioning and scaling.
- Implemented robust zoom-to-mouse-pointer functionality:
    - ApplyZoom method now solely handles image scaling and PictureBox resizing.
    - PictureBox1_MouseWheel method calculates the focal point, calls ApplyZoom, and then correctly positions/clamps the PictureBox within the panel.
- Added explicit initial positioning for the map in the RefreshMap method to ensure it loads centered or clamped at (0,0) as appropriate.

These changes improve map usability through corrected mouse dragging and zooming, and provide the requested enhancement to the visual style of the map cells.