### PR TITLE
Add AutoConstructor attribute to CostGridShader

### DIFF
--- a/CostGridShader.cs
+++ b/CostGridShader.cs
@@ -2,6 +2,7 @@ using ComputeSharp;
 
 namespace StrategyGame
 {
+    [AutoConstructor]
     [ThreadGroupSize(8, 8, 1)]
     internal readonly partial struct CostGridShader : IComputeShader
     {


### PR DESCRIPTION
## Summary
- mark `CostGridShader` with `[AutoConstructor]` so ComputeSharp generates descriptors

## Testing
- `dotnet build "economy sim.sln" -v minimal -p:EnableWindowsTargeting=true` *(fails: AutoConstructor attribute not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866658ae13083239914bfa247fe10ad