### PR TITLE
Performance improvements with GPU compute and parallelism

### DIFF
--- a/BuildingGenerator.cs
+++ b/BuildingGenerator.cs
@@ -27,7 +27,7 @@ namespace StrategyGame
                         foot = gf.ToGeometry(temp.EnvelopeInternal);
                         break;
                     case LandUseType.Park:
-                        continue;
+                        return;
                 }
 
                 if (foot is Nts.Polygon p && !foot.IsEmpty)

--- a/BuildingGenerator.cs
+++ b/BuildingGenerator.cs
@@ -1,6 +1,7 @@
 using Nts = NetTopologySuite.Geometries;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace StrategyGame

--- a/CostGridShader.cs
+++ b/CostGridShader.cs
@@ -1,0 +1,37 @@
+using ComputeSharp;
+using ComputeSharp; // for attributes
+
+namespace StrategyGame
+{
+    [AutoConstructor]
+    public readonly partial struct CostGridShader : IComputeShader
+    {
+        public readonly ReadOnlyTexture2D<float> elevation;
+        public readonly ReadOnlyTexture2D<float> water;
+        public readonly ReadWriteTexture2D<float> cost;
+
+        public void Execute()
+        {
+            int x = ThreadIds.X;
+            int y = ThreadIds.Y;
+            float elev = elevation[x, y];
+            float waterValue = water[x, y];
+            float slope = 0f;
+            int width = elevation.Width;
+            int height = elevation.Height;
+            for (int oy = -1; oy <= 1; oy++)
+            {
+                for (int ox = -1; ox <= 1; ox++)
+                {
+                    if (ox == 0 && oy == 0) continue;
+                    int nx = Hlsl.Clamp(x + ox, 0, width - 1);
+                    int ny = Hlsl.Clamp(y + oy, 0, height - 1);
+                    slope += Hlsl.Abs(elevation[nx, ny] - elev);
+                }
+            }
+            slope /= 8f;
+            float costVal = slope * 50f + waterValue * 1000f;
+            cost[x, y] = costVal;
+        }
+    }
+}

--- a/CostGridShader.cs
+++ b/CostGridShader.cs
@@ -1,13 +1,21 @@
 using ComputeSharp;
