### PR TITLE
Enable mouse wheel zoom

### DIFF
--- a/MainGame.Designer.cs
+++ b/MainGame.Designer.cs
@@ -552,6 +552,7 @@
             panelMap.AutoScroll = false;
             panelMap.TabStop = true;
             panelMap.KeyDown += new System.Windows.Forms.KeyEventHandler(this.panelMap_KeyDown);
+            panelMap.MouseWheel += new System.Windows.Forms.MouseEventHandler(this.PanelMap_MouseWheel);
             this.panelMap.MouseUp += new System.Windows.Forms.MouseEventHandler(this.panelMap_MouseUp_ForPanning);
             // 
             // pictureBox1

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -1998,6 +1998,11 @@ namespace economy_sim
             PreloadMapTiles();
         }
 
+        private void PanelMap_MouseWheel(object sender, MouseEventArgs e)
+        {
+            PictureBox1_MouseWheel(sender, e);
+        }
+
         private void panelMap_KeyDown(object sender, KeyEventArgs e)
         {
             if (this.pictureBox1 == null || this.panelMap == null) // Safety check


### PR DESCRIPTION
## Summary
- link mouse wheel events from `panelMap` to existing zoom handler
- delegate the handler to keep scroll-based zoom working when the panel has focus

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854f822aa608323ae90d635a79ff1fa