### PR TITLE
Look for data directory in Documents

### DIFF
--- a/MultiResolutionMapManager.cs
+++ b/MultiResolutionMapManager.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+
+namespace StrategyGame
+{
+    /// <summary>
+    /// Generates and stores maps for each zoom level at game start.
+    /// Maps are kept in memory so they can be cropped when rendering.
+    /// </summary>
+    public class MultiResolutionMapManager
+    {
+        public enum ZoomLevel { Global = 1, Continental, Country, State, City }
+
+        private readonly Dictionary<ZoomLevel, Bitmap> _maps = new();
+        private readonly int _baseWidth;
+        private readonly int _baseHeight;
+
+        public MultiResolutionMapManager(int baseWidth, int baseHeight)
+        {
+            _baseWidth = baseWidth;
+            _baseHeight = baseHeight;
+        }
+
+        /// <summary>
+        /// Generate maps for all zoom levels. Each level doubles the resolution
+        /// of the previous one.
+        /// </summary>
+        public void GenerateMaps()
+        {
+            int width = _baseWidth;
+            int height = _baseHeight;
+            for (int i = 1; i <= 5; i++)
+            {
+                var level = (ZoomLevel)i;
+                Bitmap bmp = PixelMapGenerator.GeneratePixelArtMapWithCountries(width, height);
+                OverlayFeatures(bmp, level);
+                _maps[level] = bmp;
+                width *= 2;
+                height *= 2;
+            }
+        }
+
+        /// <summary>
+        /// Retrieve the full map bitmap for a zoom level.
+        /// </summary>
+        public Bitmap GetMap(ZoomLevel level)
+        {
+            return _maps.TryGetValue(level, out var bmp) ? bmp : null;
+        }
+
+        /// <summary>
+        /// Return a cropped portion of the map at the requested zoom level.
+        /// </summary>
+        public Bitmap GetMap(ZoomLevel level, Rectangle view)
+        {
+            if (!_maps.TryGetValue(level, out var bmp))
+                return null;
+            Rectangle src = Rectangle.Intersect(new Rectangle(Point.Empty, bmp.Size), view);
+            if (src.Width <= 0 || src.Height <= 0)
+                return null;
+            Bitmap dest = new Bitmap(src.Width, src.Height);
+            using (Graphics g = Graphics.FromImage(dest))
+            {
+                g.InterpolationMode = InterpolationMode.NearestNeighbor;
+                g.PixelOffsetMode = PixelOffsetMode.Half;
+                g.DrawImage(bmp, new Rectangle(0, 0, dest.Width, dest.Height), src, GraphicsUnit.Pixel);
+            }
+            return dest;
+        }
+
+        private static void OverlayFeatures(Bitmap bmp, ZoomLevel level)
+        {
+            using Graphics g = Graphics.FromImage(bmp);
+            Random rng = new Random(42);
+            switch (level)
+            {
+                case ZoomLevel.Country:
+                    // Simple storms as grey circles
+                    for (int i = 0; i < 3; i++)
+                    {
+                        int size = bmp.Width / 15;
+                        int x = rng.Next(bmp.Width - size);
+                        int y = rng.Next(bmp.Height - size);
+                        g.FillEllipse(Brushes.LightGray, x, y, size, size);
+                    }
+                    break;
+                case ZoomLevel.State:
+                    // Highways and railways as lines
+                    using (Pen highway = new Pen(Color.Gray, 2))
+                    {
+                        g.DrawLine(highway, 0, bmp.Height / 3, bmp.Width, bmp.Height / 3);
+                        g.DrawLine(highway, bmp.Width / 2, 0, bmp.Width / 2, bmp.Height);
+                    }
+                    using (Pen rail = new Pen(Color.DarkGray, 1) { DashStyle = DashStyle.Dot })
+                    {
+                        g.DrawLine(rail, 0, bmp.Height * 2 / 3, bmp.Width, bmp.Height * 2 / 3);
+                    }
+                    break;
+                case ZoomLevel.City:
+                    // Draw a simple grid of roads
+                    using (Pen road = new Pen(Color.Gray, 1))
+                    {
+                        for (int x = 0; x < bmp.Width; x += 20)
+                            g.DrawLine(road, x, 0, x, bmp.Height);
+                        for (int y = 0; y < bmp.Height; y += 20)
+                            g.DrawLine(road, 0, y, bmp.Width, y);
+                    }
+                    // Add buildings and cars
+                    for (int i = 0; i < 50; i++)
+                    {
+                        int w = rng.Next(4, 8);
+                        int h = rng.Next(4, 8);
+                        int x = rng.Next(bmp.Width - w);
+                        int y = rng.Next(bmp.Height - h);
+                        g.FillRectangle(Brushes.DarkSlateBlue, x, y, w, h);
+                    }
+                    for (int i = 0; i < 20; i++)
+                    {
+                        int x = rng.Next(bmp.Width - 3);
+                        int y = rng.Next(bmp.Height - 2);
+                        g.FillRectangle(Brushes.Red, x, y, 3, 2);
+                    }
+                    break;
+            }
+        }
+    }
+}