+using System;
 
 namespace StrategyGame
 {
-    [AutoConstructor]
+    [ThreadGroupSize(16, 16, 1)]
     public readonly partial struct CostGridShader : IComputeShader
     {
         public readonly ReadOnlyTexture2D<float> elevation;
         public readonly ReadOnlyTexture2D<float> water;
         public readonly ReadWriteTexture2D<float> cost;
+
+        public CostGridShader(ReadOnlyTexture2D<float> elevation, ReadOnlyTexture2D<float> water, ReadWriteTexture2D<float> cost)
+        {
+            this.elevation = elevation;
+            this.water = water;
+            this.cost = cost;
+        }
 
         public void Execute()
         {

--- a/CostGridShader.cs
+++ b/CostGridShader.cs
@@ -1,5 +1,4 @@
 using ComputeSharp;
-using ComputeSharp; // for attributes
 
 namespace StrategyGame
 {

--- a/CostGridShader.cs
+++ b/CostGridShader.cs
@@ -1,21 +1,14 @@
 using ComputeSharp;
-using System;
 
 namespace StrategyGame
 {
+    [AutoConstructor]
     [ThreadGroupSize(16, 16, 1)]
     public readonly partial struct CostGridShader : IComputeShader
     {
         public readonly ReadOnlyTexture2D<float> elevation;
         public readonly ReadOnlyTexture2D<float> water;
         public readonly ReadWriteTexture2D<float> cost;
-
-        public CostGridShader(ReadOnlyTexture2D<float> elevation, ReadOnlyTexture2D<float> water, ReadWriteTexture2D<float> cost)
-        {
-            this.elevation = elevation;
-            this.water = water;
-            this.cost = cost;
-        }
 
         public void Execute()
         {

--- a/CostGridShader.hlsl
+++ b/CostGridShader.hlsl
@@ -1,0 +1,31 @@
+Texture2D<float> elevationTex : register(t0);
+Texture2D<float> waterTex : register(t1);
+RWTexture2D<float> costTex : register(u0);
+
+static const int2 Offsets[8] = {
+    int2(-1,-1), int2(0,-1), int2(1,-1),
+    int2(-1,0),               int2(1,0),
+    int2(-1,1),  int2(0,1),  int2(1,1)
+};
+
+[numthreads(16,16,1)]
+void main(uint3 id : SV_DispatchThreadID)
+{
+    uint2 coord = id.xy;
+    float elev = elevationTex[coord];
+    float water = waterTex[coord];
+    float slope = 0.0f;
+    int2 size;
+    elevationTex.GetDimensions(size.x, size.y);
+
+    for (int i = 0; i < 8; ++i)
+    {
+        int2 n = coord + Offsets[i];
+        n = clamp(n, int2(0,0), size - 1);
+        float neigh = elevationTex[n];
+        slope += abs(neigh - elev);
+    }
+    slope /= 8.0f;
+    float cost = slope * 50.0f + water * 1000.0f;
+    costTex[coord] = cost;
+}

--- a/LandUseAssigner.cs
+++ b/LandUseAssigner.cs
@@ -2,6 +2,7 @@ using Nts = NetTopologySuite.Geometries;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace StrategyGame
 {
@@ -37,7 +38,7 @@ namespace StrategyGame
                 .Select(seg => gf.CreateLineString(new[] { new Nts.Coordinate(seg.X1, seg.Y1), new Nts.Coordinate(seg.X2, seg.Y2) }))
                 .ToList();
 
-            foreach (var parcel in model.Parcels)
+            Parallel.ForEach(model.Parcels, parcel =>
             {
                 var weights = new Dictionary<LandUseType, double>();
                 var parcelCenter = parcel.Shape.Centroid;
@@ -73,7 +74,7 @@ namespace StrategyGame
 
                 // --- Select Land Use ---
                 parcel.LandUse = GetRandomLandUse(weights);
-            }
+            });
         }
 
         private static LandUseType GetRandomLandUse(Dictionary<LandUseType, double> weights)

--- a/ParcelGenerator.cs
+++ b/ParcelGenerator.cs
@@ -32,7 +32,7 @@ namespace StrategyGame
 
             if (lineStrings.Length == 0)
             {
-                return parcels;
+                return new List<Parcel>();
             }
 
             var nodedLines = (Nts.MultiLineString)lineStrings.First().Union(lineStrings.Skip(1).First());

--- a/economy sim.csproj
+++ b/economy sim.csproj
@@ -89,6 +89,7 @@
                 <PackageReference Include="System.ValueTuple" Version="4.5.0" />
                 <PackageReference Include="SixLabors.ImageSharp" Version="3.1.10" />
                 <PackageReference Include="ComputeSharp" Version="2.3.0" />
+                <PackageReference Include="ComputeSharp.SourceGenerators" Version="2.3.0" PrivateAssets="all" />
                 <None Include="world_setup.json">
                         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
                 </None>

--- a/economy sim.csproj
+++ b/economy sim.csproj
@@ -88,6 +88,7 @@
 		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
                 <PackageReference Include="System.ValueTuple" Version="4.5.0" />
                 <PackageReference Include="SixLabors.ImageSharp" Version="3.1.10" />
+                <PackageReference Include="ComputeSharp" Version="2.3.0" />
                 <None Include="world_setup.json">
                         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
                 </None>


### PR DESCRIPTION
## Summary
- speed up road generation with GPU cost grid and STRtree queries
- parallelize parcel, land use, and building generation
- add ComputeSharp shader source and reference

## Testing
- `dotnet build "economy sim.sln" -v minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686671ae34508323a2f9fb0832b77770