### PR TITLE
Fix map panning logic in MainGame.cs

### DIFF
--- a/MainGame.cs
+++ b/MainGame.cs
@@ -1927,7 +1927,7 @@ namespace economy_sim
                 pictureBox1.Location = new Point(newX, newY);
 
                 // Update panStart for the next move
-                panStart = e.Location;
+                // panStart = e.Location; // Removed as per request
             }
         }
 


### PR DESCRIPTION
The map panning functionality was not working correctly due to an issue in the PictureBox1_MouseMove method. The panStart variable, which records the initial mouse down position relative to the PictureBox, was being incorrectly updated during each mouse move event. This effectively reset the reference point for the drag calculation, preventing proper panning.

This commit removes the erroneous line `panStart = e.Location;` from the PictureBox1_MouseMove method. With this change, panStart correctly retains the initial mouse down coordinates throughout the drag operation, allowing dx/dy to represent the total mouse movement relative to that initial point. The PictureBox location is now updated correctly, resulting in smooth and accurate map dragging.