### PR TITLE
Implement LRU tile caching

### DIFF
--- a/MainGame.cs
+++ b/MainGame.cs
@@ -285,7 +285,6 @@ namespace economy_sim
             {
                 mapManager = new MultiResolutionMapManager(panelMap.ClientSize.Width, panelMap.ClientSize.Height);
                 mapManager.GenerateMaps();
-                mapManager.GenerateTileCache();
             }
 
             pictureBox1.Size = panelMap.ClientSize;
@@ -374,6 +373,7 @@ namespace economy_sim
         }
         private void InitializeGameData()
         {
+            mapManager?.ClearTileCache();
             RefreshMap();
             // 1. Clear all global static lists first
             Market.GoodDefinitions.Clear();
@@ -1826,6 +1826,7 @@ namespace economy_sim
                 DebugLogger.LogDetailedCityData(selectedCity); // Log detailed data for the selected city
             }
             DebugLogger.FinalizeLog(allCountries); // Pass the list of countries to the logger
+            mapManager?.ClearTileCache();
             base.OnFormClosing(e);
         }
 


### PR DESCRIPTION
## Summary
- generate map tiles on demand without eager caching
- add an LRU tile cache limit and eviction logic
- clear tile cache when starting a new game or closing the map

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-7.0` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68541f4f93d48323b21d365a4875cf45