### PR TITLE
Implement procedural urban generation

### DIFF
--- a/GeometryUtil.cs
+++ b/GeometryUtil.cs
@@ -1,0 +1,79 @@
+namespace StrategyGame
+{
+    public struct GeoBounds { public double MinLon, MaxLon, MinLat, MaxLat; }
+
+    public static class GeometryUtil
+    {
+        public static bool ClipLine(GeoBounds bounds, ref double x1, ref double y1, ref double x2, ref double y2)
+        {
+            double t0 = 0.0, t1 = 1.0;
+            double dx = x2 - x1, dy = y2 - y1;
+            double p, q, r;
+
+            p = -dx; q = x1 - bounds.MinLon;
+            if (p == 0 && q < 0) return false;
+            if (p != 0)
+            {
+                r = q / p;
+                if (p < 0)
+                {
+                    if (r > t1) return false; if (r > t0) t0 = r;
+                }
+                else
+                {
+                    if (r < t0) return false; if (r < t1) t1 = r;
+                }
+            }
+
+            p = dx; q = bounds.MaxLon - x1;
+            if (p == 0 && q < 0) return false;
+            if (p != 0)
+            {
+                r = q / p;
+                if (p < 0)
+                {
+                    if (r > t1) return false; if (r > t0) t0 = r;
+                }
+                else
+                {
+                    if (r < t0) return false; if (r < t1) t1 = r;
+                }
+            }
+
+            p = -dy; q = y1 - bounds.MinLat;
+            if (p == 0 && q < 0) return false;
+            if (p != 0)
+            {
+                r = q / p;
+                if (p < 0)
+                {
+                    if (r > t1) return false; if (r > t0) t0 = r;
+                }
+                else
+                {
+                    if (r < t0) return false; if (r < t1) t1 = r;
+                }
+            }
+
+            p = dy; q = bounds.MaxLat - y1;
+            if (p == 0 && q < 0) return false;
+            if (p != 0)
+            {
+                r = q / p;
+                if (p < 0)
+                {
+                    if (r > t1) return false; if (r > t0) t0 = r;
+                }
+                else
+                {
+                    if (r < t0) return false; if (r < t1) t1 = r;
+                }
+            }
+
+            if (t1 < 1.0) { x2 = x1 + t1 * dx; y2 = y1 + t1 * dy; }
+            if (t0 > 0.0) { x1 = x1 + t0 * dx; y1 = y1 + t0 * dy; }
+
+            return true;
+        }
+    }
+}

--- a/LineSegment.cs
+++ b/LineSegment.cs
@@ -1,0 +1,11 @@
+namespace StrategyGame
+{
+    public struct LineSegment
+    {
+        public double X1, Y1, X2, Y2;
+        public LineSegment(double x1, double y1, double x2, double y2)
+        {
+            X1 = x1; Y1 = y1; X2 = x2; Y2 = y2;
+        }
+    }
+}

--- a/MainGame.Designer.cs
+++ b/MainGame.Designer.cs
@@ -63,7 +63,6 @@
             checkBoxLogPops = new CheckBox();
             checkBoxLogBuildings = new CheckBox();
             checkBoxLogEconomy = new CheckBox();
-            buttonGenerateUrbanLayer = new Button();
             buttonGenerateTileCache = new Button();
             tabPageDiplomacy = new TabPage();
             labelProposedTrades = new Label();
@@ -264,7 +263,6 @@
             tabPageDebug.Controls.Add(checkBoxLogPops);
             tabPageDebug.Controls.Add(checkBoxLogBuildings);
             tabPageDebug.Controls.Add(checkBoxLogEconomy);
-            tabPageDebug.Controls.Add(buttonGenerateUrbanLayer);
             tabPageDebug.Controls.Add(buttonGenerateTileCache);
             tabPageDebug.Controls.Add(buttonToggleDebugMode);
             tabPageDebug.Location = new Point(4, 29);
@@ -425,16 +423,6 @@
             buttonGenerateTileCache.Text = "Build Tile Cache";
             buttonGenerateTileCache.UseVisualStyleBackColor = true;
 
