### PR TITLE
Fix compile errors around geometry and drawing

### DIFF
--- a/MainGame.cs
+++ b/MainGame.cs
@@ -210,7 +210,7 @@ namespace economy_sim
                 });
             }
 
-            pictureBox1.SD.Size = panelMap.ClientSize;
+            pictureBox1.Size = panelMap.ClientSize;
             pictureBox1.Location = new SD.Point(0, 0);
         }
 
@@ -460,8 +460,8 @@ namespace economy_sim
             SD.Bitmap dest = new SD.Bitmap(width, height);
             using (var g = SD.Graphics.FromImage(dest))
             {
-                g.InterpolationMode = InterpolationMode.NearestNeighbor;
-                g.PixelOffsetMode = PixelOffsetMode.Half;
+                g.InterpolationMode = SDD.InterpolationMode.NearestNeighbor;
+                g.PixelOffsetMode = SDD.PixelOffsetMode.Half;
                 g.DrawImage(src, 0, 0, width, height);
             }
             return dest;
@@ -1576,9 +1576,9 @@ namespace economy_sim
             TextFormatFlags flags = TextFormatFlags.Left | TextFormatFlags.NoPadding; // Removed VerticalCenter
 
             // Draw main text part
-            SD.Size mainTextSize = TextRenderer.MeasureText(e.SD.Graphics, mainTextPart, itemFont, itemDrawBounds.SD.Size, flags);
+            SD.Size mainTextSize = TextRenderer.MeasureText(e.Graphics, mainTextPart, itemFont, itemDrawBounds.Size, flags);
             SD.Rectangle mainTextRect = new SD.Rectangle(itemDrawBounds.Left, itemDrawBounds.Top, mainTextSize.Width, itemDrawBounds.Height);
-            TextRenderer.DrawText(e.SD.Graphics, mainTextPart, itemFont, mainTextRect, defaultTextColor, flags);
+            TextRenderer.DrawText(e.Graphics, mainTextPart, itemFont, mainTextRect, defaultTextColor, flags);
 
             if (!string.IsNullOrEmpty(changeTextWithSpaceAndParens))
             {
@@ -1588,9 +1588,9 @@ namespace economy_sim
                 else if (contentInsideParens.Contains("-"))
                     changeColor = SD.Color.Red;
 
-                SD.Size changeTextSize = TextRenderer.MeasureText(e.SD.Graphics, changeTextWithSpaceAndParens, itemFont, itemDrawBounds.SD.Size, flags);
+                SD.Size changeTextSize = TextRenderer.MeasureText(e.Graphics, changeTextWithSpaceAndParens, itemFont, itemDrawBounds.Size, flags);
                 SD.Rectangle changeTextRect = new SD.Rectangle(itemDrawBounds.Left + mainTextSize.Width, itemDrawBounds.Top, changeTextSize.Width, itemDrawBounds.Height);
-                TextRenderer.DrawText(e.SD.Graphics, changeTextWithSpaceAndParens, itemFont, changeTextRect, changeColor, flags);
+                TextRenderer.DrawText(e.Graphics, changeTextWithSpaceAndParens, itemFont, changeTextRect, changeColor, flags);
             }
 
             // Draw focus rectangle if the item has focus

--- a/ParcelGenerator.cs
+++ b/ParcelGenerator.cs
@@ -45,8 +45,8 @@ namespace StrategyGame
             if (vertical)
             {
                 double midX = (env.MinX + env.MaxX) / 2.0;
-                var leftRect = gf.ToGeometry(new Envelope(env.MinX, midX, env.MinY, env.MaxY));
-                var rightRect = gf.ToGeometry(new Envelope(midX, env.MaxX, env.MinY, env.MaxY));
+                var leftRect = gf.ToGeometry(new Nts.Envelope(env.MinX, midX, env.MinY, env.MaxY));
+                var rightRect = gf.ToGeometry(new Nts.Envelope(midX, env.MaxX, env.MinY, env.MaxY));
                 var left = poly.Intersection(leftRect);
                 var right = poly.Intersection(rightRect);
                 if (left is Nts.Polygon lp)
@@ -57,8 +57,8 @@ namespace StrategyGame
             else
             {
                 double midY = (env.MinY + env.MaxY) / 2.0;
-                var botRect = gf.ToGeometry(new Envelope(env.MinX, env.MaxX, env.MinY, midY));
-                var topRect = gf.ToGeometry(new Envelope(env.MinX, env.MaxX, midY, env.MaxY));
+                var botRect = gf.ToGeometry(new Nts.Envelope(env.MinX, env.MaxX, env.MinY, midY));
+                var topRect = gf.ToGeometry(new Nts.Envelope(env.MinX, env.MaxX, midY, env.MaxY));
                 var bot = poly.Intersection(botRect);
                 var top = poly.Intersection(topRect);
                 if (bot is Nts.Polygon bp)

--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -65,7 +65,7 @@ namespace StrategyGame
                             coords[c + 1].X, coords[c + 1].Y));
                     }
                 }
-                else if (intersection is MultiLineString mls)
+                else if (intersection is Nts.MultiLineString mls)
                 {
                     foreach (var geom in mls.Geometries)
                     {


### PR DESCRIPTION
## Summary
- qualify MultiLineString usage to NetTopologySuite alias
- use Nts.Envelope when subdividing parcels
- fix Windows Forms alias usage in MainGame
- reference Drawing2D enums with alias

## Testing
- `dotnet build "economy sim.sln" -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865264724148323849c1302ea4236a2