### PR TITLE
Fix compute shader descriptor and bag type

### DIFF
--- a/CostGridShader.cs
+++ b/CostGridShader.cs
@@ -2,22 +2,13 @@ using ComputeSharp;
 
 namespace StrategyGame
 {
+    [AutoConstructor]
     [ThreadGroupSize(8, 8, 1)]
     internal readonly partial struct CostGridShader : IComputeShader
     {
         public readonly ReadOnlyTexture2D<float> elevation;
         public readonly ReadOnlyTexture2D<float> water;
         public readonly ReadWriteTexture2D<float> cost;
-
-        public CostGridShader(
-            ReadOnlyTexture2D<float> elevation,
-            ReadOnlyTexture2D<float> water,
-            ReadWriteTexture2D<float> cost)
-        {
-            this.elevation = elevation;
-            this.water = water;
-            this.cost = cost;
-        }
 
         public void Execute()
         {

--- a/ParcelGenerator.cs
+++ b/ParcelGenerator.cs
@@ -66,7 +66,7 @@ namespace StrategyGame
             return parcelsBag.ToList();
         }
 
-        private static void RecursiveOBBSplitting(Nts.Polygon poly, ICollection<Parcel> output, int depth)
+        private static void RecursiveOBBSplitting(Nts.Polygon poly, ConcurrentBag<Parcel> output, int depth)
         {
             const double MinArea = 0.00005;
             const int MaxDepth = 4;


### PR DESCRIPTION
## Summary
- add `AutoConstructor` to `CostGridShader` so `GraphicsDevice.For` can use it
- use `ConcurrentBag<Parcel>` in `ParcelGenerator`

## Testing
- `dotnet build "economy sim.sln" -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68666a81362883239c113616d8fdd907