### PR TITLE
Implement cached zoom bitmaps

### DIFF
--- a/MainGame.cs
+++ b/MainGame.cs
@@ -285,6 +285,7 @@ namespace economy_sim
             {
                 mapManager = new MultiResolutionMapManager(panelMap.ClientSize.Width, panelMap.ClientSize.Height);
                 mapManager.GenerateMaps();
+                mapManager.ClearCache();
             }
 
 


### PR DESCRIPTION
## Summary
- cache scaled maps in `MultiResolutionMapManager` keyed by cell size
- expose `ClearCache()` to dispose cached bitmaps
- invoke `ClearCache` when maps are generated in `RefreshMap`

## Testing
- `dotnet build 'economy sim.sln' -c Release` *(fails: SDK `Microsoft.NET.Sdk.WindowsDesktop` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68516a6db19c8323a319c6c02d210bee