### PR TITLE
Add urban layer precomputation and overlay

### DIFF
--- a/DataFileNames
+++ b/DataFileNames
@@ -1,3 +1,7 @@
 files to be used that are local not on git
 NE1_HR_LC.tif
 ne_10m_admin_0_countries.shp
+
+ne_10m_urban_areas.shp
+ne_10m_populated_places.shp
+urban_texture.png

--- a/MainGame.Designer.cs
+++ b/MainGame.Designer.cs
@@ -63,6 +63,7 @@
             checkBoxLogPops = new CheckBox();
             checkBoxLogBuildings = new CheckBox();
             checkBoxLogEconomy = new CheckBox();
+            buttonGenerateUrbanLayer = new Button();
             buttonGenerateTileCache = new Button();
             tabPageDiplomacy = new TabPage();
             labelProposedTrades = new Label();
@@ -263,6 +264,7 @@
             tabPageDebug.Controls.Add(checkBoxLogPops);
             tabPageDebug.Controls.Add(checkBoxLogBuildings);
             tabPageDebug.Controls.Add(checkBoxLogEconomy);
+            tabPageDebug.Controls.Add(buttonGenerateUrbanLayer);
             tabPageDebug.Controls.Add(buttonGenerateTileCache);
             tabPageDebug.Controls.Add(buttonToggleDebugMode);
             tabPageDebug.Location = new Point(4, 29);
@@ -414,7 +416,7 @@
             checkBoxLogEconomy.CheckedChanged += CheckBoxLogEconomy_CheckedChanged;
             // 
             // buttonGenerateTileCache
-            // 
+            //
             buttonGenerateTileCache.Location = new Point(182, 662);
             buttonGenerateTileCache.Margin = new Padding(5, 4, 5, 4);
             buttonGenerateTileCache.Name = "buttonGenerateTileCache";
@@ -422,6 +424,17 @@
             buttonGenerateTileCache.TabIndex = 13;
             buttonGenerateTileCache.Text = "Build Tile Cache";
             buttonGenerateTileCache.UseVisualStyleBackColor = true;
+
+            //
+            // buttonGenerateUrbanLayer
+            //
+            buttonGenerateUrbanLayer.Location = new Point(14, 662);
+            buttonGenerateUrbanLayer.Margin = new Padding(5, 4, 5, 4);
+            buttonGenerateUrbanLayer.Name = "buttonGenerateUrbanLayer";
+            buttonGenerateUrbanLayer.Size = new Size(160, 36);
+            buttonGenerateUrbanLayer.TabIndex = 14;
+            buttonGenerateUrbanLayer.Text = "Generate Urban Layer";
+            buttonGenerateUrbanLayer.UseVisualStyleBackColor = true;
             // 
             // tabPageDiplomacy
             // 
@@ -712,6 +725,7 @@
         private System.Windows.Forms.CheckBox checkBoxLogPops;
         private System.Windows.Forms.CheckBox checkBoxLogBuildings;
         private System.Windows.Forms.CheckBox checkBoxLogEconomy;
+        private System.Windows.Forms.Button buttonGenerateUrbanLayer;
         private System.Windows.Forms.Button buttonGenerateTileCache;
         private System.Windows.Forms.TabPage tabPageDiplomacy;
         private System.Windows.Forms.Label labelProposedTrades;

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -159,6 +159,8 @@ namespace economy_sim
             this.buttonShowFactoryStats.Location = new System.Drawing.Point(this.buttonShowPopStats.Right + 10, buttonsTargetY);
             this.buttonShowFactoryStats.Click += ButtonShowFactoryStats_Click;
 
+            this.buttonGenerateUrbanLayer.Click += ButtonGenerateUrbanLayer_Click;
+
             this.buttonShowConstruction.Location = new System.Drawing.Point(this.buttonShowFactoryStats.Right + 10, buttonsTargetY);
             this.buttonShowConstruction.Click += ButtonShowConstruction_Click;
 
@@ -1882,6 +1884,19 @@ namespace economy_sim
         private void CheckBoxLogEconomy_CheckedChanged(object sender, EventArgs e)
         {
             DebugLogger.EnableEconomyLogging(checkBoxLogEconomy.Checked);
+        }
+
+        private async void ButtonGenerateUrbanLayer_Click(object sender, EventArgs e)
+        {
+            try
+            {
+                await Task.Run(() => StrategyGame.UrbanAreaRenderer.GenerateUrbanTextureLayer());
+                MessageBox.Show("Urban texture generated", "Generation Complete");
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show($"Failed to generate urban layer: {ex.Message}");
+            }
         }
 
         // Update the Finance tab UI

