### PR TITLE
Improve urban area rendering and cache networks

### DIFF
--- a/GeometryUtil.cs
+++ b/GeometryUtil.cs
@@ -1,0 +1,79 @@
+namespace StrategyGame
+{
+    public struct GeoBounds { public double MinLon, MaxLon, MinLat, MaxLat; }
+
+    public static class GeometryUtil
+    {
+        public static bool ClipLine(GeoBounds bounds, ref double x1, ref double y1, ref double x2, ref double y2)
+        {
+            double t0 = 0.0, t1 = 1.0;
+            double dx = x2 - x1, dy = y2 - y1;
+            double p, q, r;
+
+            p = -dx; q = x1 - bounds.MinLon;
+            if (p == 0 && q < 0) return false;
+            if (p != 0)
+            {
+                r = q / p;
+                if (p < 0)
+                {
+                    if (r > t1) return false; if (r > t0) t0 = r;
+                }
+                else
+                {
+                    if (r < t0) return false; if (r < t1) t1 = r;
+                }
+            }
+
+            p = dx; q = bounds.MaxLon - x1;
+            if (p == 0 && q < 0) return false;
+            if (p != 0)
+            {
+                r = q / p;
+                if (p < 0)
+                {
+                    if (r > t1) return false; if (r > t0) t0 = r;
+                }
+                else
+                {
+                    if (r < t0) return false; if (r < t1) t1 = r;
+                }
+            }
+
+            p = -dy; q = y1 - bounds.MinLat;
+            if (p == 0 && q < 0) return false;
+            if (p != 0)
+            {
+                r = q / p;
+                if (p < 0)
+                {
+                    if (r > t1) return false; if (r > t0) t0 = r;
+                }
+                else
+                {
+                    if (r < t0) return false; if (r < t1) t1 = r;
+                }
+            }
+
+            p = dy; q = bounds.MaxLat - y1;
+            if (p == 0 && q < 0) return false;
+            if (p != 0)
+            {
+                r = q / p;
+                if (p < 0)
+                {
+                    if (r > t1) return false; if (r > t0) t0 = r;
+                }
+                else
+                {
+                    if (r < t0) return false; if (r < t1) t1 = r;
+                }
+            }
+
+            if (t1 < 1.0) { x2 = x1 + t1 * dx; y2 = y1 + t1 * dy; }
+            if (t0 > 0.0) { x1 = x1 + t0 * dx; y1 = y1 + t0 * dy; }
+
+            return true;
+        }
+    }
+}

--- a/LineSegment.cs
+++ b/LineSegment.cs
@@ -1,0 +1,11 @@
+namespace StrategyGame
+{
+    public struct LineSegment
+    {
+        public double X1, Y1, X2, Y2;
+        public LineSegment(double x1, double y1, double x2, double y2)
+        {
+            X1 = x1; Y1 = y1; X2 = x2; Y2 = y2;
+        }
+    }
+}

--- a/MainGame.Designer.cs
+++ b/MainGame.Designer.cs
@@ -63,7 +63,6 @@
             checkBoxLogPops = new CheckBox();
             checkBoxLogBuildings = new CheckBox();
             checkBoxLogEconomy = new CheckBox();
-            buttonGenerateUrbanLayer = new Button();
             buttonGenerateTileCache = new Button();
             tabPageDiplomacy = new TabPage();
             labelProposedTrades = new Label();
@@ -264,7 +263,6 @@
             tabPageDebug.Controls.Add(checkBoxLogPops);
             tabPageDebug.Controls.Add(checkBoxLogBuildings);
             tabPageDebug.Controls.Add(checkBoxLogEconomy);
-            tabPageDebug.Controls.Add(buttonGenerateUrbanLayer);
             tabPageDebug.Controls.Add(buttonGenerateTileCache);
             tabPageDebug.Controls.Add(buttonToggleDebugMode);
             tabPageDebug.Location = new Point(4, 29);
@@ -425,16 +423,6 @@
             buttonGenerateTileCache.Text = "Build Tile Cache";
             buttonGenerateTileCache.UseVisualStyleBackColor = true;
 
-            //
-            // buttonGenerateUrbanLayer
-            //
-            buttonGenerateUrbanLayer.Location = new Point(14, 662);
-            buttonGenerateUrbanLayer.Margin = new Padding(5, 4, 5, 4);
-            buttonGenerateUrbanLayer.Name = "buttonGenerateUrbanLayer";
-            buttonGenerateUrbanLayer.Size = new Size(160, 36);
-            buttonGenerateUrbanLayer.TabIndex = 14;
-            buttonGenerateUrbanLayer.Text = "Generate Urban Layer";
-            buttonGenerateUrbanLayer.UseVisualStyleBackColor = true;
             // 
             // tabPageDiplomacy
             // 
