### PR TITLE
Add NE state and city overlays to map tiles

### DIFF
--- a/MultiResolutionMapManager.cs
+++ b/MultiResolutionMapManager.cs
@@ -853,7 +853,7 @@ namespace StrategyGame
             }
 
             SystemDrawing.Bitmap bmp;
-            using var img = PixelMapGenerator.GenerateTileWithCountriesLarge(_baseWidth, _baseHeight, cellSize, tileX, tileY);
+            using var img = PixelMapGenerator.GenerateTileWithWorldDataLarge(_baseWidth, _baseHeight, cellSize, tileX, tileY);
             OverlayFeaturesLarge(img, ZoomLevel.City);
             bmp = ImageSharpToBitmap(img);
 
@@ -915,7 +915,7 @@ namespace StrategyGame
             SystemDrawing.Bitmap bmp;
             using var img = await Task.Run(() =>
                 {
-                    var generated = PixelMapGenerator.GenerateTileWithCountriesLarge(_baseWidth, _baseHeight, cellSize, tileX, tileY);
+                    var generated = PixelMapGenerator.GenerateTileWithWorldDataLarge(_baseWidth, _baseHeight, cellSize, tileX, tileY);
                     OverlayFeaturesLarge(generated, ZoomLevel.City);
                     return generated;
                 }, token).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- overlay state borders and city markers using Natural Earth data
- include new shapefile paths for admin1 borders and populated places
- update tile generation to use the new overlay routine

## Testing
- `dotnet build --no-restore` *(fails: Could not resolve SDK 'Microsoft.NET.Sdk.WindowsDesktop')*


------
https://chatgpt.com/codex/tasks/task_e_685f9bc7a6e8832387f8dd3f718b4c9b