--- a/PixelMapGenerator.cs
+++ b/PixelMapGenerator.cs
@@ -54,6 +54,9 @@ namespace StrategyGame
 
         private static readonly Dictionary<string, string> DataFiles = LoadDataFiles();
 
+        private static Image<Rgba32> _cachedUrbanTexture;
+        private static readonly object UrbanLock = new();
+
         // System.Drawing fails with "Parameter is not valid" when width or height
         // exceed approximately 32k pixels.  Clamp generated bitmap dimensions to
         // stay below this threshold.
@@ -109,6 +112,21 @@ namespace StrategyGame
         // Terrain map used for pixel-art generation.
         private static readonly string TerrainTifPath =
             GetDataFile("NE1_HR_LC.tif");
+
+        private static readonly string UrbanTexturePath =
+            GetDataFile("urban_texture.png");
+
+        private static Image<Rgba32> GetUrbanTexture()
+        {
+            lock (UrbanLock)
+            {
+                if (_cachedUrbanTexture == null && File.Exists(UrbanTexturePath))
+                {
+                    _cachedUrbanTexture = Image.Load<Rgba32>(UrbanTexturePath);
+                }
+                return _cachedUrbanTexture;
+            }
+        }
 
 
         /// <summary>
@@ -224,6 +242,39 @@ namespace StrategyGame
             return dest;
         }
 
+        private static void OverlayUrban(Image<Rgba32> tile, int offsetX, int offsetY, int fullWidth, int fullHeight)
+        {
+            var texture = GetUrbanTexture();
+            if (texture == null)
+                return;
+
+            float scaleX = (float)texture.Width / fullWidth;
+            float scaleY = (float)texture.Height / fullHeight;
+
+            for (int y = 0; y < tile.Height; y++)
+            {
+                Span<Rgba32> row = tile.DangerousGetPixelRowMemory(y).Span;
+                for (int x = 0; x < tile.Width; x++)
+                {
+                    int ux = (int)((offsetX + x) * scaleX);
+                    int uy = (int)((offsetY + y) * scaleY);
+                    if (ux < 0 || ux >= texture.Width || uy < 0 || uy >= texture.Height)
+                        continue;
+
+                    Rgba32 urban = texture[ux, uy];
+                    if (urban.A == 0)
+                        continue;
+
+                    Rgba32 basePix = row[x];
+                    float a = urban.A / 255f;
+                    byte r = (byte)(basePix.R * (1 - a) + urban.R * a);
+                    byte g = (byte)(basePix.G * (1 - a) + urban.G * a);
+                    byte b = (byte)(basePix.B * (1 - a) + urban.B * a);
+                    row[x] = new Rgba32(r, g, b, 255);
+                }
+            }
+        }
+
         /// <summary>
         /// Generate a terrain tile and overlay country borders.
         /// </summary>
@@ -240,6 +291,8 @@ namespace StrategyGame
             var img = GenerateTerrainTileLarge(mapWidth, mapHeight, cellSize, tileX, tileY, tileSizePx, mask);
 
             DrawBordersLarge(img, mask);
+
+            OverlayUrban(img, offsetX, offsetY, fullW, fullH);
 
             return img;
         }

--- a/PixelMapGenerator.cs
+++ b/PixelMapGenerator.cs
@@ -122,7 +122,7 @@ namespace StrategyGame
             {
                 if (_cachedUrbanTexture == null && File.Exists(UrbanTexturePath))
                 {
-                    _cachedUrbanTexture = Image.Load<Rgba32>(UrbanTexturePath);
+                    _cachedUrbanTexture = SixLabors.ImageSharp.Image.Load<Rgba32>(UrbanTexturePath);
                 }
                 return _cachedUrbanTexture;
             }

