### PR TITLE
Accelerated city generator

### DIFF
--- a/BuildingGenerator.cs
+++ b/BuildingGenerator.cs
@@ -28,7 +28,7 @@ namespace StrategyGame
                         foot = gf.ToGeometry(temp.EnvelopeInternal);
                         break;
                     case LandUseType.Park:
-                        continue;
+                        return;
                 }
 
                 if (foot is Nts.Polygon p && !foot.IsEmpty)

--- a/CostGridShader.cs
+++ b/CostGridShader.cs
@@ -2,12 +2,21 @@ using ComputeSharp;
 
 namespace StrategyGame
 {
-    [AutoConstructor]
+    [ThreadGroupSize(8, 8, 1)]
     internal readonly partial struct CostGridShader : IComputeShader
     {
         public readonly ReadOnlyTexture2D<float> elevation;
         public readonly ReadOnlyTexture2D<float> water;
         public readonly ReadWriteTexture2D<float> cost;
+
+        public CostGridShader(ReadOnlyTexture2D<float> elevation,
+                               ReadOnlyTexture2D<float> water,
+                               ReadWriteTexture2D<float> cost)
+        {
+            this.elevation = elevation;
+            this.water = water;
+            this.cost = cost;
+        }
 
         public void Execute()
         {

--- a/CostGridShader.cs
+++ b/CostGridShader.cs
@@ -2,22 +2,13 @@ using ComputeSharp;
 
 namespace StrategyGame
 {
+    [AutoConstructor]
     [ThreadGroupSize(8, 8, 1)]
     internal readonly partial struct CostGridShader : IComputeShader
     {
         public readonly ReadOnlyTexture2D<float> elevation;
         public readonly ReadOnlyTexture2D<float> water;
         public readonly ReadWriteTexture2D<float> cost;
-
-        public CostGridShader(
-            ReadOnlyTexture2D<float> elevation,
-            ReadOnlyTexture2D<float> water,
-            ReadWriteTexture2D<float> cost)
-        {
-            this.elevation = elevation;
-            this.water = water;
-            this.cost = cost;
-        }
 
         public void Execute()
         {

--- a/CostGridShader.cs
+++ b/CostGridShader.cs
@@ -1,0 +1,34 @@
+using ComputeSharp;
+
+namespace StrategyGame
+{
+    [AutoConstructor]
+    internal readonly partial struct CostGridShader : IComputeShader
+    {
+        public readonly ReadOnlyTexture2D<float> elevation;
+        public readonly ReadOnlyTexture2D<float> water;
+        public readonly ReadWriteTexture2D<float> cost;
+
+        public void Execute()
+        {
+            int x = ThreadIds.X;
+            int y = ThreadIds.Y;
+            float eCenter = elevation[x, y];
+            float slope = 0f;
+            for (int oy = -1; oy <= 1; oy++)
+            {
+                for (int ox = -1; ox <= 1; ox++)
+                {
+                    if (ox == 0 && oy == 0) continue;
+                    int nx = Hlsl.Clamp(x + ox, 0, elevation.Width - 1);
+                    int ny = Hlsl.Clamp(y + oy, 0, elevation.Height - 1);
+                    float e = elevation[nx, ny];
+                    slope += Hlsl.Abs(e - eCenter);
+                }
+            }
+            slope /= 8f;
+            float waterCost = water[x, y];
+            cost[x, y] = slope * 50f + waterCost * 1000f;
+        }
+    }
+}

--- a/CostGridShader.cs
+++ b/CostGridShader.cs
@@ -2,13 +2,19 @@ using ComputeSharp;
 
 namespace StrategyGame
 {
-    [AutoConstructor]
     [ThreadGroupSize(8, 8, 1)]
     internal readonly partial struct CostGridShader : IComputeShader
     {
         public readonly ReadOnlyTexture2D<float> elevation;
         public readonly ReadOnlyTexture2D<float> water;
         public readonly ReadWriteTexture2D<float> cost;
+
+        public CostGridShader(ReadOnlyTexture2D<float> elevation, ReadOnlyTexture2D<float> water, ReadWriteTexture2D<float> cost)
+        {
+            this.elevation = elevation;
+            this.water = water;
+            this.cost = cost;
+        }
 
         public void Execute()
         {

--- a/CostGridShader.cs
+++ b/CostGridShader.cs
@@ -2,13 +2,22 @@ using ComputeSharp;
 
 namespace StrategyGame
 {
-    [AutoConstructor]
     [ThreadGroupSize(8, 8, 1)]
     internal readonly partial struct CostGridShader : IComputeShader
     {
         public readonly ReadOnlyTexture2D<float> elevation;
         public readonly ReadOnlyTexture2D<float> water;
         public readonly ReadWriteTexture2D<float> cost;
+
+        public CostGridShader(
+            ReadOnlyTexture2D<float> elevation,
+            ReadOnlyTexture2D<float> water,
+            ReadWriteTexture2D<float> cost)
+        {
+            this.elevation = elevation;
+            this.water = water;
+            this.cost = cost;
+        }
 
         public void Execute()
         {

--- a/CostGridShader.cs
+++ b/CostGridShader.cs
@@ -2,21 +2,13 @@ using ComputeSharp;
 
 namespace StrategyGame
 {
+    [AutoConstructor]
     [ThreadGroupSize(8, 8, 1)]
     internal readonly partial struct CostGridShader : IComputeShader
     {
         public readonly ReadOnlyTexture2D<float> elevation;
         public readonly ReadOnlyTexture2D<float> water;
         public readonly ReadWriteTexture2D<float> cost;
-
-        public CostGridShader(ReadOnlyTexture2D<float> elevation,
-                               ReadOnlyTexture2D<float> water,
-                               ReadWriteTexture2D<float> cost)
-        {
-            this.elevation = elevation;
-            this.water = water;
-            this.cost = cost;
-        }
 
         public void Execute()
         {

--- a/CostGridShader.hlsl
+++ b/CostGridShader.hlsl
@@ -1,0 +1,27 @@
+// HLSL equivalent of CostGridShader
+
+Texture2D<float> elevation : register(t0);
+Texture2D<float> water : register(t1);
+RWTexture2D<float> cost : register(u0);
+
+[numthreads(8,8,1)]
+void main(uint3 id : SV_DispatchThreadID)
+{
+    float eCenter = elevation[id.xy];
+    float slope = 0.0;
+    [unroll]
+    for(int oy = -1; oy <= 1; oy++)
+    {
+        [unroll]
+        for(int ox = -1; ox <= 1; ox++)
+        {
+            if(ox == 0 && oy == 0) continue;
+            int2 n = clamp(int2(id.x + ox, id.y + oy), int2(0,0), int2(elevation.GetDimensions() - 1));
+            float e = elevation[n];
+            slope += abs(e - eCenter);
+        }
+    }
+    slope /= 8.0;
+    float waterCost = water[id.xy];
+    cost[id.xy] = slope * 50.0 + waterCost * 1000.0;
+}

--- a/ParcelGenerator.cs
+++ b/ParcelGenerator.cs
@@ -66,7 +66,7 @@ namespace StrategyGame
             return parcelsBag.ToList();
         }
 
-        private static void RecursiveOBBSplitting(Nts.Polygon poly, ICollection<Parcel> output, int depth)
+        private static void RecursiveOBBSplitting(Nts.Polygon poly, ConcurrentBag<Parcel> output, int depth)
         {
             const double MinArea = 0.00005;
             const int MaxDepth = 4;

--- a/ParcelGenerator.cs
+++ b/ParcelGenerator.cs
@@ -32,7 +32,7 @@ namespace StrategyGame
 
             if (lineStrings.Length == 0)
             {
-                return parcels;
+                return parcelsBag.ToList();
             }
 
             var nodedLines = (Nts.MultiLineString)lineStrings.First().Union(lineStrings.Skip(1).First());

--- a/economy sim.csproj
+++ b/economy sim.csproj
@@ -88,6 +88,7 @@
 		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
                 <PackageReference Include="System.ValueTuple" Version="4.5.0" />
                 <PackageReference Include="SixLabors.ImageSharp" Version="3.1.10" />
+                <PackageReference Include="ComputeSharp" Version="2.2.4" />
                 <None Include="world_setup.json">
                         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
                 </None>


### PR DESCRIPTION
## Summary
- add ComputeSharp compute shader for GPU cost grid
- integrate GPU-accelerated A* into road generation
- speed up local road checks using `STRtree`
- parallelize parcel, land use, and building generation
- include ComputeSharp in project

## Testing
- `dotnet build "economy sim.sln" -v minimal` *(fails: Could not resolve SDK 'Microsoft.NET.Sdk.WindowsDesktop')*

------
https://chatgpt.com/codex/tasks/task_e_68663ed573fc8323b1b8a78bd69a61c4