### PR TITLE
Fix map image disposal

### DIFF
--- a/MainGame.cs
+++ b/MainGame.cs
@@ -195,14 +195,20 @@ namespace economy_sim
 
                     this.Invoke((MethodInvoker)(() =>
                     {
-                        pictureBox1.Image = mapManager.AssembleView(mapZoom, viewRect, () =>
+                        var img = mapManager.AssembleView(mapZoom, viewRect, () =>
                         {
                             this.Invoke((MethodInvoker)(() =>
                             {
                                 var updatedViewRect = new Rectangle(mapViewOrigin, panelMap.ClientSize);
+                                var oldInner = pictureBox1.Image;
                                 pictureBox1.Image = mapManager.AssembleView(mapZoom, updatedViewRect);
+                                oldInner?.Dispose();
                             }));
                         });
+
+                        var old = pictureBox1.Image;
+                        pictureBox1.Image = img;
+                        old?.Dispose();
                     }));
                 });
             }


### PR DESCRIPTION
## Summary
- dispose old map images when refreshing the map

## Testing
- `dotnet build "economy sim.sln" -v minimal` *(fails: SDK 'Microsoft.NET.Sdk.WindowsDesktop' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860ebf53e58832393a8eed1ce23ab8b