--- a/UrbanAreaRenderer.cs
+++ b/UrbanAreaRenderer.cs
@@ -1,0 +1,193 @@
+using MaxRev.Gdal.Core;
+using OSGeo.GDAL;
+using OSGeo.OGR;
+using OSGeo.OSR;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace StrategyGame
+{
+    /// <summary>
+    /// Generates a global urban texture layer by rasterizing Natural Earth
+    /// urban area polygons and city points. The result is stored as a PNG
+    /// for fast overlay when rendering map tiles.
+    /// </summary>
+    public static class UrbanAreaRenderer
+    {
+        private const int TextureWidth = 14400;
+        private const int TextureHeight = 7200;
+
+        private static readonly object GdalLock = new();
+        private static bool _gdalConfigured = false;
+
+        private static readonly string RepoRoot =
+            Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "..", "..", ".."));
+
+        private static readonly string DataDir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+            "data");
+
+        private static readonly string RepoDataDir = Path.Combine(RepoRoot, "data");
+        private static readonly string DataFileList = Path.Combine(RepoRoot, "DataFileNames");
+        private static readonly Dictionary<string, string> DataFiles = LoadDataFiles();
+
+        private static string GetDataFile(string name)
+        {
+            if (DataFiles.TryGetValue(name, out var mapped) && File.Exists(mapped))
+                return mapped;
+
+            string userPath = Path.Combine(DataDir, name);
+            if (File.Exists(userPath))
+                return userPath;
+
+            string repoPath = Path.Combine(RepoDataDir, name);
+            if (File.Exists(repoPath))
+                return repoPath;
+
+            return userPath;
+        }
+
+        public static void GenerateUrbanTextureLayer()
+        {
+            lock (GdalLock)
+            {
+                if (!_gdalConfigured)
+                {
+                    GdalBase.ConfigureAll();
+                    _gdalConfigured = true;
+                }
+            }
+
+            string urbanPath = GetDataFile("ne_10m_urban_areas.shp");
+            string placesPath = GetDataFile("ne_10m_populated_places.shp");
+            if (!File.Exists(urbanPath) || !File.Exists(placesPath))
+                throw new FileNotFoundException("Missing urban shapefiles");
+
+            var driver = Gdal.GetDriverByName("MEM");
+            using var ds = driver.Create("", TextureWidth, TextureHeight, 1, DataType.GDT_Byte, null);
+            double pixelSizeX = 360.0 / TextureWidth;
+            double pixelSizeY = 180.0 / TextureHeight;
+            double[] gt = { -180.0, pixelSizeX, 0, 90.0, 0, -pixelSizeY };
+            ds.SetGeoTransform(gt);
+            using var srs = new SpatialReference(string.Empty);
+            srs.ImportFromEPSG(4326);
+            ds.SetProjection(srs.ExportToWkt());
+
+            using DataSource urbanDs = Ogr.Open(urbanPath, 0);
+            Layer urbanLayer = urbanDs.GetLayerByIndex(0);
+            // Burn value 255 where urban polygons exist
+            Gdal.RasterizeLayer(ds, 1, new[] { 1 }, urbanLayer, IntPtr.Zero, IntPtr.Zero,
+                1, new[] { 255.0 }, new[] { "ALL_TOUCHED=TRUE" }, null, "");
+
+            Band maskBand = ds.GetRasterBand(1);
+            byte[] mask = new byte[TextureWidth * TextureHeight];
+            maskBand.ReadRaster(0, 0, TextureWidth, TextureHeight, mask, TextureWidth, TextureHeight, 0, 0);
+
+            using DataSource placesDs = Ogr.Open(placesPath, 0);
+            Layer placesLayer = placesDs.GetLayerByIndex(0);
+            var grey = new Rgba32(130, 130, 130, 180);
+
+            using var img = new Image<Rgba32>(TextureWidth, TextureHeight);
+            img.Mutate(ctx => ctx.Clear(Color.Transparent));
+
+            // Transfer existing mask to image
+            for (int y = 0; y < TextureHeight; y++)
+            {
+                Span<Rgba32> row = img.DangerousGetPixelRowMemory(y).Span;
+                int offset = y * TextureWidth;
+                for (int x = 0; x < TextureWidth; x++)
+                {
+                    if (mask[offset + x] != 0)
+                        row[x] = grey;
+                }
+            }
+
+            // Draw circles for populated places not already covered
+            placesLayer.ResetReading();
+            Feature feat;
+            while ((feat = placesLayer.GetNextFeature()) != null)
+            {
+                var geom = feat.GetGeometryRef();
+                double lon = geom.GetX(0);
+                double lat = geom.GetY(0);
+                int px = (int)((lon + 180.0) / 360.0 * TextureWidth);
+                int py = (int)((90.0 - lat) / 180.0 * TextureHeight);
+                if (px < 0 || px >= TextureWidth || py < 0 || py >= TextureHeight)
+                    continue;
+
+                int idx = py * TextureWidth + px;
+                if (mask[idx] != 0)
+                    continue; // already urban
+
+                int pop = 0;
+                if (feat.GetFieldIndex("POP_MAX") != -1)
+                    pop = feat.GetFieldAsInteger("POP_MAX");
+                else if (feat.GetFieldIndex("pop_max") != -1)
+                    pop = feat.GetFieldAsInteger("pop_max");
+
+                int radius = pop switch
+                {
+                    > 10000000 => 6,
+                    > 5000000 => 5,
+                    > 1000000 => 4,
+                    > 500000 => 3,
+                    > 100000 => 2,
+                    _ => 1
+                };
+                FillCircle(img, px - radius, py - radius, radius * 2, grey);
+            }
+
+            string outPath = Path.Combine(DataDir, "urban_texture.png");
+            Directory.CreateDirectory(DataDir);
+            img.Save(outPath);
+        }
+
+        private static void FillCircle(Image<Rgba32> img, int x, int y, int size, Rgba32 color)
+        {
+            int radius = size / 2;
+            int cx = x + radius;
+            int cy = y + radius;
+            for (int iy = -radius; iy <= radius; iy++)
+            {
+                int yy = cy + iy;
+                if (yy < 0 || yy >= img.Height) continue;
+                int dx = (int)Math.Sqrt(radius * radius - iy * iy);
+                int start = cx - dx;
+                int end = cx + dx;
+                if (start < 0) start = 0;
+                if (end >= img.Width) end = img.Width - 1;
+                Span<Rgba32> row = img.DangerousGetPixelRowMemory(yy).Span;
+                for (int ix = start; ix <= end; ix++)
+                    row[ix] = color;
+            }
+        }
+
+        private static Dictionary<string, string> LoadDataFiles()
+        {
+            var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (File.Exists(DataFileList))
+            {
+                foreach (var line in File.ReadAllLines(DataFileList))
+                {
+                    var trimmed = line.Trim();
+                    if (string.IsNullOrEmpty(trimmed) || trimmed.StartsWith("#") || trimmed.StartsWith("files"))
+                        continue;
+
+                    string userPath = Path.Combine(DataDir, trimmed);
+                    if (File.Exists(userPath))
+                    {
+                        dict[trimmed] = userPath;
+                    }
+                    else
+                    {
+                        dict[trimmed] = Path.Combine(RepoDataDir, trimmed);
+                    }
+                }
+            }
+            return dict;
+        }
+    }
+}

