### PR TITLE
Fix tile bitmap creation via stream clone

### DIFF
--- a/MultiResolutionMapManager.cs
+++ b/MultiResolutionMapManager.cs
@@ -479,11 +479,21 @@ namespace StrategyGame
             {
                 ms = new MemoryStream();
             }
+
+            // Save the ImageSharp image to the pooled memory stream
             img.SaveAsBmp(ms);
             ms.Position = 0;
-            var bmp = new SystemDrawing.Bitmap(ms);
+
+            // Bitmap constructed from a stream keeps that stream alive for the
+            // lifetime of the bitmap. Clone the bitmap to detach it so the
+            // stream can be reused.
+            using var temp = new SystemDrawing.Bitmap(ms);
+            var bmp = new SystemDrawing.Bitmap(temp);
+
+            // Reset and return the memory stream to the pool
             ms.SetLength(0);
             _msPool.Enqueue(ms);
+
             return bmp;
         }
 


### PR DESCRIPTION
## Summary
- fix tile generation by cloning Bitmaps created from ImageSharp streams

## Testing
- `dotnet build "economy sim.sln" -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_686122f2946083238d401b70adb3baf9