### PR TITLE
Add tile cache generation button

### DIFF
--- a/MainGame.Designer.cs
+++ b/MainGame.Designer.cs
@@ -55,6 +55,7 @@
             checkBoxLogPops = new CheckBox();
             checkBoxLogBuildings = new CheckBox();
             checkBoxLogEconomy = new CheckBox();
+            buttonGenerateTileCache = new Button();
             tabPageDiplomacy = new TabPage();
             labelProposedTrades = new Label();
             listBoxProposedTradeAgreements = new ListBox();
@@ -172,6 +173,7 @@
             tabPageDebug.Controls.Add(checkBoxLogPops);
             tabPageDebug.Controls.Add(checkBoxLogBuildings);
             tabPageDebug.Controls.Add(checkBoxLogEconomy);
+            tabPageDebug.Controls.Add(buttonGenerateTileCache);
             tabPageDebug.Location = new Point(4, 24);
             tabPageDebug.Margin = new Padding(4, 3, 4, 3);
             tabPageDebug.Name = "tabPageDebug";
@@ -319,9 +321,20 @@
             checkBoxLogEconomy.Text = "Log Economy Stats";
             checkBoxLogEconomy.UseVisualStyleBackColor = true;
             checkBoxLogEconomy.CheckedChanged += CheckBoxLogEconomy_CheckedChanged;
-            // 
+            //
+            // buttonGenerateTileCache
+            //
+            buttonGenerateTileCache.Location = new Point(12, 323);
+            buttonGenerateTileCache.Margin = new Padding(4, 3, 4, 3);
+            buttonGenerateTileCache.Name = "buttonGenerateTileCache";
+            buttonGenerateTileCache.Size = new Size(140, 27);
+            buttonGenerateTileCache.TabIndex = 13;
+            buttonGenerateTileCache.Text = "Build Tile Cache";
+            buttonGenerateTileCache.UseVisualStyleBackColor = true;
+            buttonGenerateTileCache.Click += ButtonGenerateTileCache_Click;
+            //
             // tabPageDiplomacy
-            // 
+            //
             tabPageDiplomacy.Controls.Add(labelProposedTrades);
             tabPageDiplomacy.Controls.Add(listBoxProposedTradeAgreements);
             tabPageDiplomacy.Controls.Add(buttonAcceptTrade);
@@ -613,6 +626,7 @@
         private System.Windows.Forms.CheckBox checkBoxLogPops;
         private System.Windows.Forms.CheckBox checkBoxLogBuildings;
         private System.Windows.Forms.CheckBox checkBoxLogEconomy;
+        private System.Windows.Forms.Button buttonGenerateTileCache;
         private System.Windows.Forms.TabPage tabPageDiplomacy;
         private System.Windows.Forms.Label labelProposedTrades;
         private System.Windows.Forms.ListBox listBoxProposedTradeAgreements;

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -1866,6 +1866,13 @@ namespace economy_sim
             DebugLogger.EnableEconomyLogging(checkBoxLogEconomy.Checked);
         }
 
+        private void ButtonGenerateTileCache_Click(object sender, EventArgs e)
+        {
+            mapManager ??= new MultiResolutionMapManager(panelMap.ClientSize.Width, panelMap.ClientSize.Height);
+            mapManager.GenerateMissingTileCaches();
+            MessageBox.Show("Tile cache generation complete.");
+        }
+
         // Update the Finance tab UI
         private void UpdateFinanceTab()
         {

--- a/MultiResolutionMapManager.cs
+++ b/MultiResolutionMapManager.cs
@@ -233,6 +233,35 @@ namespace StrategyGame
         }
 
         /// <summary>
+        /// Generate tile caches for zoom levels that are missing tiles on disk.
+        /// Existing caches are left untouched.
+        /// </summary>
+        public void GenerateMissingTileCaches()
+        {
+            foreach (ZoomLevel level in Enum.GetValues(typeof(ZoomLevel)))
+            {
+                float z = (int)level;
+                int cellSize = GetCellSize(z);
+                if (IsTileCacheComplete(cellSize))
+                    continue;
+
+                var size = GetMapSize(z);
+                int tilesX = (size.Width + TileSizePx - 1) / TileSizePx;
+                int tilesY = (size.Height + TileSizePx - 1) / TileSizePx;
+
+                for (int x = 0; x < tilesX; x++)
+                {
+                    for (int y = 0; y < tilesY; y++)
+                    {
+                        // Use the public method so any generated tile is also
+                        // written to disk and cached consistently
+                        GetTile(z, x, y);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
         /// Retrieve a single tile bitmap for the given zoom level and tile coordinates.
         /// </summary>
         public SystemDrawing.Bitmap GetTile(float zoom, int tileX, int tileY)


### PR DESCRIPTION
## Summary
- generate missing map tile caches in `MultiResolutionMapManager`
- add a debug tab button to trigger cache generation

## Testing
- `dotnet build 'economy sim.csproj' -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854ed28e740832390173b4f8ae858f4