@@ -725,7 +713,6 @@
         private System.Windows.Forms.CheckBox checkBoxLogPops;
         private System.Windows.Forms.CheckBox checkBoxLogBuildings;
         private System.Windows.Forms.CheckBox checkBoxLogEconomy;
-        private System.Windows.Forms.Button buttonGenerateUrbanLayer;
         private System.Windows.Forms.Button buttonGenerateTileCache;
         private System.Windows.Forms.TabPage tabPageDiplomacy;
         private System.Windows.Forms.Label labelProposedTrades;

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -431,7 +431,6 @@ namespace economy_sim
 
             // Load urban area polygons for procedural generation
             UrbanAreaManager.LoadUrbanAreas();
-            Task.Run(() => UrbanAreaManager.PrecomputeAllRoadNetworks());
 
             // 3. Load World Setup from JSON
             string jsonFilePath = "world_setup.json";

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -159,7 +159,6 @@ namespace economy_sim
             this.buttonShowFactoryStats.Location = new System.Drawing.Point(this.buttonShowPopStats.Right + 10, buttonsTargetY);
             this.buttonShowFactoryStats.Click += ButtonShowFactoryStats_Click;
 
-            this.buttonGenerateUrbanLayer.Click += ButtonGenerateUrbanLayer_Click;
 
             this.buttonShowConstruction.Location = new System.Drawing.Point(this.buttonShowFactoryStats.Right + 10, buttonsTargetY);
             this.buttonShowConstruction.Click += ButtonShowConstruction_Click;
@@ -429,6 +428,10 @@ namespace economy_sim
 
             // 2. Initialize Factory Blueprints (this also populates Market.GoodDefinitions now)
             FactoryBlueprints.InitializeBlueprints();
+
+            // Load urban area polygons for procedural generation
+            UrbanAreaManager.LoadUrbanAreas();
+            Task.Run(() => UrbanAreaManager.PrecomputeAllRoadNetworks());
 
             // 3. Load World Setup from JSON
             string jsonFilePath = "world_setup.json";
@@ -1886,18 +1889,6 @@ namespace economy_sim
             DebugLogger.EnableEconomyLogging(checkBoxLogEconomy.Checked);
         }
 
-        private async void ButtonGenerateUrbanLayer_Click(object sender, EventArgs e)
-        {
-            try
-            {
-                await Task.Run(() => StrategyGame.UrbanAreaRenderer.GenerateUrbanTextureLayer());
-                MessageBox.Show("Urban texture generated", "Generation Complete");
-            }
-            catch (Exception ex)
-            {
-                MessageBox.Show($"Failed to generate urban layer: {ex.Message}");
-            }
-        }
 
         // Update the Finance tab UI
         private void UpdateFinanceTab()

--- a/PixelMapGenerator.cs
+++ b/PixelMapGenerator.cs
@@ -54,8 +54,6 @@ namespace StrategyGame
 
         private static readonly Dictionary<string, string> DataFiles = LoadDataFiles();
 
-        private static Image<Rgba32> _cachedUrbanTexture;
-        private static readonly object UrbanLock = new();
 
         // System.Drawing fails with "Parameter is not valid" when width or height
         // exceed approximately 32k pixels.  Clamp generated bitmap dimensions to
@@ -113,20 +111,7 @@ namespace StrategyGame
         private static readonly string TerrainTifPath =
             GetDataFile("NE1_HR_LC.tif");
 
-        private static readonly string UrbanTexturePath =
-            GetDataFile("urban_texture.png");
-
-        private static Image<Rgba32> GetUrbanTexture()
-        {
-            lock (UrbanLock)
-            {
-                if (_cachedUrbanTexture == null && File.Exists(UrbanTexturePath))
-                {
-                    _cachedUrbanTexture = SixLabors.ImageSharp.Image.Load<Rgba32>(UrbanTexturePath);
-                }
-                return _cachedUrbanTexture;
-            }
-        }
+        // Urban texture is no longer used; procedural generation handles urban areas.
 
 
         /// <summary>
@@ -242,38 +227,6 @@ namespace StrategyGame
             return dest;
         }
 
