### PR TITLE
Enable GDAL tile generation

### DIFF
--- a/MultiResolutionMapManager.cs
+++ b/MultiResolutionMapManager.cs
@@ -310,7 +310,7 @@ namespace StrategyGame
             }
             else if (_baseMap == null)
             {
-                bmp = LoadOrGenerateTileFromData(cellSize, tileX, tileY, rect);
+                bmp = LoadOrGenerateTileFromData(cellSize, tileX, tileY);
             }
 
             if (bmp != null)
@@ -767,7 +767,7 @@ namespace StrategyGame
             }
         }
 
-        private SystemDrawing.Bitmap LoadOrGenerateTileFromData(int cellSize, int tileX, int tileY, SystemDrawing.Rectangle rect)
+        private SystemDrawing.Bitmap LoadOrGenerateTileFromData(int cellSize, int tileX, int tileY)
         {
             string dir = System.IO.Path.Combine(TileCacheDir, cellSize.ToString());
             string path = System.IO.Path.Combine(dir, $"{tileX}_{tileY}.png");
@@ -791,9 +791,9 @@ namespace StrategyGame
 
             }
 
-            using var img = PixelMapGenerator.GeneratePixelArtMapWithCountriesLarge(_baseWidth, _baseHeight, cellSize);
+            using var img = PixelMapGenerator.GenerateTileWithCountriesLarge(_baseWidth, _baseHeight, cellSize, tileX, tileY);
             OverlayFeaturesLarge(img, ZoomLevel.City);
-            var bmp = CropImageSharp(img, rect);
+            var bmp = ImageSharpToBitmap(img);
 
             try
             {


### PR DESCRIPTION
## Summary
- add GDAL-based tile generation that reads only the required raster window
- overlay borders using a cropped mask for the tile
- replace tile generation logic in the map manager to use the new method

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685526633f5883239bd22301f5182d20