### PR TITLE
Fix GDAL thread safety in map generation

### DIFF
--- a/CountryMaskGenerator.cs
+++ b/CountryMaskGenerator.cs
@@ -10,6 +10,8 @@ namespace StrategyGame
     /// </summary>
     public static class CountryMaskGenerator
     {
+        private static readonly object GdalLock = new object();
+        private static bool _gdalRegistered = false;
         /// <summary>
         /// Generates a rasterized country mask matching the given DEM.
         /// </summary>
@@ -18,8 +20,14 @@ namespace StrategyGame
         /// <returns>Two dimensional array of ISO codes indexed by row/column.</returns>
         public static int[,] CreateCountryMask(string demPath, string shpPath)
         {
-            Gdal.AllRegister();
-            Ogr.RegisterAll();
+            lock (GdalLock)
+            {
+                if (!_gdalRegistered)
+                {
+                    Gdal.AllRegister();
+                    Ogr.RegisterAll();
+                    _gdalRegistered = true;
+                }
 
             Dataset dem = Gdal.Open(demPath, Access.GA_ReadOnly);
             if (dem == null)
@@ -68,6 +76,7 @@ namespace StrategyGame
             }
 
             return result;
+            }
         }
 
         /// <summary>
@@ -80,8 +89,14 @@ namespace StrategyGame
         /// <returns>Two dimensional array of ISO codes indexed by row/column.</returns>
         public static int[,] CreateCountryMask(string demPath, string shpPath, int width, int height)
         {
-            Gdal.AllRegister();
-            Ogr.RegisterAll();
+            lock (GdalLock)
+            {
+                if (!_gdalRegistered)
+                {
+                    Gdal.AllRegister();
+                    Ogr.RegisterAll();
+                    _gdalRegistered = true;
+                }
 
             Dataset dem = Gdal.Open(demPath, Access.GA_ReadOnly);
             if (dem == null)
@@ -127,6 +142,7 @@ namespace StrategyGame
             }
 
             return result;
+            }
         }
     }
 }

--- a/PixelMapGenerator.cs
+++ b/PixelMapGenerator.cs
@@ -16,6 +16,8 @@ namespace StrategyGame
     /// </summary>
     public static class PixelMapGenerator
     {
+        private static readonly object GdalConfigLock = new object();
+        private static bool _gdalConfigured = false;
 
         // Resolve paths relative to the repository root so the application does
         // not depend on developer specific locations. The executable lives in
@@ -146,7 +148,14 @@ namespace StrategyGame
         /// </summary>
         public static Bitmap GeneratePixelArtMapWithCountries(int width, int height, int pixelsPerCell = 8)
         {
-            GdalBase.ConfigureAll();
+            lock (GdalConfigLock)
+            {
+                if (!_gdalConfigured)
+                {
+                    GdalBase.ConfigureAll();
+                    _gdalConfigured = true;
+                }
+            }
             Bitmap baseMap = GenerateTerrainPixelArtMap(width, height, pixelsPerCell);
 
             // mask dimensions == pixel dimensions


### PR DESCRIPTION
## Summary
- ensure GDAL is configured only once in `PixelMapGenerator`
- guard GDAL/OGR calls in `CountryMaskGenerator` with a lock to avoid concurrent initialization

## Testing
- `dotnet build "economy sim.sln" -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685131415c648323bb89938665357e6f