-        private static void OverlayUrban(Image<Rgba32> tile, int offsetX, int offsetY, int fullWidth, int fullHeight)
-        {
-            var texture = GetUrbanTexture();
-            if (texture == null)
-                return;
-
-            float scaleX = (float)texture.Width / fullWidth;
-            float scaleY = (float)texture.Height / fullHeight;
-
-            for (int y = 0; y < tile.Height; y++)
-            {
-                Span<Rgba32> row = tile.DangerousGetPixelRowMemory(y).Span;
-                for (int x = 0; x < tile.Width; x++)
-                {
-                    int ux = (int)((offsetX + x) * scaleX);
-                    int uy = (int)((offsetY + y) * scaleY);
-                    if (ux < 0 || ux >= texture.Width || uy < 0 || uy >= texture.Height)
-                        continue;
-
-                    Rgba32 urban = texture[ux, uy];
-                    if (urban.A == 0)
-                        continue;
-
-                    Rgba32 basePix = row[x];
-                    float a = urban.A / 255f;
-                    byte r = (byte)(basePix.R * (1 - a) + urban.R * a);
-                    byte g = (byte)(basePix.G * (1 - a) + urban.G * a);
-                    byte b = (byte)(basePix.B * (1 - a) + urban.B * a);
-                    row[x] = new Rgba32(r, g, b, 255);
-                }
-            }
-        }
 
         /// <summary>
         /// Generate a terrain tile and overlay country borders.
@@ -292,7 +245,120 @@ namespace StrategyGame
 
             DrawBordersLarge(img, mask);
 