--- a/UrbanAreaRenderer.cs
+++ b/UrbanAreaRenderer.cs
@@ -4,6 +4,8 @@ using OSGeo.OGR;
 using OSGeo.OSR;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+using SixLabors.ImageSharp.Advanced;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -74,7 +76,9 @@ namespace StrategyGame
             ds.SetGeoTransform(gt);
             using var srs = new SpatialReference(string.Empty);
             srs.ImportFromEPSG(4326);
-            ds.SetProjection(srs.ExportToWkt());
+            string wkt;
+            srs.ExportToWkt(out wkt, null);
+            ds.SetProjection(wkt);
 
             using DataSource urbanDs = Ogr.Open(urbanPath, 0);
             Layer urbanLayer = urbanDs.GetLayerByIndex(0);

--- a/UrbanAreaRenderer.cs
+++ b/UrbanAreaRenderer.cs
@@ -3,7 +3,9 @@ using OSGeo.GDAL;
 using OSGeo.OGR;
 using OSGeo.OSR;
 using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Advanced; // Add this using directive
 using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing; // Add this using directive
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -74,7 +76,8 @@ namespace StrategyGame
             ds.SetGeoTransform(gt);
             using var srs = new SpatialReference(string.Empty);
             srs.ImportFromEPSG(4326);
-            ds.SetProjection(srs.ExportToWkt());
+            srs.ExportToWkt(out string wkt, null);
+            ds.SetProjection(wkt);
 
             using DataSource urbanDs = Ogr.Open(urbanPath, 0);
             Layer urbanLayer = urbanDs.GetLayerByIndex(0);
@@ -91,7 +94,7 @@ namespace StrategyGame
             var grey = new Rgba32(130, 130, 130, 180);
 
             using var img = new Image<Rgba32>(TextureWidth, TextureHeight);
-            img.Mutate(ctx => ctx.Clear(Color.Transparent));
+            // Image starts with transparent pixels by default
 
             // Transfer existing mask to image
             for (int y = 0; y < TextureHeight; y++)


### PR DESCRIPTION
## Summary
- implement `UrbanAreaRenderer` to build a global urban texture from Natural Earth data
- load and blend the texture in `PixelMapGenerator`
- expose "Generate Urban Layer" button on the Debug tab
- wire new button to generate the texture asynchronously
- update data file list for new shapefiles

## Testing
- `dotnet build "economy sim.sln" -v minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686290e0b3c883238365e5a0ae7d8742