### PR TITLE
Enable zoom when scrolling over the map

### DIFF
--- a/MainGame.Designer.cs
+++ b/MainGame.Designer.cs
@@ -552,6 +552,8 @@
             panelMap.AutoScroll = false;
             panelMap.TabStop = true;
             panelMap.KeyDown += new System.Windows.Forms.KeyEventHandler(this.panelMap_KeyDown);
+            panelMap.MouseWheel += new System.Windows.Forms.MouseEventHandler(this.PanelMap_MouseWheel);
+            panelMap.MouseEnter += new System.EventHandler(this.panelMap_MouseEnter);
             this.panelMap.MouseUp += new System.Windows.Forms.MouseEventHandler(this.panelMap_MouseUp_ForPanning);
             // 
             // pictureBox1

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -1998,6 +1998,16 @@ namespace economy_sim
             PreloadMapTiles();
         }
 
+        private void PanelMap_MouseWheel(object sender, MouseEventArgs e)
+        {
+            PictureBox1_MouseWheel(sender, e);
+        }
+
+        private void panelMap_MouseEnter(object sender, EventArgs e)
+        {
+            panelMap.Focus();
+        }
+
         private void panelMap_KeyDown(object sender, KeyEventArgs e)
         {
             if (this.pictureBox1 == null || this.panelMap == null) // Safety check


### PR DESCRIPTION
## Summary
- ensure the map panel gains focus when the mouse enters
- wire the new handler so scroll wheel events trigger zoom consistently

## Testing
- `dotnet --version` *(fails: command not found)*
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854f822aa608323ae90d635a79ff1fa