-            OverlayUrban(img, offsetX, offsetY, fullW, fullH);
+            int tileWidth = Math.Min(tileSizePx, fullW - offsetX);
+            int tileHeight = Math.Min(tileSizePx, fullH - offsetY);
+
+            GeoBounds bounds = new GeoBounds
+            {
+                MinLon = -180 + (double)offsetX / fullW * 360.0,
+                MaxLon = -180 + (double)(offsetX + tileWidth) / fullW * 360.0,
+                MaxLat = 90 - (double)offsetY / fullH * 180.0,
+                MinLat = 90 - (double)(offsetY + tileHeight) / fullH * 180.0
+            };
+            var factory = NetTopologySuite.Geometries.GeometryFactory.Default;
+            var tilePoly = factory.CreatePolygon(new[]
+            {
+                new NetTopologySuite.Geometries.Coordinate(bounds.MinLon, bounds.MinLat),
+                new NetTopologySuite.Geometries.Coordinate(bounds.MaxLon, bounds.MinLat),
+                new NetTopologySuite.Geometries.Coordinate(bounds.MaxLon, bounds.MaxLat),
+                new NetTopologySuite.Geometries.Coordinate(bounds.MinLon, bounds.MaxLat),
+                new NetTopologySuite.Geometries.Coordinate(bounds.MinLon, bounds.MinLat)
+            });
+
+            var roadColor = new Rgba32(50, 50, 50, 255);
+            var fillColor = new Rgba32(100, 100, 100, 80);
+
+            foreach (var urban in UrbanAreaManager.UrbanPolygons)
+            {
+                if (!urban.EnvelopeInternal.Intersects(tilePoly.EnvelopeInternal))
+                    continue;
+                if (!urban.Intersects(tilePoly))
+                    continue;
+
+                var network = RoadNetworkGenerator.GetOrGenerateFor(urban, cellSize);
+                if (network.Count == 0)
+                {
+                    var visibleFill = urban.Intersection(tilePoly);
+                    if (visibleFill != null && !visibleFill.IsEmpty)
+                    {
+                        long totalR = 0, totalG = 0, totalB = 0; int samples = 0;
+                        var rng = new Random();
+                        var vb = visibleFill.EnvelopeInternal;
+
+                        for (int i = 0; i < 50; i++)
+                        {
+                            double lon = vb.MinX + rng.NextDouble() * vb.Width;
+                            double lat = vb.MinY + rng.NextDouble() * vb.Height;
+                            var pt = factory.CreatePoint(new NetTopologySuite.Geometries.Coordinate(lon, lat));
+                            if (!visibleFill.Contains(pt))
+                                continue;
+
+                            int px = (int)((lon - bounds.MinLon) / (bounds.MaxLon - bounds.MinLon) * tileWidth);
+                            int py = (int)((bounds.MaxLat - lat) / (bounds.MaxLat - bounds.MinLat) * tileHeight);
+
+                            if (px < 0 || py < 0 || px >= img.Width || py >= img.Height)
+                                continue;
+
+                            var col = img[px, py];
+                            totalR += col.R; totalG += col.G; totalB += col.B;
+                            samples++;
+                        }
+
+                        Rgba32 adaptive = fillColor;
+                        if (samples > 0)
+                        {
+                            byte r = (byte)Math.Clamp(totalR / samples * 0.7, 0, 255);
+                            byte g = (byte)Math.Clamp(totalG / samples * 0.7, 0, 255);
+                            byte b = (byte)Math.Clamp(totalB / samples * 0.7, 0, 255);
+                            adaptive = new Rgba32(r, g, b, 150);
+                        }
+
+                        if (visibleFill is NetTopologySuite.Geometries.Polygon p)
+                        {
+                            RenderPolygon(img, p, bounds, tileWidth, tileHeight, adaptive);
+                        }
+                        else if (visibleFill is NetTopologySuite.Geometries.MultiPolygon mpFill)
+                        {
+                            for (int i = 0; i < mpFill.NumGeometries; i++)
+                            {
+                                if (mpFill.GetGeometryN(i) is NetTopologySuite.Geometries.Polygon pp)
+                                    RenderPolygon(img, pp, bounds, tileWidth, tileHeight, adaptive);
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    foreach (var road in network)
+                    {
+                        double x1 = road.X1, y1 = road.Y1, x2 = road.X2, y2 = road.Y2;
+                        if (!GeometryUtil.ClipLine(bounds, ref x1, ref y1, ref x2, ref y2))
+                            continue;
+                        int px1 = (int)((x1 - bounds.MinLon) / (bounds.MaxLon - bounds.MinLon) * tileWidth);
+                        int py1 = (int)((bounds.MaxLat - y1) / (bounds.MaxLat - bounds.MinLat) * tileHeight);
+                        int px2 = (int)((x2 - bounds.MinLon) / (bounds.MaxLon - bounds.MinLon) * tileWidth);
+                        int py2 = (int)((bounds.MaxLat - y2) / (bounds.MaxLat - bounds.MinLat) * tileHeight);
+                        DrawLine(img, px1, py1, px2, py2, roadColor);
+                    }
+
+                    var visible = urban.Intersection(tilePoly);
+                    if (visible != null && !visible.IsEmpty)
+                    {
+                        if (visible is NetTopologySuite.Geometries.Polygon p)
+                        {
+                            RenderPolygon(img, p, bounds, tileWidth, tileHeight, fillColor);
+                        }
+                        else if (visible is NetTopologySuite.Geometries.MultiPolygon mp)
+                        {
+                            for (int i = 0; i < mp.NumGeometries; i++)
+                            {
+                                if (mp.GetGeometryN(i) is NetTopologySuite.Geometries.Polygon pp)
+                                    RenderPolygon(img, pp, bounds, tileWidth, tileHeight, fillColor);
+                            }
+                        }
+                    }
+                }
+            }
 
             return img;
         }
@@ -466,6 +532,69 @@ namespace StrategyGame
                 if (e2 >= dy) { err += dy; x0 += sx; }
                 if (e2 <= dx) { err += dx; y0 += sy; }
             }
+        }
+
+        private static void FillPolygon(
+            SixLabors.ImageSharp.Image<SixLabors.ImageSharp.PixelFormats.Rgba32> img,
+            List<(int X, int Y)> points,
+            SixLabors.ImageSharp.PixelFormats.Rgba32 color)
+        {
+            if (points.Count < 3) return;
+            int minY = int.MaxValue, maxY = int.MinValue;
+            foreach (var p in points)
+            {
+                if (p.Y < minY) minY = p.Y;
+                if (p.Y > maxY) maxY = p.Y;
+            }
+            for (int y = minY; y <= maxY; y++)
+            {
+                List<int> nodeX = new();
+                for (int i = 0, j = points.Count - 1; i < points.Count; j = i++)
+                {
+                    var pi = points[i];
+                    var pj = points[j];
+                    if ((pi.Y < y && pj.Y >= y) || (pj.Y < y && pi.Y >= y))
+                    {
+                        int x = (int)(pi.X + (double)(y - pi.Y) / (pj.Y - pi.Y) * (pj.X - pi.X));
+                        nodeX.Add(x);
+                    }
+                }
+                nodeX.Sort();
+                for (int k = 0; k < nodeX.Count - 1; k += 2)
+                {
+                    int start = nodeX[k];
+                    int end = nodeX[k + 1];
+                    for (int x = start; x <= end; x++)
+                    {
+                        if (x < 0 || x >= img.Width || y < 0 || y >= img.Height) continue;
+                        var basePix = img[x, y];
+                        float a = color.A / 255f;
+                        byte r = (byte)(basePix.R * (1 - a) + color.R * a);
+                        byte g = (byte)(basePix.G * (1 - a) + color.G * a);
+                        byte b = (byte)(basePix.B * (1 - a) + color.B * a);
+                        img[x, y] = new Rgba32(r, g, b, 255);
+                    }
+                }
+            }
+        }
+
+        private static void RenderPolygon(
+            SixLabors.ImageSharp.Image<SixLabors.ImageSharp.PixelFormats.Rgba32> img,
+            NetTopologySuite.Geometries.Polygon poly,
+            GeoBounds bounds,
+            int tileWidth,
+            int tileHeight,
+            SixLabors.ImageSharp.PixelFormats.Rgba32 color)
+        {
+            var coords = poly.ExteriorRing.Coordinates;
+            var pts = new List<(int X, int Y)>(coords.Length);
+            foreach (var c in coords)
+            {
+                int px = (int)((c.X - bounds.MinLon) / (bounds.MaxLon - bounds.MinLon) * tileWidth);
+                int py = (int)((bounds.MaxLat - c.Y) / (bounds.MaxLat - bounds.MinLat) * tileHeight);
+                pts.Add((px, py));
+            }
+            FillPolygon(img, pts, color);
         }
 
         /// <summary>

