### PR TITLE
Fix tile loader to show water for missing tiles

### DIFF
--- a/MultiResolutionMapManager.cs
+++ b/MultiResolutionMapManager.cs
@@ -957,7 +957,13 @@ namespace StrategyGame
                 {
                     try { File.Delete(path); } catch { }
                 }
-                return null;
+                int fullW = _baseWidth * cellSize;
+                int fullH = _baseHeight * cellSize;
+                int offsetX = tileX * TileSizePx;
+                int offsetY = tileY * TileSizePx;
+                int widthPx = Math.Min(TileSizePx, fullW - offsetX);
+                int heightPx = Math.Min(TileSizePx, fullH - offsetY);
+                return CreateWaterTile(widthPx, heightPx);
             }
 
             if (File.Exists(path))
@@ -1009,7 +1015,13 @@ namespace StrategyGame
                 {
                     try { File.Delete(path); } catch { }
                 }
-                return null;
+                int fullW = _baseWidth * cellSize;
+                int fullH = _baseHeight * cellSize;
+                int offsetX = tileX * TileSizePx;
+                int offsetY = tileY * TileSizePx;
+                int widthPx = Math.Min(TileSizePx, fullW - offsetX);
+                int heightPx = Math.Min(TileSizePx, fullH - offsetY);
+                return CreateWaterTile(widthPx, heightPx);
             }
 
             if (File.Exists(path))


### PR DESCRIPTION
## Summary
- draw water tiles when TileContainsLand returns false
- keep water tile creation logic centralized

## Testing
- `dotnet build 'economy sim.sln' -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6855409c97c883238c1258a53fef3429