-            //
-            // buttonGenerateUrbanLayer
-            //
-            buttonGenerateUrbanLayer.Location = new Point(14, 662);
-            buttonGenerateUrbanLayer.Margin = new Padding(5, 4, 5, 4);
-            buttonGenerateUrbanLayer.Name = "buttonGenerateUrbanLayer";
-            buttonGenerateUrbanLayer.Size = new Size(160, 36);
-            buttonGenerateUrbanLayer.TabIndex = 14;
-            buttonGenerateUrbanLayer.Text = "Generate Urban Layer";
-            buttonGenerateUrbanLayer.UseVisualStyleBackColor = true;
             // 
             // tabPageDiplomacy
             // 
@@ -725,7 +713,6 @@
         private System.Windows.Forms.CheckBox checkBoxLogPops;
         private System.Windows.Forms.CheckBox checkBoxLogBuildings;
         private System.Windows.Forms.CheckBox checkBoxLogEconomy;
-        private System.Windows.Forms.Button buttonGenerateUrbanLayer;
         private System.Windows.Forms.Button buttonGenerateTileCache;
         private System.Windows.Forms.TabPage tabPageDiplomacy;
         private System.Windows.Forms.Label labelProposedTrades;

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -159,7 +159,6 @@ namespace economy_sim
             this.buttonShowFactoryStats.Location = new System.Drawing.Point(this.buttonShowPopStats.Right + 10, buttonsTargetY);
             this.buttonShowFactoryStats.Click += ButtonShowFactoryStats_Click;
 
-            this.buttonGenerateUrbanLayer.Click += ButtonGenerateUrbanLayer_Click;
 
             this.buttonShowConstruction.Location = new System.Drawing.Point(this.buttonShowFactoryStats.Right + 10, buttonsTargetY);
             this.buttonShowConstruction.Click += ButtonShowConstruction_Click;
@@ -429,6 +428,9 @@ namespace economy_sim
 
             // 2. Initialize Factory Blueprints (this also populates Market.GoodDefinitions now)
             FactoryBlueprints.InitializeBlueprints();
+
+            // Load urban area polygons for procedural generation
+            UrbanAreaManager.LoadUrbanAreas();
 
             // 3. Load World Setup from JSON
             string jsonFilePath = "world_setup.json";
@@ -1886,18 +1888,6 @@ namespace economy_sim
             DebugLogger.EnableEconomyLogging(checkBoxLogEconomy.Checked);
         }
 
-        private async void ButtonGenerateUrbanLayer_Click(object sender, EventArgs e)
-        {
-            try
-            {
-                await Task.Run(() => StrategyGame.UrbanAreaRenderer.GenerateUrbanTextureLayer());
-                MessageBox.Show("Urban texture generated", "Generation Complete");
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show($"Failed to generate urban layer: {ex.Message}");
-            }
-        }
 
         // Update the Finance tab UI
         private void UpdateFinanceTab()

--- a/PixelMapGenerator.cs
+++ b/PixelMapGenerator.cs
@@ -275,32 +275,54 @@ namespace StrategyGame
                 if (!urban.Intersects(tilePoly))
                     continue;
 