--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -1,5 +1,6 @@
 using NetTopologySuite.Geometries;
 using System.Collections.Generic;
+using System;
 
 namespace StrategyGame
 {
@@ -18,7 +19,7 @@ namespace StrategyGame
 
             var env = urbanArea.EnvelopeInternal;
             double diagonal = System.Math.Sqrt(env.Width * env.Width + env.Height * env.Height);
-            int divisions = (int)System.Math.Max(5, diagonal * 400.0);
+            int divisions = System.Math.Clamp((int)(diagonal * 40.0), 5, 100);
 
             double stepX = env.Width / divisions;
             double stepY = env.Height / divisions;

--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -1,0 +1,86 @@
+using NetTopologySuite.Geometries;
+using System.Collections.Generic;
+
+namespace StrategyGame
+{
+    public static class RoadNetworkGenerator
+    {
+        private static Dictionary<Polygon, List<LineSegment>> networkCache = new();
+
+        public static List<LineSegment> GetOrGenerateFor(Polygon urbanArea, int cellSize)
+        {
+            // Low zoom levels use a simple fill instead of detailed roads
+            if (cellSize < 40)
+                return new List<LineSegment>();
+
+            if (networkCache.TryGetValue(urbanArea, out var cached))
+                return cached;
+
+            var env = urbanArea.EnvelopeInternal;
+            double diagonal = System.Math.Sqrt(env.Width * env.Width + env.Height * env.Height);
+            int divisions = (int)System.Math.Max(5, diagonal * 400.0);
+
+            double stepX = env.Width / divisions;
+            double stepY = env.Height / divisions;
+
+            var gridLines = new List<LineSegment>();
+            for (int i = 0; i <= divisions; i++)
+            {
+                double x = env.MinX + i * stepX;
+                gridLines.Add(new LineSegment(x, env.MinY, x, env.MaxY));
+            }
+            for (int j = 0; j <= divisions; j++)
+            {
+                double y = env.MinY + j * stepY;
+                gridLines.Add(new LineSegment(env.MinX, y, env.MaxX, y));
+            }
+
+            var clippedNetwork = new List<LineSegment>();
+            var factory = GeometryFactory.Default;
+
+            foreach (var line in gridLines)
+            {
+                var lineString = factory.CreateLineString(new[]
+                {
+                    new Coordinate(line.X1, line.Y1),
+                    new Coordinate(line.X2, line.Y2)
+                });
+
+                if (!urbanArea.Intersects(lineString))
+                    continue;
+
+                var intersection = urbanArea.Intersection(lineString);
+
+                if (intersection is LineString ls)
+                {
+                    var coords = ls.Coordinates;
+                    for (int c = 0; c < coords.Length - 1; c++)
+                    {
+                        clippedNetwork.Add(new LineSegment(
+                            coords[c].X, coords[c].Y,
+                            coords[c + 1].X, coords[c + 1].Y));
+                    }
+                }
+                else if (intersection is MultiLineString mls)
+                {
+                    foreach (var geom in mls.Geometries)
+                    {
+                        if (geom is LineString subLs)
+                        {
+                            var coords = subLs.Coordinates;
+                            for (int c = 0; c < coords.Length - 1; c++)
+                            {
+                                clippedNetwork.Add(new LineSegment(
+                                    coords[c].X, coords[c].Y,
+                                    coords[c + 1].X, coords[c + 1].Y));
+                            }
+                        }
+                    }
+                }
+            }
+
+            networkCache[urbanArea] = clippedNetwork;
+            return clippedNetwork;
+        }
+    }
+}

--- a/UrbanAreaManager.cs
+++ b/UrbanAreaManager.cs
@@ -1,0 +1,119 @@
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using System.IO;
+
+namespace StrategyGame
+{
+    public static class UrbanAreaManager
+    {
+        public static List<Polygon> UrbanPolygons { get; private set; } = new();
+
+        private static readonly string RepoRoot =
+            Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "..", "..", ".."));
+        private static readonly string DataDir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+            "data");
+        private static readonly string RepoDataDir = Path.Combine(RepoRoot, "data");
+        private static readonly string DataFileList = Path.Combine(RepoRoot, "DataFileNames");
+        private static readonly Dictionary<string, string> DataFiles = LoadDataFiles();
+
+        public static void LoadUrbanAreas()
+        {
+            UrbanPolygons.Clear();
+            string shp = GetDataFile("ne_10m_urban_areas.shp");
+            if (!File.Exists(shp))
+                return;
+
+            var reader = new ShapefileDataReader(shp, GeometryFactory.Default);
+            while (reader.Read())
+            {
+                var geom = reader.Geometry;
+                if (geom is MultiPolygon mp)
+                {
+                    for (int i = 0; i < mp.NumGeometries; i++)
+                    {
+                        if (mp.GetGeometryN(i) is Polygon p)
+                            UrbanPolygons.Add(p);
+                    }
+                }
+                else if (geom is Polygon p)
+                {
+                    UrbanPolygons.Add(p);
+                }
+            }
+        }
+
+        public static void PrecomputeAllRoadNetworks()
+        {
+            Debug.WriteLine("Starting background pre-computation of all urban road networks...");
+            var sw = Stopwatch.StartNew();
+
+            Parallel.ForEach(UrbanPolygons, urbanArea =>
+            {
+                RoadNetworkGenerator.GetOrGenerateFor(urbanArea, 40);
+            });
+
+            sw.Stop();
+            Debug.WriteLine($"Finished pre-computing all road networks in {sw.Elapsed.TotalSeconds:F2} seconds.");
+        }
+
+        private static string GetDataFile(string name)
+        {
+            if (DataFiles.TryGetValue(name, out var mapped) && File.Exists(mapped))
+                return mapped;
+
+            string userPath = Path.Combine(DataDir, name);
+            if (File.Exists(userPath))
+                return userPath;
+
+            if (Directory.Exists(DataDir))
+            {
+                var matches = Directory.GetFiles(DataDir, name, SearchOption.AllDirectories);
+                if (matches.Length > 0)
+                    return matches[0];
+            }
+
+            string repoPath = Path.Combine(RepoDataDir, name);
+            if (File.Exists(repoPath))
+                return repoPath;
+
+            if (Directory.Exists(RepoDataDir))
+            {
+                var matches = Directory.GetFiles(RepoDataDir, name, SearchOption.AllDirectories);
+                if (matches.Length > 0)
+                    return matches[0];
+            }
+
+            return userPath;
+        }
+
+        private static Dictionary<string, string> LoadDataFiles()
+        {
+            var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (File.Exists(DataFileList))
+            {
+                foreach (var line in File.ReadAllLines(DataFileList))
+                {
+                    var trimmed = line.Trim();
+                    if (string.IsNullOrEmpty(trimmed) || trimmed.StartsWith("#") || trimmed.StartsWith("files"))
+                        continue;
+
+                    string userPath = Path.Combine(DataDir, trimmed);
+                    if (File.Exists(userPath))
+                    {
+                        dict[trimmed] = userPath;
+                    }
+                    else
+                    {
+                        dict[trimmed] = Path.Combine(RepoDataDir, trimmed);
+                    }
+                }
+            }
+            return dict;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- darken sampled terrain colors for a natural urban fill at low zoom
- precompute road networks on a background thread during initialization

## Testing
- `dotnet restore` *(fails: `dotnet` not found)*
- `dotnet build "economy sim.sln" -v minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864ea2447408323a4c3e1081af37b33