### PR TITLE
Reduce memory usage by clearing map cache

### DIFF
--- a/MultiResolutionMapManager.cs
+++ b/MultiResolutionMapManager.cs
@@ -116,8 +116,11 @@ namespace StrategyGame
                 }
                 GenerateTileCache();
 
-                _largeBaseMap.Dispose();
+                ClearCache();
+
+                _largeBaseMap?.Dispose();
                 _largeBaseMap = null;
+                _baseMap?.Dispose();
                 _baseMap = null;
             }
             else
@@ -127,6 +130,11 @@ namespace StrategyGame
                 _baseMap = bmp;
                 _largeBaseMap = null;
                 GenerateTileCache();
+
+                ClearCache();
+
+                _baseMap?.Dispose();
+                _baseMap = null;
             }
         }
 


### PR DESCRIPTION
## Summary
- clear internal caches after generating tiles

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68551aad33b88323849064c044e0e65a