-                var network = RoadNetworkGenerator.GetOrGenerateFor(urban);
-                foreach (var road in network)
+                var network = RoadNetworkGenerator.GetOrGenerateFor(urban, cellSize);
+                if (network.Count == 0)
                 {
-                    double x1 = road.X1, y1 = road.Y1, x2 = road.X2, y2 = road.Y2;
-                    if (!GeometryUtil.ClipLine(bounds, ref x1, ref y1, ref x2, ref y2))
-                        continue;
-                    int px1 = (int)((x1 - bounds.MinLon) / (bounds.MaxLon - bounds.MinLon) * tileWidth);
-                    int py1 = (int)((bounds.MaxLat - y1) / (bounds.MaxLat - bounds.MinLat) * tileHeight);
-                    int px2 = (int)((x2 - bounds.MinLon) / (bounds.MaxLon - bounds.MinLon) * tileWidth);
-                    int py2 = (int)((bounds.MaxLat - y2) / (bounds.MaxLat - bounds.MinLat) * tileHeight);
-                    DrawLine(img, px1, py1, px2, py2, roadColor);
-                }
-
-                var visible = urban.Intersection(tilePoly);
-                if (visible != null && !visible.IsEmpty)
-                {
-                    if (visible is NetTopologySuite.Geometries.Polygon p)
+                    var visibleFill = urban.Intersection(tilePoly);
+                    if (visibleFill != null && !visibleFill.IsEmpty)
                     {
-                        RenderPolygon(img, p, bounds, tileWidth, tileHeight, fillColor);
-                    }
-                    else if (visible is NetTopologySuite.Geometries.MultiPolygon mp)
-                    {
-                        for (int i = 0; i < mp.NumGeometries; i++)
+                        if (visibleFill is NetTopologySuite.Geometries.Polygon p)
                         {
-                            if (mp.GetGeometryN(i) is NetTopologySuite.Geometries.Polygon pp)
-                                RenderPolygon(img, pp, bounds, tileWidth, tileHeight, fillColor);
+                            RenderPolygon(img, p, bounds, tileWidth, tileHeight, fillColor);
+                        }
+                        else if (visibleFill is NetTopologySuite.Geometries.MultiPolygon mpFill)
+                        {
+                            for (int i = 0; i < mpFill.NumGeometries; i++)
+                            {
+                                if (mpFill.GetGeometryN(i) is NetTopologySuite.Geometries.Polygon pp)
+                                    RenderPolygon(img, pp, bounds, tileWidth, tileHeight, fillColor);
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    foreach (var road in network)
+                    {
+                        double x1 = road.X1, y1 = road.Y1, x2 = road.X2, y2 = road.Y2;
+                        if (!GeometryUtil.ClipLine(bounds, ref x1, ref y1, ref x2, ref y2))
+                            continue;
+                        int px1 = (int)((x1 - bounds.MinLon) / (bounds.MaxLon - bounds.MinLon) * tileWidth);
+                        int py1 = (int)((bounds.MaxLat - y1) / (bounds.MaxLat - bounds.MinLat) * tileHeight);
+                        int px2 = (int)((x2 - bounds.MinLon) / (bounds.MaxLon - bounds.MinLon) * tileWidth);
+                        int py2 = (int)((bounds.MaxLat - y2) / (bounds.MaxLat - bounds.MinLat) * tileHeight);
+                        DrawLine(img, px1, py1, px2, py2, roadColor);
+                    }
+
+                    var visible = urban.Intersection(tilePoly);
+                    if (visible != null && !visible.IsEmpty)
+                    {
+                        if (visible is NetTopologySuite.Geometries.Polygon p)
+                        {
+                            RenderPolygon(img, p, bounds, tileWidth, tileHeight, fillColor);
+                        }
+                        else if (visible is NetTopologySuite.Geometries.MultiPolygon mp)
+                        {
+                            for (int i = 0; i < mp.NumGeometries; i++)
+                            {
+                                if (mp.GetGeometryN(i) is NetTopologySuite.Geometries.Polygon pp)
+                                    RenderPolygon(img, pp, bounds, tileWidth, tileHeight, fillColor);
+                            }
                         }
                     }
                 }

--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -7,28 +7,80 @@ namespace StrategyGame
     {
         private static Dictionary<Polygon, List<LineSegment>> networkCache = new();
 
-        public static List<LineSegment> GetOrGenerateFor(Polygon urbanArea)
+        public static List<LineSegment> GetOrGenerateFor(Polygon urbanArea, int cellSize)
         {
+            // Low zoom levels use a simple fill instead of detailed roads
+            if (cellSize < 40)
+                return new List<LineSegment>();
+
             if (networkCache.TryGetValue(urbanArea, out var cached))
                 return cached;
 
             var env = urbanArea.EnvelopeInternal;
-            int grid = 50;
-            double stepX = (env.MaxX - env.MinX) / grid;
-            double stepY = (env.MaxY - env.MinY) / grid;
-            var list = new List<LineSegment>();
-            for (int i = 0; i <= grid; i++)
+            double diagonal = System.Math.Sqrt(env.Width * env.Width + env.Height * env.Height);
+            int divisions = (int)System.Math.Max(5, diagonal * 400.0);
+
+            double stepX = env.Width / divisions;
+            double stepY = env.Height / divisions;
+
+            var gridLines = new List<LineSegment>();
+            for (int i = 0; i <= divisions; i++)
             {
                 double x = env.MinX + i * stepX;
-                list.Add(new LineSegment(x, env.MinY, x, env.MaxY));
+                gridLines.Add(new LineSegment(x, env.MinY, x, env.MaxY));
             }
-            for (int j = 0; j <= grid; j++)
+            for (int j = 0; j <= divisions; j++)
             {
                 double y = env.MinY + j * stepY;
-                list.Add(new LineSegment(env.MinX, y, env.MaxX, y));
+                gridLines.Add(new LineSegment(env.MinX, y, env.MaxX, y));
             }
-            networkCache[urbanArea] = list;
-            return list;
+
+            var clippedNetwork = new List<LineSegment>();
+            var factory = GeometryFactory.Default;
+
+            foreach (var line in gridLines)
+            {
+                var lineString = factory.CreateLineString(new[]
+                {
+                    new Coordinate(line.X1, line.Y1),
+                    new Coordinate(line.X2, line.Y2)
+                });
+
+                if (!urbanArea.Intersects(lineString))
+                    continue;
+
+                var intersection = urbanArea.Intersection(lineString);
+
+                if (intersection is LineString ls)
+                {
+                    var coords = ls.Coordinates;
+                    for (int c = 0; c < coords.Length - 1; c++)
+                    {
+                        clippedNetwork.Add(new LineSegment(
+                            coords[c].X, coords[c].Y,
+                            coords[c + 1].X, coords[c + 1].Y));
+                    }
+                }
+                else if (intersection is MultiLineString mls)
+                {
+                    foreach (var geom in mls.Geometries)
+                    {
+                        if (geom is LineString subLs)
+                        {
+                            var coords = subLs.Coordinates;
+                            for (int c = 0; c < coords.Length - 1; c++)
+                            {
+                                clippedNetwork.Add(new LineSegment(
+                                    coords[c].X, coords[c].Y,
+                                    coords[c + 1].X, coords[c + 1].Y));
+                            }
+                        }
+                    }
+                }
+            }
+
+            networkCache[urbanArea] = clippedNetwork;
+            return clippedNetwork;
         }
     }
 }

--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -1,0 +1,34 @@
+using NetTopologySuite.Geometries;
+using System.Collections.Generic;
+
+namespace StrategyGame
+{
+    public static class RoadNetworkGenerator
+    {
+        private static Dictionary<Polygon, List<LineSegment>> networkCache = new();
+
+        public static List<LineSegment> GetOrGenerateFor(Polygon urbanArea)
+        {
+            if (networkCache.TryGetValue(urbanArea, out var cached))
+                return cached;
+
+            var env = urbanArea.EnvelopeInternal;
+            int grid = 50;
+            double stepX = (env.MaxX - env.MinX) / grid;
+            double stepY = (env.MaxY - env.MinY) / grid;
+            var list = new List<LineSegment>();
+            for (int i = 0; i <= grid; i++)
+            {
+                double x = env.MinX + i * stepX;
+                list.Add(new LineSegment(x, env.MinY, x, env.MaxY));
+            }
+            for (int j = 0; j <= grid; j++)
+            {
+                double y = env.MinY + j * stepY;
+                list.Add(new LineSegment(env.MinX, y, env.MaxX, y));
+            }
+            networkCache[urbanArea] = list;
+            return list;
+        }
+    }
+}

--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -1,34 +1,34 @@
 using NetTopologySuite.Geometries;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 
 namespace StrategyGame
 {
     public static class RoadNetworkGenerator
     {
-        private static Dictionary<Polygon, List<LineSegment>> networkCache = new();
+        private static readonly ConcurrentDictionary<Polygon, List<LineSegment>> networkCache = new();
 
         public static List<LineSegment> GetOrGenerateFor(Polygon urbanArea)
         {
-            if (networkCache.TryGetValue(urbanArea, out var cached))
-                return cached;
-
-            var env = urbanArea.EnvelopeInternal;
-            int grid = 50;
-            double stepX = (env.MaxX - env.MinX) / grid;
-            double stepY = (env.MaxY - env.MinY) / grid;
-            var list = new List<LineSegment>();
-            for (int i = 0; i <= grid; i++)
+            return networkCache.GetOrAdd(urbanArea, _ =>
             {
-                double x = env.MinX + i * stepX;
-                list.Add(new LineSegment(x, env.MinY, x, env.MaxY));
-            }
-            for (int j = 0; j <= grid; j++)
-            {
-                double y = env.MinY + j * stepY;
-                list.Add(new LineSegment(env.MinX, y, env.MaxX, y));
-            }
-            networkCache[urbanArea] = list;
-            return list;
+                var env = urbanArea.EnvelopeInternal;
+                int grid = 50;
+                double stepX = (env.MaxX - env.MinX) / grid;
+                double stepY = (env.MaxY - env.MinY) / grid;
+                var list = new List<LineSegment>();
+                for (int i = 0; i <= grid; i++)
+                {
+                    double x = env.MinX + i * stepX;
+                    list.Add(new LineSegment(x, env.MinY, x, env.MaxY));
+                }
+                for (int j = 0; j <= grid; j++)
+                {
+                    double y = env.MinY + j * stepY;
+                    list.Add(new LineSegment(env.MinX, y, env.MaxX, y));
+                }
+                return list;
+            });
         }
     }
 }

--- a/UrbanAreaManager.cs
+++ b/UrbanAreaManager.cs
@@ -1,0 +1,103 @@
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace StrategyGame
+{
+    public static class UrbanAreaManager
+    {
+        public static List<Polygon> UrbanPolygons { get; private set; } = new();
+
+        private static readonly string RepoRoot =
+            Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "..", "..", ".."));
+        private static readonly string DataDir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+            "data");
+        private static readonly string RepoDataDir = Path.Combine(RepoRoot, "data");
+        private static readonly string DataFileList = Path.Combine(RepoRoot, "DataFileNames");
+        private static readonly Dictionary<string, string> DataFiles = LoadDataFiles();
+
+        public static void LoadUrbanAreas()
+        {
+            UrbanPolygons.Clear();
+            string shp = GetDataFile("ne_10m_urban_areas.shp");
+            if (!File.Exists(shp))
+                return;
+
+            var reader = new ShapefileDataReader(shp, GeometryFactory.Default);
+            while (reader.Read())
+            {
+                var geom = reader.Geometry;
+                if (geom is MultiPolygon mp)
+                {
+                    for (int i = 0; i < mp.NumGeometries; i++)
+                    {
+                        if (mp.GetGeometryN(i) is Polygon p)
+                            UrbanPolygons.Add(p);
+                    }
+                }
+                else if (geom is Polygon p)
+                {
+                    UrbanPolygons.Add(p);
+                }
+            }
+        }
+
+        private static string GetDataFile(string name)
+        {
+            if (DataFiles.TryGetValue(name, out var mapped) && File.Exists(mapped))
+                return mapped;
+
+            string userPath = Path.Combine(DataDir, name);
+            if (File.Exists(userPath))
+                return userPath;
+
+            if (Directory.Exists(DataDir))
+            {
+                var matches = Directory.GetFiles(DataDir, name, SearchOption.AllDirectories);
+                if (matches.Length > 0)
+                    return matches[0];
+            }
+
+            string repoPath = Path.Combine(RepoDataDir, name);
+            if (File.Exists(repoPath))
+                return repoPath;
+
+            if (Directory.Exists(RepoDataDir))
+            {
+                var matches = Directory.GetFiles(RepoDataDir, name, SearchOption.AllDirectories);
+                if (matches.Length > 0)
+                    return matches[0];
+            }
+
+            return userPath;
+        }
+
+        private static Dictionary<string, string> LoadDataFiles()
+        {
+            var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (File.Exists(DataFileList))
+            {
+                foreach (var line in File.ReadAllLines(DataFileList))
+                {
+                    var trimmed = line.Trim();
+                    if (string.IsNullOrEmpty(trimmed) || trimmed.StartsWith("#") || trimmed.StartsWith("files"))
+                        continue;
+
+                    string userPath = Path.Combine(DataDir, trimmed);
+                    if (File.Exists(userPath))
+                    {
+                        dict[trimmed] = userPath;
+                    }
+                    else
+                    {
+                        dict[trimmed] = Path.Combine(RepoDataDir, trimmed);
+                    }
+                }
+            }
+            return dict;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- load urban area polygons from Natural Earth data
- provide road network generation with caching
- clip rendered segments to tile bounds
- integrate dynamic road drawing into tile generation
- remove obsolete urban texture button and handler

## Testing
- `dotnet build "economy sim.sln" -v minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864ea2447408323a4c3e1081af37b33