### PR TITLE
Extend zoom levels and optimize tiles

### DIFF
--- a/MainGame.cs
+++ b/MainGame.cs
@@ -331,7 +331,8 @@ namespace economy_sim
 
         private void AdjustZoom(float newZoom)
         {
-            newZoom = Math.Max(1f, Math.Min(5f, newZoom));
+            float maxZoom = MultiResolutionMapManager.PixelsPerCellLevels.Length;
+            newZoom = Math.Max(1f, Math.Min(maxZoom, newZoom));
             if (Math.Abs(newZoom - mapZoom) < 0.001f)
                 return;
 
@@ -1984,7 +1985,8 @@ namespace economy_sim
             float ratioY = worldY / oldSize.Height;
 
             float newZoom = mapZoom + Math.Sign(e.Delta) * 0.25f;
-            newZoom = Math.Max(1f, Math.Min(5f, newZoom));
+            float maxZoom = MultiResolutionMapManager.PixelsPerCellLevels.Length;
+            newZoom = Math.Max(1f, Math.Min(maxZoom, newZoom));
             if (Math.Abs(newZoom - mapZoom) < 0.001f)
                 return;
 
@@ -2132,7 +2134,7 @@ namespace economy_sim
                 return;
             var view = new Rectangle(mapViewOrigin, panelMap.ClientSize);
 
-            _ = mapManager.PreloadTilesAsync(mapZoom, view);
+            _ = mapManager.PreloadTilesAsync(mapZoom, view, 1, CancellationToken.None);
 
         }
     }


### PR DESCRIPTION
## Summary
- shrink cells for distant zoom levels and add a helper to detect water tiles
- add tile generation guard that uses a solid water tile if no land is present
- expose `IsWaterColor` and new `TileContainsLand` for land checks
- support a reusable water tile

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68552f9e0c08832395fc6ab9eab9c65a