--- a/PixelMapGenerator.cs
+++ b/PixelMapGenerator.cs
@@ -1,6 +1,7 @@
 ﻿using MaxRev.Gdal.Core;
 using System;
 using System.Diagnostics;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.IO;
@@ -22,21 +23,59 @@ namespace StrategyGame
         private static readonly string RepoRoot =
             System.IO.Path.GetFullPath(System.IO.Path.Combine(
                 AppDomain.CurrentDomain.BaseDirectory, "..", "..", ".."));
-        private static readonly string DataDir =
-            System.IO.Path.Combine(RepoRoot, "data");
-        private static readonly string TifPath =
-            @"C:\Users\kayla\source\repos\bitzy06\economy-sim\data\elavation data\ETOPO1_Bed_g_geotiff.tif";
-        private static readonly string ShpPath =
-            @"C:\Users\kayla\source\repos\bitzy06\economy-sim\data\country boarders\ne_10m_admin_0_countries.shp";
 
-        // Terrain map used for pixel-art generation.  We first try the copy in
-        // the repository's data folder and fall back to the absolute path that
-        // was used during development if the file is not found.  Using this
-        // fallback avoids issues when relative paths fail to resolve at runtime.
+        // Data files are expected to live in the user's Documents\data folder
+        // (e.g. "C:\\Users\\kayla\\Documents\\data").  This path is used directly
+        // rather than falling back to the repository so the game always loads
+        // external resources from that location.
+        private static readonly string DataDir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+            "data");
+
+        private static readonly string RepoDataDir = Path.Combine(RepoRoot, "data");
+
+        // Data files listed in the text file are resolved relative to the data
+        // directory.  This allows the application to load resources that are
+        // not part of the repository but exist locally.
+        private static readonly string DataFileList =
+            Path.Combine(RepoRoot, "DataFileNames");
+
+        private static readonly Dictionary<string, string> DataFiles = LoadDataFiles();
+
+        private static string GetDataFile(string name)
+        {
+            // first check explicit mappings from DataFileNames
+            if (DataFiles.TryGetValue(name, out var mapped) && File.Exists(mapped))
+                return mapped;
+
+            // search the user Documents data directory recursively
+            string userPath = Path.Combine(DataDir, name);
+            if (File.Exists(userPath))
+                return userPath;
+            var matches = Directory.GetFiles(DataDir, name, SearchOption.AllDirectories);
+            if (matches.Length > 0)
+                return matches[0];
+
+            // fall back to the repository data directory if nothing found
+            string repoPath = Path.Combine(RepoDataDir, name);
+            if (File.Exists(repoPath))
+                return repoPath;
+            matches = Directory.GetFiles(RepoDataDir, name, SearchOption.AllDirectories);
+            if (matches.Length > 0)
+                return matches[0];
+
+            // return the path in the Documents folder even if missing so callers know where it was expected
+            return userPath;
+        }
+
+        private static readonly string TifPath =
+            GetDataFile("ETOPO1_Bed_g_geotiff.tif");
+        private static readonly string ShpPath =
+            GetDataFile("ne_10m_admin_0_countries.shp");
+
+        // Terrain map used for pixel-art generation.
         private static readonly string TerrainTifPath =
-            File.Exists(Path.Combine(DataDir, "terrain", "NE1_HR_LC.tif"))
-                ? Path.Combine(DataDir, "terrain", "NE1_HR_LC.tif")
-                : @"C:\Users\kayla\source\repos\bitzy06\economy-sim\data\terrain\NE1_HR_LC.tif";
+            GetDataFile("NE1_HR_LC.tif");
 
 
         /// <summary>
@@ -216,6 +255,30 @@ namespace StrategyGame
                 baseColor,
                 Lerp(baseColor, Color.White, 0.2f)
             };
+        }
+
+        private static Dictionary<string, string> LoadDataFiles()
+        {
+            var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (File.Exists(DataFileList))
+            {
+                foreach (var line in File.ReadAllLines(DataFileList))
+                {
+                    var trimmed = line.Trim();
+                    if (string.IsNullOrEmpty(trimmed) || trimmed.StartsWith("#") || trimmed.StartsWith("files"))
+                        continue;
+                    string userPath = Path.Combine(DataDir, trimmed);
+                    if (File.Exists(userPath))
+                    {
+                        dict[trimmed] = userPath;
+                    }
+                    else
+                    {
+                        dict[trimmed] = Path.Combine(RepoDataDir, trimmed);
+                    }
+                }
+            }
+            return dict;
         }
     }
 }


### PR DESCRIPTION
## Summary
- prefer `~/Documents/data` when resolving map resources
- add search fallback into repo data folder if documents folder files are missing
- support cropping in `MultiResolutionMapManager`

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850edb246708323941b5d6ba7c8acbf