### PR TITLE
Fix CostGridShader construction without ComputeSharp source generator

### DIFF
--- a/CostGridShader.cs
+++ b/CostGridShader.cs
@@ -2,13 +2,19 @@ using ComputeSharp;
 
 namespace StrategyGame
 {
-    [AutoConstructor]
     [ThreadGroupSize(8, 8, 1)]
     internal readonly partial struct CostGridShader : IComputeShader
     {
         public readonly ReadOnlyTexture2D<float> elevation;
         public readonly ReadOnlyTexture2D<float> water;
         public readonly ReadWriteTexture2D<float> cost;
+
+        public CostGridShader(ReadOnlyTexture2D<float> elevation, ReadOnlyTexture2D<float> water, ReadWriteTexture2D<float> cost)
+        {
+            this.elevation = elevation;
+            this.water = water;
+            this.cost = cost;
+        }
 
         public void Execute()
         {


### PR DESCRIPTION
## Summary
- remove `AutoConstructor` attribute from `CostGridShader`
- add explicit constructor for its textures

## Testing
- `dotnet build "economy sim.sln" -v minimal` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68666deb30c88323894a5a5f6af81288