### PR TITLE
Add city polygon management

### DIFF
--- a/City.cs
+++ b/City.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System; // Added for Console
+using NetTopologySuite.Geometries;
 using StrategyGame; // Added to reference Suburb class
 using StrategyGame; // Ensure namespace for ProjectType and ConstructionProject is included
 
@@ -11,6 +12,10 @@ namespace StrategyGame
         public string Name { get; set; }
         public double Budget { get; set; }
         public int Population { get; set; }
+        public double Latitude { get; set; }
+        public double Longitude { get; set; }
+        public Polygon OriginalPolygon { get; set; }
+        public Polygon CurrentPolygon { get; set; }
         public double TaxRate { get; set; } // Percentage (e.g., 0.1 for 10%)
         public double CityExpenses { get; set; }
         public List<Factory> Factories { get; set; }
@@ -38,6 +43,10 @@ namespace StrategyGame
             Name = name;
             Budget = 10000; // Example starting budget
             Population = 100000; // Example starting population
+            Latitude = 0;
+            Longitude = 0;
+            OriginalPolygon = null;
+            CurrentPolygon = null;
             Factories = new List<Factory>();
             Stockpile = new Dictionary<string, Good>();
             Happiness = 50; // Out of 100
@@ -137,6 +146,7 @@ namespace StrategyGame
 
                 Budget += surplus * 0.05; // Example: reinvest surplus
             }
+            UpdateCurrentPolygon();
         }
 
         public void AddSuburb(Suburb suburb)
@@ -223,6 +233,15 @@ namespace StrategyGame
             {
                 suburb.RailwayKilometers += value / Suburbs.Count; // Distribute railway kilometers
             }
+        }
+
+        private void UpdateCurrentPolygon()
+        {
+            if (OriginalPolygon == null)
+                return;
+
+            double buffer = Math.Max(Population, 1) / 1_000_000.0;
+            CurrentPolygon = (Polygon)OriginalPolygon.Buffer(buffer);
         }
     }
 }

--- a/CityPolygonHelper.cs
+++ b/CityPolygonHelper.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using System.Linq;
+using NetTopologySuite.Geometries;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Drawing.Processing;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace StrategyGame
+{
+    public static class CityPolygonHelper
+    {
+        public static void AssignUrbanPolygons(List<City> cities, List<Polygon> urbanAreaPolygons)
+        {
+            foreach (var city in cities)
+            {
+                var point = new Point(city.Longitude, city.Latitude);
+                Polygon best = null;
+                double bestDist = double.MaxValue;
+
+                foreach (var poly in urbanAreaPolygons)
+                {
+                    if (poly.Contains(point))
+                    {
+                        best = poly;
+                        break;
+                    }
+
+                    double dist = poly.Distance(point);
+                    if (dist < bestDist)
+                    {
+                        bestDist = dist;
+                        best = poly;
+                    }
+                }
+
+                city.OriginalPolygon = best;
+                city.CurrentPolygon = best;
+            }
+        }
+
+        public static void DrawCityPolygon(Image<Rgba32> image, City city, int mapWidthPx, int mapHeightPx)
+        {
+            if (city.CurrentPolygon == null)
+                return;
+
+            var fill = new Rgba32(150, 150, 150, 90);
+            var outline = new Rgba32(70, 70, 70, 180);
+
+            var exterior = city.CurrentPolygon.ExteriorRing.Coordinates
+                .Select(c => new PointF(
+                    (float)((c.X + 180.0) / 360.0 * mapWidthPx),
+                    (float)(((90.0 - c.Y) / 180.0) * mapHeightPx)))
+                .ToArray();
+
+            image.Mutate(ctx => ctx.FillPolygon(fill, exterior));
+            image.Mutate(ctx => ctx.DrawPolygon(outline, 2, exterior));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- support polygons for each city with latitude/longitude
- update the polygon as population grows
- helper to assign nearest urban polygons and draw them

## Testing
- `dotnet build "economy sim.sln" -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fd238b31c8323bfa728874b8bf7c2