### PR TITLE
GPU accelerated rendering with SkiaSharp

### DIFF
--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -238,21 +238,17 @@ namespace StrategyGame
                     }
                     else
                     {
-                        SD.Bitmap tile = null;
                         lock (_cacheLock)
                         {
-                            _tileCache.TryGetValue(key, out tile);
-                            if (tile != null && tile.Width > 0 && tile.Height > 0)
-                                tile = (SD.Bitmap)tile.Clone();
-                            else
-                                tile = null;
+                            if (_tileCache.TryGetValue(key, out var tile) && tile.Width > 0 && tile.Height > 0)
+                            {
+                                tex = SkiaBitmapUtil.ToSKBitmap(tile);
+                                _tileTextures[key] = tex;
+                            }
                         }
 
-                        if (tile != null)
+                        if (tex != null)
                         {
-                            tex = SkiaBitmapUtil.ToSKBitmap(tile);
-                            tile.Dispose();
-                            lock (_textureLock) _tileTextures[key] = tex;
                             canvas.DrawBitmap(tex, rect);
                         }
                         else

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -240,11 +240,18 @@ namespace StrategyGame
                     {
                         SD.Bitmap tile = null;
                         lock (_cacheLock)
+                        {
                             _tileCache.TryGetValue(key, out tile);
+                            if (tile != null && tile.Width > 0 && tile.Height > 0)
+                                tile = (SD.Bitmap)tile.Clone();
+                            else
+                                tile = null;
+                        }
 
-                        if (tile != null && tile.Width > 0 && tile.Height > 0)
+                        if (tile != null)
                         {
                             tex = SkiaBitmapUtil.ToSKBitmap(tile);
+                            tile.Dispose();
                             lock (_textureLock) _tileTextures[key] = tex;
                             canvas.DrawBitmap(tex, rect);
                         }

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -28,8 +28,7 @@ namespace StrategyGame
         {
             try
             {
-                using var ctx = GRContext.CreateGl();
-                GpuAvailable = ctx != null;
+                GpuAvailable = MultiResolutionMapManager.SharedContext != null;
             }
             catch
             {
@@ -208,7 +207,7 @@ namespace StrategyGame
             int cellSize = GetCellSize(zoom);
             int tileSize = MultiResolutionMapManager.TileSizePx;
             var info = new SKImageInfo(viewArea.Width, viewArea.Height);
-            using var context = GpuAvailable ? GRContext.CreateGl() : null;
+            var context = GpuAvailable ? MultiResolutionMapManager.SharedContext : null;
             using var surface = context != null ? SKSurface.Create(context, false, info) : SKSurface.Create(info);
             var canvas = surface.Canvas;
             canvas.Clear(SKColors.Transparent);

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -253,10 +253,13 @@ namespace StrategyGame
                         }
                         else
                         {
+                            var ttx = tx;
+                            var tty = ty;
+                            var tileKey = key;
                             _ = Task.Run(async () =>
                             {
-                                var t = await GetTileAsync(zoom, tx, ty, CancellationToken.None).ConfigureAwait(false);
-                                if (t != null) UploadTileTexture(key, t);
+                                var t = await GetTileAsync(zoom, ttx, tty, CancellationToken.None).ConfigureAwait(false);
+                                if (t != null) UploadTileTexture(tileKey, t);
                                 triggerRefresh?.Invoke();
                             });
                         }

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -18,11 +18,9 @@ namespace StrategyGame
     {
         private readonly int _baseWidth;
         private readonly int _baseHeight;
-        private readonly Dictionary<(int cellSize, int x, int y), SD.Bitmap> _tileCache = new();
-        private readonly Dictionary<(int cellSize, int x, int y), Task<SD.Bitmap>> _inFlight = new();
+        private readonly Dictionary<(int cellSize, int x, int y), SKBitmap> _tileCache = new();
+        private readonly Dictionary<(int cellSize, int x, int y), Task<SKBitmap>> _inFlight = new();
         private readonly object _cacheLock = new();
-        private readonly object _textureLock = new();
-        private readonly Dictionary<(int cellSize, int x, int y), SKBitmap> _tileTextures = new();
         private readonly LinkedList<(int cellSize, int x, int y)> _lruOrder = new();
         private readonly Dictionary<(int cellSize, int x, int y), LinkedListNode<(int cellSize, int x, int y)>> _lruNodes = new();
         private const int MaxCacheSize = 256;
@@ -76,18 +74,6 @@ namespace StrategyGame
             return bmp;
         }
 
-        private void UploadTileTexture((int cellSize, int x, int y) key, SD.Bitmap bmp)
-        {
-            var sw = Stopwatch.StartNew();
-            var sk = SkiaBitmapUtil.ToSKBitmap(bmp);
-            lock (_textureLock)
-            {
-                if (_tileTextures.TryGetValue(key, out var old))
-                    old.Dispose();
-                _tileTextures[key] = sk;
-            }
-            PerformanceTracker.Record("UploadTileTexture", sw.Elapsed);
-        }
 
         private void TouchKey((int cellSize, int x, int y) key)
         {
@@ -103,7 +89,7 @@ namespace StrategyGame
             PerformanceTracker.Record("LRU-TouchKey", sw.Elapsed);
         }
 
-        private void AddToCache((int cellSize, int x, int y) key, SD.Bitmap bmp)
+        private void AddToCache((int cellSize, int x, int y) key, SKBitmap bmp)
         {
             var sw = Stopwatch.StartNew();
             lock (_cacheLock)
@@ -126,14 +112,6 @@ namespace StrategyGame
                         oldBmp.Dispose();
                     _tileCache.Remove(remKey);
                     _lruNodes.Remove(remKey);
-                    lock (_textureLock)
-                    {
-                        if (_tileTextures.TryGetValue(remKey, out var tex))
-                        {
-                            tex.Dispose();
-                            _tileTextures.Remove(remKey);
-                        }
-                    }
                 }
             }
             PerformanceTracker.Record("AddToCache", sw.Elapsed);
@@ -193,12 +171,12 @@ namespace StrategyGame
             return Path.Combine(tileFolder, $"{tileX}_{tileY}.png");
         }
 
-        public Task<SD.Bitmap> GetTileAsync(float zoom, int tileX, int tileY, CancellationToken token)
+        public Task<SKBitmap> GetTileAsync(float zoom, int tileX, int tileY, CancellationToken token)
         {
             var sw = Stopwatch.StartNew();
             int cellSize = GetCellSize(zoom);
             var key = (cellSize, tileX, tileY);
-            Task<SD.Bitmap> result;
+            Task<SKBitmap> result;
             lock (_cacheLock)
             {
                 if (_inFlight.TryGetValue(key, out var existing))
@@ -223,7 +201,7 @@ namespace StrategyGame
             return result;
         }
 
-        private async Task<SD.Bitmap> LoadTileInternalAsync(int cellSize, int tileX, int tileY, CancellationToken token)
+        private async Task<SKBitmap> LoadTileInternalAsync(int cellSize, int tileX, int tileY, CancellationToken token)
         {
             var sw = Stopwatch.StartNew();
             var key = (cellSize, tileX, tileY);
@@ -248,10 +226,12 @@ namespace StrategyGame
                     await using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, true);
                     using var img = await SixLabors.ImageSharp.Image.LoadAsync<Rgba32>(fs, token).ConfigureAwait(false);
                     var bmp = ImageSharpToBitmap(img);
-                    AddToCache(key, bmp);
+                    var sk = SkiaBitmapUtil.ToSKBitmap(bmp);
+                    bmp.Dispose();
+                    AddToCache(key, sk);
                     PerformanceTracker.Record("LoadTileInternal-FromDisk", swFileLoad.Elapsed);
                     PerformanceTracker.Record("LoadTileInternal-Total", sw.Elapsed);
-                    return bmp;
+                    return sk;
                 }
                 finally
                 {
@@ -286,11 +266,12 @@ namespace StrategyGame
             }
             PerformanceTracker.Record("TileGeneration-SaveToDisk", swSave.Elapsed);
 
-            AddToCache(key, bitmap);
-            UploadTileTexture(key, bitmap);
+            var skBmp = SkiaBitmapUtil.ToSKBitmap(bitmap);
+            bitmap.Dispose();
+            AddToCache(key, skBmp);
             PerformanceTracker.Record("LoadTileInternal-Generation", swGeneration.Elapsed);
             PerformanceTracker.Record("LoadTileInternal-Total", sw.Elapsed);
-            return bitmap;
+            return skBmp;
         }
 
         public SKBitmap AssembleView(float zoom, SD.Rectangle viewArea, Action triggerRefresh = null)
@@ -328,8 +309,8 @@ namespace StrategyGame
                         ty * tileSize - viewArea.Y + tileSize);
 
                     SKBitmap tex = null;
-                    lock (_textureLock)
-                        _tileTextures.TryGetValue(key, out tex);
+                    lock (_cacheLock)
+                        _tileCache.TryGetValue(key, out tex);
 
                     if (tex != null)
                     {
@@ -339,61 +320,17 @@ namespace StrategyGame
                     }
                     else
                     {
-                        // Try to safely create texture from cached bitmap
-                        SKBitmap newTexture = null;
-                        lock (_cacheLock)
+                        tilesMissing++;
+                        var ttx = tx;
+                        var tty = ty;
+                        var tileKey = key;
+                        _ = Task.Run(async () =>
                         {
-                            if (_tileCache.TryGetValue(key, out var tile))
-                            {
-                                TouchKey(key);
-                                try
-                                {
-                                    // Check dimensions inside the lock to avoid concurrent access
-                                    if (tile.Width > 0 && tile.Height > 0)
-                                    {
-                                        // Create texture directly from the cached bitmap while holding the lock
-                                        // This reduces the window for concurrent access issues
-                                        var swTexConvert = Stopwatch.StartNew();
-                                        newTexture = SkiaBitmapUtil.ToSKBitmap(tile);
-                                        PerformanceTracker.Record("CachedBitmapToSkia", swTexConvert.Elapsed);
-                                    }
-                                }
-                                catch (InvalidOperationException)
-                                {
-                                    // Bitmap was disposed or being used elsewhere, skip this tile
-                                    newTexture = null;
-                                }
-                                catch (ArgumentException)
-                                {
-                                    // Bitmap properties became invalid
-                                    newTexture = null;
-                                }
-                            }
-                        }
-
-                        if (newTexture != null)
-                        {
-                            lock (_textureLock)
-                                _tileTextures[key] = newTexture;
-                            TouchKey(key);
-                            canvas.DrawBitmap(newTexture, rect);
-                            tilesDrawn++;
-                        }
-                        else
-                        {
-                            tilesMissing++;
-                            var ttx = tx;
-                            var tty = ty;
-                            var tileKey = key;
-                            _ = Task.Run(async () =>
-                            {
-                                var swAsync = Stopwatch.StartNew();
-                                var t = await GetTileAsync(zoom, ttx, tty, CancellationToken.None).ConfigureAwait(false);
-                                if (t != null) UploadTileTexture(tileKey, t);
-                                PerformanceTracker.Record("AssembleView-AsyncTileLoad", swAsync.Elapsed);
-                                triggerRefresh?.Invoke();
-                            });
-                        }
+                            var swAsync = Stopwatch.StartNew();
+                            var t = await GetTileAsync(zoom, ttx, tty, CancellationToken.None).ConfigureAwait(false);
+                            if (t != null) triggerRefresh?.Invoke();
+                            PerformanceTracker.Record("AssembleView-AsyncTileLoad", swAsync.Elapsed);
+                        });
                     }
                 }
             }

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -22,6 +22,9 @@ namespace StrategyGame
         private readonly object _cacheLock = new();
         private readonly object _textureLock = new();
         private readonly Dictionary<(int cellSize, int x, int y), SKBitmap> _tileTextures = new();
+        private readonly LinkedList<(int cellSize, int x, int y)> _lruOrder = new();
+        private readonly Dictionary<(int cellSize, int x, int y), LinkedListNode<(int cellSize, int x, int y)>> _lruNodes = new();
+        private const int MaxCacheSize = 256;
         public static readonly bool GpuAvailable;
 
         static CityTileManager()
@@ -77,6 +80,52 @@ namespace StrategyGame
                 if (_tileTextures.TryGetValue(key, out var old))
                     old.Dispose();
                 _tileTextures[key] = sk;
+            }
+        }
+
+        private void TouchKey((int cellSize, int x, int y) key)
+        {
+            lock (_cacheLock)
+            {
+                if (_lruNodes.TryGetValue(key, out var node))
+                {
+                    _lruOrder.Remove(node);
+                    _lruOrder.AddFirst(node);
+                }
+            }
+        }
+
+        private void AddToCache((int cellSize, int x, int y) key, SD.Bitmap bmp)
+        {
+            lock (_cacheLock)
+            {
+                _tileCache[key] = bmp;
+                if (_lruNodes.TryGetValue(key, out var existing))
+                {
+                    _lruOrder.Remove(existing);
+                }
+                var node = _lruOrder.AddFirst(key);
+                _lruNodes[key] = node;
+
+                while (_tileCache.Count > MaxCacheSize)
+                {
+                    var last = _lruOrder.Last;
+                    if (last == null) break;
+                    _lruOrder.RemoveLast();
+                    var remKey = last.Value;
+                    if (_tileCache.TryGetValue(remKey, out var oldBmp))
+                        oldBmp.Dispose();
+                    _tileCache.Remove(remKey);
+                    _lruNodes.Remove(remKey);
+                    lock (_textureLock)
+                    {
+                        if (_tileTextures.TryGetValue(remKey, out var tex))
+                        {
+                            tex.Dispose();
+                            _tileTextures.Remove(remKey);
+                        }
+                    }
+                }
             }
         }
 
@@ -155,7 +204,10 @@ namespace StrategyGame
             lock (_cacheLock)
             {
                 if (_tileCache.TryGetValue(key, out var cached))
+                {
+                    TouchKey(key);
                     return cached;
+                }
             }
 
             string path = GetTilePath(cellSize, tileX, tileY);
@@ -168,8 +220,7 @@ namespace StrategyGame
                     await using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, true);
                     using var img = await SixLabors.ImageSharp.Image.LoadAsync<Rgba32>(fs, token).ConfigureAwait(false);
                     var bmp = ImageSharpToBitmap(img);
-                    lock (_cacheLock)
-                        _tileCache[key] = bmp;
+                    AddToCache(key, bmp);
                     return bmp;
                 }
                 finally
@@ -196,8 +247,7 @@ namespace StrategyGame
                 lockFile.Release();
             }
 
-            lock (_cacheLock)
-                _tileCache[key] = bitmap;
+            AddToCache(key, bitmap);
             UploadTileTexture(key, bitmap);
             return bitmap;
         }
@@ -234,6 +284,7 @@ namespace StrategyGame
 
                     if (tex != null)
                     {
+                        TouchKey(key);
                         canvas.DrawBitmap(tex, rect);
                     }
                     else
@@ -244,6 +295,7 @@ namespace StrategyGame
                         {
                             if (_tileCache.TryGetValue(key, out var tile))
                             {
+                                TouchKey(key);
                                 try
                                 {
                                     // Check dimensions inside the lock to avoid concurrent access
@@ -271,6 +323,7 @@ namespace StrategyGame
                         {
                             lock (_textureLock)
                                 _tileTextures[key] = newTexture;
+                            TouchKey(key);
                             canvas.DrawBitmap(newTexture, rect);
                         }
                         else

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Linq;
 using SkiaSharp;
+using economy_sim;
 
 namespace StrategyGame
 {
@@ -66,14 +67,18 @@ namespace StrategyGame
 
         private static SD.Bitmap ImageSharpToBitmap(Image<Rgba32> img)
         {
+            var sw = Stopwatch.StartNew();
             using var ms = new MemoryStream();
             img.SaveAsPng(ms);
             ms.Position = 0;
-            return new SD.Bitmap(ms);
+            var bmp = new SD.Bitmap(ms);
+            PerformanceTracker.Record("ImageSharpToBitmap", sw.Elapsed);
+            return bmp;
         }
 
         private void UploadTileTexture((int cellSize, int x, int y) key, SD.Bitmap bmp)
         {
+            var sw = Stopwatch.StartNew();
             var sk = SkiaBitmapUtil.ToSKBitmap(bmp);
             lock (_textureLock)
             {
@@ -81,10 +86,12 @@ namespace StrategyGame
                     old.Dispose();
                 _tileTextures[key] = sk;
             }
+            PerformanceTracker.Record("UploadTileTexture", sw.Elapsed);
         }
 
         private void TouchKey((int cellSize, int x, int y) key)
         {
+            var sw = Stopwatch.StartNew();
             lock (_cacheLock)
             {
                 if (_lruNodes.TryGetValue(key, out var node))
@@ -93,10 +100,12 @@ namespace StrategyGame
                     _lruOrder.AddFirst(node);
                 }
             }
+            PerformanceTracker.Record("LRU-TouchKey", sw.Elapsed);
         }
 
         private void AddToCache((int cellSize, int x, int y) key, SD.Bitmap bmp)
         {
+            var sw = Stopwatch.StartNew();
             lock (_cacheLock)
             {
                 _tileCache[key] = bmp;
@@ -127,10 +136,12 @@ namespace StrategyGame
                     }
                 }
             }
+            PerformanceTracker.Record("AddToCache", sw.Elapsed);
         }
 
         private int GetCellSize(float zoom)
         {
+            var sw = Stopwatch.StartNew();
             float[] anchors = new float[MultiResolutionMapManager.PixelsPerCellLevels.Length];
             for (int i = 0; i < anchors.Length; i++)
                 anchors[i] = MultiResolutionMapManager.PixelsPerCellLevels[i];
@@ -150,11 +161,14 @@ namespace StrategyGame
             if (size < 1f)
                 size = 1f;
 
-            return (int)Math.Round(size);
+            var result = (int)Math.Round(size);
+            PerformanceTracker.Record("GetCellSize", sw.Elapsed);
+            return result;
         }
 
         private GeoBounds ComputeTileBounds(int cellSize, int tileX, int tileY)
         {
+            var sw = Stopwatch.StartNew();
             int fullW = _baseWidth * cellSize;
             int fullH = _baseHeight * cellSize;
             int offsetX = tileX * MultiResolutionMapManager.TileSizePx;
@@ -162,13 +176,15 @@ namespace StrategyGame
             int tileWidth = Math.Min(MultiResolutionMapManager.TileSizePx, fullW - offsetX);
             int tileHeight = Math.Min(MultiResolutionMapManager.TileSizePx, fullH - offsetY);
 
-            return new GeoBounds
+            var bounds = new GeoBounds
             {
                 MinLon = -180 + (double)offsetX / fullW * 360.0,
                 MaxLon = -180 + (double)(offsetX + tileWidth) / fullW * 360.0,
                 MaxLat = 90 - (double)offsetY / fullH * 180.0,
                 MinLat = 90 - (double)(offsetY + tileHeight) / fullH * 180.0
             };
+            PerformanceTracker.Record("ComputeTileBounds", sw.Elapsed);
+            return bounds;
         }
 
         private string GetTilePath(int cellSize, int tileX, int tileY)
@@ -179,33 +195,44 @@ namespace StrategyGame
 
         public Task<SD.Bitmap> GetTileAsync(float zoom, int tileX, int tileY, CancellationToken token)
         {
+            var sw = Stopwatch.StartNew();
             int cellSize = GetCellSize(zoom);
             var key = (cellSize, tileX, tileY);
+            Task<SD.Bitmap> result;
             lock (_cacheLock)
             {
                 if (_inFlight.TryGetValue(key, out var existing))
-                    return existing;
-                var task = LoadTileInternalAsync(cellSize, tileX, tileY, token);
-                _inFlight[key] = task;
-                task.ContinueWith(_ =>
                 {
-                    lock (_cacheLock)
+                    result = existing;
+                }
+                else
+                {
+                    var task = LoadTileInternalAsync(cellSize, tileX, tileY, token);
+                    _inFlight[key] = task;
+                    task.ContinueWith(_ =>
                     {
-                        _inFlight.Remove(key);
-                    }
-                }, TaskScheduler.Default);
-                return task;
+                        lock (_cacheLock)
+                        {
+                            _inFlight.Remove(key);
+                        }
+                    }, TaskScheduler.Default);
+                    result = task;
+                }
             }
+            PerformanceTracker.Record("GetTileAsync", sw.Elapsed);
+            return result;
         }
 
         private async Task<SD.Bitmap> LoadTileInternalAsync(int cellSize, int tileX, int tileY, CancellationToken token)
         {
+            var sw = Stopwatch.StartNew();
             var key = (cellSize, tileX, tileY);
             lock (_cacheLock)
             {
                 if (_tileCache.TryGetValue(key, out var cached))
                 {
                     TouchKey(key);
+                    PerformanceTracker.Record("LoadTileInternal-CacheHit", sw.Elapsed);
                     return cached;
                 }
             }
@@ -213,6 +240,7 @@ namespace StrategyGame
             string path = GetTilePath(cellSize, tileX, tileY);
             if (File.Exists(path))
             {
+                var swFileLoad = Stopwatch.StartNew();
                 var fileLock = GetFileLock(path);
                 await fileLock.WaitAsync(token).ConfigureAwait(false);
                 try
@@ -221,6 +249,8 @@ namespace StrategyGame
                     using var img = await SixLabors.ImageSharp.Image.LoadAsync<Rgba32>(fs, token).ConfigureAwait(false);
                     var bmp = ImageSharpToBitmap(img);
                     AddToCache(key, bmp);
+                    PerformanceTracker.Record("LoadTileInternal-FromDisk", swFileLoad.Elapsed);
+                    PerformanceTracker.Record("LoadTileInternal-Total", sw.Elapsed);
                     return bmp;
                 }
                 finally
@@ -229,11 +259,17 @@ namespace StrategyGame
                 }
             }
 
+            var swGeneration = Stopwatch.StartNew();
             GeoBounds bounds = ComputeTileBounds(cellSize, tileX, tileY);
             var swGen = Stopwatch.StartNew();
             using var generated = await ProceduralCityRenderer.RenderCityTileAsync(bounds, cellSize).ConfigureAwait(false);
             PerformanceTracker.Record("TileGeneration", swGen.Elapsed);
+            
+            var swBitmap = Stopwatch.StartNew();
             var bitmap = ImageSharpToBitmap(generated);
+            PerformanceTracker.Record("TileGeneration-ToBitmap", swBitmap.Elapsed);
+            
+            var swSave = Stopwatch.StartNew();
             string dir = Path.Combine(TileCacheDir, cellSize.ToString());
             Directory.CreateDirectory(dir);
             var lockFile = GetFileLock(path);
@@ -248,9 +284,12 @@ namespace StrategyGame
             {
                 lockFile.Release();
             }
+            PerformanceTracker.Record("TileGeneration-SaveToDisk", swSave.Elapsed);
 
             AddToCache(key, bitmap);
             UploadTileTexture(key, bitmap);
+            PerformanceTracker.Record("LoadTileInternal-Generation", swGeneration.Elapsed);
+            PerformanceTracker.Record("LoadTileInternal-Total", sw.Elapsed);
             return bitmap;
         }
 
@@ -259,17 +298,24 @@ namespace StrategyGame
             var swRender = Stopwatch.StartNew();
             int cellSize = GetCellSize(zoom);
             int tileSize = MultiResolutionMapManager.TileSizePx;
+            
+            var swSurface = Stopwatch.StartNew();
             var info = new SKImageInfo(viewArea.Width, viewArea.Height);
             var context = GpuAvailable ? MultiResolutionMapManager.SharedContext : null;
             using var surface = context != null ? SKSurface.Create(context, false, info) : SKSurface.Create(info);
             var canvas = surface.Canvas;
             canvas.Clear(SKColors.Transparent);
+            PerformanceTracker.Record("AssembleView-CreateSurface", swSurface.Elapsed);
 
             int tileStartX = Math.Max(0, viewArea.X / tileSize);
             int tileStartY = Math.Max(0, viewArea.Y / tileSize);
             int tileEndX = (viewArea.Right + tileSize - 1) / tileSize;
             int tileEndY = (viewArea.Bottom + tileSize - 1) / tileSize;
 
+            var swDrawing = Stopwatch.StartNew();
+            int tilesDrawn = 0;
+            int tilesMissing = 0;
+            
             for (int ty = tileStartY; ty < tileEndY; ty++)
             {
                 for (int tx = tileStartX; tx < tileEndX; tx++)
@@ -289,6 +335,7 @@ namespace StrategyGame
                     {
                         TouchKey(key);
                         canvas.DrawBitmap(tex, rect);
+                        tilesDrawn++;
                     }
                     else
                     {
@@ -306,7 +353,9 @@ namespace StrategyGame
                                     {
                                         // Create texture directly from the cached bitmap while holding the lock
                                         // This reduces the window for concurrent access issues
+                                        var swTexConvert = Stopwatch.StartNew();
                                         newTexture = SkiaBitmapUtil.ToSKBitmap(tile);
+                                        PerformanceTracker.Record("CachedBitmapToSkia", swTexConvert.Elapsed);
                                     }
                                 }
                                 catch (InvalidOperationException)
@@ -328,31 +377,41 @@ namespace StrategyGame
                                 _tileTextures[key] = newTexture;
                             TouchKey(key);
                             canvas.DrawBitmap(newTexture, rect);
+                            tilesDrawn++;
                         }
                         else
                         {
+                            tilesMissing++;
                             var ttx = tx;
                             var tty = ty;
                             var tileKey = key;
                             _ = Task.Run(async () =>
                             {
+                                var swAsync = Stopwatch.StartNew();
                                 var t = await GetTileAsync(zoom, ttx, tty, CancellationToken.None).ConfigureAwait(false);
                                 if (t != null) UploadTileTexture(tileKey, t);
+                                PerformanceTracker.Record("AssembleView-AsyncTileLoad", swAsync.Elapsed);
                                 triggerRefresh?.Invoke();
                             });
                         }
                     }
                 }
             }
+            PerformanceTracker.Record("AssembleView-DrawingTiles", swDrawing.Elapsed);
+            PerformanceTracker.Record("AssembleView-TilesDrawn", TimeSpan.FromMilliseconds(tilesDrawn));
+            PerformanceTracker.Record("AssembleView-TilesMissing", TimeSpan.FromMilliseconds(tilesMissing));
 
+            var swReadPixels = Stopwatch.StartNew();
             var result = new SKBitmap(info);
             surface.ReadPixels(result.Info, result.GetPixels(), result.RowBytes, 0, 0);
+            PerformanceTracker.Record("AssembleView-ReadPixels", swReadPixels.Elapsed);
             PerformanceTracker.Record("TileRendering", swRender.Elapsed);
             return result;
         }
 
         public void PreloadVisibleTiles(float zoom, SD.Rectangle viewRect)
         {
+            var sw = Stopwatch.StartNew();
             int cellSize = GetCellSize(zoom);
             int tileSize = MultiResolutionMapManager.TileSizePx;
             int startX = Math.Max(0, viewRect.X / tileSize);
@@ -366,21 +425,30 @@ namespace StrategyGame
                     .Select(y => (x, y)))
                 .ToList();
 
+            int tileCount = coords.Count;
             using var throttle = new SemaphoreSlim(Environment.ProcessorCount);
+            int loaded = 0;
 
+            var swParallel = Stopwatch.StartNew();
             Parallel.ForEach(coords, coord =>
             {
                 throttle.Wait();
                 try
                 {
+                    var swTile = Stopwatch.StartNew();
                     GetTileAsync(zoom, coord.x, coord.y, CancellationToken.None)
                         .GetAwaiter().GetResult();
+                    PerformanceTracker.Record("PreloadTile-Single", swTile.Elapsed);
+                    Interlocked.Increment(ref loaded);
                 }
                 finally
                 {
                     throttle.Release();
                 }
             });
+            PerformanceTracker.Record("PreloadTiles-Parallel", swParallel.Elapsed);
+            PerformanceTracker.Record("PreloadTiles-Count", TimeSpan.FromMilliseconds(loaded));
+            PerformanceTracker.Record("PreloadTiles-Total", sw.Elapsed);
         }
     }
 }

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -238,20 +238,40 @@ namespace StrategyGame
                     }
                     else
                     {
-                        SD.Bitmap clone = null;
+                        // Try to safely create texture from cached bitmap
+                        SKBitmap newTexture = null;
                         lock (_cacheLock)
                         {
-                            if (_tileCache.TryGetValue(key, out var tile) && tile.Width > 0 && tile.Height > 0)
-                                clone = (SD.Bitmap)tile.Clone();
+                            if (_tileCache.TryGetValue(key, out var tile))
+                            {
+                                try
+                                {
+                                    // Check dimensions inside the lock to avoid concurrent access
+                                    if (tile.Width > 0 && tile.Height > 0)
+                                    {
+                                        // Create texture directly from the cached bitmap while holding the lock
+                                        // This reduces the window for concurrent access issues
+                                        newTexture = SkiaBitmapUtil.ToSKBitmap(tile);
+                                    }
+                                }
+                                catch (InvalidOperationException)
+                                {
+                                    // Bitmap was disposed or being used elsewhere, skip this tile
+                                    newTexture = null;
+                                }
+                                catch (ArgumentException)
+                                {
+                                    // Bitmap properties became invalid
+                                    newTexture = null;
+                                }
+                            }
                         }
 
-                        if (clone != null)
+                        if (newTexture != null)
                         {
-                            tex = SkiaBitmapUtil.ToSKBitmap(clone);
-                            clone.Dispose();
                             lock (_textureLock)
-                                _tileTextures[key] = tex;
-                            canvas.DrawBitmap(tex, rect);
+                                _tileTextures[key] = newTexture;
+                            canvas.DrawBitmap(newTexture, rect);
                         }
                         else
                         {

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -238,17 +238,19 @@ namespace StrategyGame
                     }
                     else
                     {
+                        SD.Bitmap clone = null;
                         lock (_cacheLock)
                         {
                             if (_tileCache.TryGetValue(key, out var tile) && tile.Width > 0 && tile.Height > 0)
-                            {
-                                tex = SkiaBitmapUtil.ToSKBitmap(tile);
-                                _tileTextures[key] = tex;
-                            }
+                                clone = (SD.Bitmap)tile.Clone();
                         }
 
-                        if (tex != null)
+                        if (clone != null)
                         {
+                            tex = SkiaBitmapUtil.ToSKBitmap(clone);
+                            clone.Dispose();
+                            lock (_textureLock)
+                                _tileTextures[key] = tex;
                             canvas.DrawBitmap(tex, rect);
                         }
                         else

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -22,6 +22,9 @@ namespace StrategyGame
         private readonly object _cacheLock = new();
         private readonly object _textureLock = new();
         private readonly Dictionary<(int cellSize, int x, int y), SKBitmap> _tileTextures = new();
+        private readonly LinkedList<(int cellSize, int x, int y)> _lruOrder = new();
+        private readonly Dictionary<(int cellSize, int x, int y), LinkedListNode<(int cellSize, int x, int y)>> _lruNodes = new();
+        private const int MaxCacheSize = 256;
         public static readonly bool GpuAvailable;
 
         static CityTileManager()
@@ -77,6 +80,52 @@ namespace StrategyGame
                 if (_tileTextures.TryGetValue(key, out var old))
                     old.Dispose();
                 _tileTextures[key] = sk;
+            }
+        }
+
+        private void TouchKey((int cellSize, int x, int y) key)
+        {
+            lock (_cacheLock)
+            {
+                if (_lruNodes.TryGetValue(key, out var node))
+                {
+                    _lruOrder.Remove(node);
+                    _lruOrder.AddFirst(node);
+                }
+            }
+        }
+
+        private void AddToCache((int cellSize, int x, int y) key, SD.Bitmap bmp)
+        {
+            lock (_cacheLock)
+            {
+                _tileCache[key] = bmp;
+                if (_lruNodes.TryGetValue(key, out var existing))
+                {
+                    _lruOrder.Remove(existing);
+                }
+                var node = _lruOrder.AddFirst(key);
+                _lruNodes[key] = node;
+
+                while (_tileCache.Count > MaxCacheSize)
+                {
+                    var last = _lruOrder.Last;
+                    if (last == null) break;
+                    _lruOrder.RemoveLast();
+                    var remKey = last.Value;
+                    if (_tileCache.TryGetValue(remKey, out var oldBmp))
+                        oldBmp.Dispose();
+                    _tileCache.Remove(remKey);
+                    _lruNodes.Remove(remKey);
+                    lock (_textureLock)
+                    {
+                        if (_tileTextures.TryGetValue(remKey, out var tex))
+                        {
+                            tex.Dispose();
+                            _tileTextures.Remove(remKey);
+                        }
+                    }
+                }
             }
         }
 
@@ -155,7 +204,10 @@ namespace StrategyGame
             lock (_cacheLock)
             {
                 if (_tileCache.TryGetValue(key, out var cached))
+                {
+                    TouchKey(key);
                     return cached;
+                }
             }
 
             string path = GetTilePath(cellSize, tileX, tileY);
@@ -168,8 +220,7 @@ namespace StrategyGame
                     await using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, true);
                     using var img = await SixLabors.ImageSharp.Image.LoadAsync<Rgba32>(fs, token).ConfigureAwait(false);
                     var bmp = ImageSharpToBitmap(img);
-                    lock (_cacheLock)
-                        _tileCache[key] = bmp;
+                    AddToCache(key, bmp);
                     return bmp;
                 }
                 finally
@@ -179,7 +230,9 @@ namespace StrategyGame
             }
 
             GeoBounds bounds = ComputeTileBounds(cellSize, tileX, tileY);
+            var swGen = Stopwatch.StartNew();
             using var generated = await ProceduralCityRenderer.RenderCityTileAsync(bounds, cellSize).ConfigureAwait(false);
+            PerformanceTracker.Record("TileGeneration", swGen.Elapsed);
             var bitmap = ImageSharpToBitmap(generated);
             string dir = Path.Combine(TileCacheDir, cellSize.ToString());
             Directory.CreateDirectory(dir);
@@ -196,14 +249,14 @@ namespace StrategyGame
                 lockFile.Release();
             }
 
-            lock (_cacheLock)
-                _tileCache[key] = bitmap;
+            AddToCache(key, bitmap);
             UploadTileTexture(key, bitmap);
             return bitmap;
         }
 
         public SKBitmap AssembleView(float zoom, SD.Rectangle viewArea, Action triggerRefresh = null)
         {
+            var swRender = Stopwatch.StartNew();
             int cellSize = GetCellSize(zoom);
             int tileSize = MultiResolutionMapManager.TileSizePx;
             var info = new SKImageInfo(viewArea.Width, viewArea.Height);
@@ -234,6 +287,7 @@ namespace StrategyGame
 
                     if (tex != null)
                     {
+                        TouchKey(key);
                         canvas.DrawBitmap(tex, rect);
                     }
                     else
@@ -244,6 +298,7 @@ namespace StrategyGame
                         {
                             if (_tileCache.TryGetValue(key, out var tile))
                             {
+                                TouchKey(key);
                                 try
                                 {
                                     // Check dimensions inside the lock to avoid concurrent access
@@ -271,6 +326,7 @@ namespace StrategyGame
                         {
                             lock (_textureLock)
                                 _tileTextures[key] = newTexture;
+                            TouchKey(key);
                             canvas.DrawBitmap(newTexture, rect);
                         }
                         else
@@ -291,6 +347,7 @@ namespace StrategyGame
 
             var result = new SKBitmap(info);
             surface.ReadPixels(result.Info, result.GetPixels(), result.RowBytes, 0, 0);
+            PerformanceTracker.Record("TileRendering", swRender.Elapsed);
             return result;
         }
 

--- a/MainGame.Designer.cs
+++ b/MainGame.Designer.cs
@@ -67,6 +67,7 @@
             labelCityModelRate = new Label();
             buttonGenerateTileCache = new Button();
             buttonGenerateCityData = new Button();
+            buttonShowPerformance = new Button();
             tabPageDiplomacy = new TabPage();
             labelProposedTrades = new Label();
             listBoxProposedTradeAgreements = new ListBox();
@@ -270,6 +271,7 @@
             tabPageDebug.Controls.Add(labelCityModelRate);
             tabPageDebug.Controls.Add(buttonGenerateTileCache);
             tabPageDebug.Controls.Add(buttonGenerateCityData);
+            tabPageDebug.Controls.Add(buttonShowPerformance);
             tabPageDebug.Controls.Add(buttonToggleDebugMode);
             tabPageDebug.Location = new Point(4, 29);
             tabPageDebug.Margin = new Padding(5, 4, 5, 4);
@@ -459,6 +461,18 @@
             buttonGenerateCityData.Text = "Generate City Data";
             buttonGenerateCityData.UseVisualStyleBackColor = true;
             buttonGenerateCityData.Click += ButtonGenerateCityData_Click;
+
+            //
+            // buttonShowPerformance
+            //
+            buttonShowPerformance.Location = new Point(522, 662);
+            buttonShowPerformance.Margin = new Padding(5, 4, 5, 4);
+            buttonShowPerformance.Name = "buttonShowPerformance";
+            buttonShowPerformance.Size = new Size(160, 36);
+            buttonShowPerformance.TabIndex = 18;
+            buttonShowPerformance.Text = "Performance Stats";
+            buttonShowPerformance.UseVisualStyleBackColor = true;
+            buttonShowPerformance.Click += ButtonShowPerformance_Click;
 
             // 
             // tabPageDiplomacy
@@ -754,6 +768,7 @@
         private System.Windows.Forms.Label labelCityModelRate;
         private System.Windows.Forms.Button buttonGenerateTileCache;
         private System.Windows.Forms.Button buttonGenerateCityData;
+        private System.Windows.Forms.Button buttonShowPerformance;
         private System.Windows.Forms.TabPage tabPageDiplomacy;
         private System.Windows.Forms.Label labelProposedTrades;
         private System.Windows.Forms.ListBox listBoxProposedTradeAgreements;

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -516,7 +516,7 @@ namespace economy_sim
         {
             if (terrain == null) return null;
             var info = new SKImageInfo(terrain.Width, terrain.Height);
-            using var context = MultiResolutionMapManager.GpuAvailable ? GRContext.CreateGl() : null;
+            var context = MultiResolutionMapManager.GpuAvailable ? MultiResolutionMapManager.SharedContext : null;
             using var surface = context != null ? SKSurface.Create(context, false, info) : SKSurface.Create(info);
             var canvas = surface.Canvas;
             canvas.Clear(SKColors.Transparent);

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -31,6 +31,7 @@ namespace economy_sim
         private PopStatsForm popStatsForm;
         private FactoryStatsForm factoryStatsForm;
         private ConstructionForm constructionForm;
+        private PerformanceStatsForm performanceStatsForm;
         private List<State> states;
         private PlayerRoleManager playerRoleManager;
         private Random random = new Random(); // Add a Random instance for AI and other uses
@@ -209,6 +210,7 @@ namespace economy_sim
             popStatsForm = new PopStatsForm();
             factoryStatsForm = new FactoryStatsForm();
             constructionForm = new ConstructionForm();
+            performanceStatsForm = new PerformanceStatsForm();
             tabControlMain.SelectedIndexChanged += TabControlMain_SelectedIndexChanged;
 
             this.listBoxCityStats.DrawMode = DrawMode.OwnerDrawFixed;
@@ -224,6 +226,9 @@ namespace economy_sim
 
             this.buttonShowConstruction.Location = new SD.Point(this.buttonShowFactoryStats.Right + 10, buttonsTargetY);
             this.buttonShowConstruction.Click += ButtonShowConstruction_Click;
+
+            this.buttonShowPerformance.Location = new SD.Point(this.buttonShowConstruction.Right + 10, buttonsTargetY);
+            this.buttonShowPerformance.Click += ButtonShowPerformance_Click;
 
             Console.WriteLine($"[Startup] TOTAL startup time: {totalSw.Elapsed.TotalSeconds:F2} seconds");
             this.Shown += (s, e) =>
@@ -971,6 +976,7 @@ namespace economy_sim
 
         private void TimerSim_Tick(object sender, EventArgs e)
         {
+            var swSim = Stopwatch.StartNew();
             simTurn++;
             labelSimTime.Text = $"Turn: {simTurn}";
 
@@ -1296,6 +1302,7 @@ namespace economy_sim
                     }
                 }
             }
+            PerformanceTracker.Record("GameSimulation", swSim.Elapsed);
         }
 
         private string FormatValueWithChange(double currentValue, double previousValue, string formatSpecifier, bool calculateDiff, double tolerance = 0.001)
@@ -1449,6 +1456,12 @@ namespace economy_sim
                 constructionForm.Show();
                 constructionForm.BringToFront();
             }
+        }
+
+        private void ButtonShowPerformance_Click(object sender, EventArgs e)
+        {
+            performanceStatsForm.Show();
+            performanceStatsForm.BringToFront();
         }
 
         private void UpdateOrderLists()

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -2485,7 +2485,10 @@ namespace economy_sim
         {
             if (_currentMapView != null)
             {
-                SkiaSharp.Views.Desktop.Extensions.DrawToBitmap(_currentMapView, e.Graphics, new SKRectI(0, 0, _currentMapView.Width, _currentMapView.Height));
+                using (var bitmap = _currentMapView.ToBitmap())
+                {
+                    e.Graphics.DrawImage(bitmap, new SD.Rectangle(0, 0, _currentMapView.Width, _currentMapView.Height));
+                }
             }
         }
 

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -17,6 +17,7 @@ using System.Threading;
 using System.Windows.Forms;
 using Nts = NetTopologySuite.Geometries;
 using SkiaSharp;
+using SkiaSharp.Views.Desktop;
 
 namespace economy_sim
 {
@@ -71,6 +72,7 @@ namespace economy_sim
         private bool pendingMapUpdate = false;
         private bool mapRenderInProgress = false;
         private bool mapRenderQueued = false;
+        private SKBitmap _currentMapView;
         private readonly object _zoomLock = new();
         private float _zoom = 1f;
         private int lastCityModelCount = 0;
@@ -180,6 +182,7 @@ namespace economy_sim
             pictureBox1.MouseDown += PictureBox1_MouseDown;
             pictureBox1.MouseMove += PictureBox1_MouseMove;
             pictureBox1.MouseUp += PictureBox1_MouseUp;
+            pictureBox1.Paint += PictureBox1_Paint;
 
             sw.Restart();
             InitializeCorporations();
@@ -198,8 +201,10 @@ namespace economy_sim
             Console.WriteLine($"[Startup] UpdateOrderLists took {sw.Elapsed.TotalSeconds:F2} seconds");
             pictureBox1.Dock = DockStyle.Fill;
             pictureBox1.SizeMode = PictureBoxSizeMode.Normal;
-            timerSim.Tick += TimerSim_Tick;
-            timerSim.Start();
+            timerSim.Tick += TimerSim_Tick; // legacy timer unused
+            //timerSim.Start();
+            var simCts = new CancellationTokenSource();
+            _ = RunGameSimulationLoop(simCts.Token);
 
             int buttonsTargetX = 30;
             int buttonsTargetY = 411;
@@ -269,10 +274,14 @@ namespace economy_sim
                             {
                                 var updatedViewRect = new SD.Rectangle(mapViewOrigin, panelMap.ClientSize);
                                 using var sk2 = mapManager.AssembleView(mapZoom, updatedViewRect);
-                                pictureBox1.Image = SkiaBitmapUtil.ToGdiBitmap(sk2);
+                                _currentMapView?.Dispose();
+                                _currentMapView = sk2.Copy();
+                                pictureBox1.Invalidate();
                             }));
                         });
-                        pictureBox1.Image = SkiaBitmapUtil.ToGdiBitmap(sk);
+                        _currentMapView?.Dispose();
+                        _currentMapView = sk.Copy();
+                        pictureBox1.Invalidate();
                     }));
                 });
             }
@@ -341,9 +350,9 @@ namespace economy_sim
             if (finalSk == null)
                 return;
 
-            pictureBox1.Image?.Dispose();
-            using var bmp = SkiaBitmapUtil.ToGdiBitmap(finalSk);
-            pictureBox1.Image = bmp;
+            _currentMapView?.Dispose();
+            _currentMapView = finalSk.Copy();
+            pictureBox1.Invalidate();
         }
         private CancellationTokenSource redrawCts;
 
@@ -396,9 +405,9 @@ namespace economy_sim
                     {
                         this.Invoke(() =>
                         {
-                            pictureBox1.Image?.Dispose();
-                            using var bmp = SkiaBitmapUtil.ToGdiBitmap(finalSk);
-                            pictureBox1.Image = bmp;
+                            _currentMapView?.Dispose();
+                            _currentMapView = finalSk.Copy();
+                            pictureBox1.Invalidate();
                         });
                     }
                 }
@@ -461,12 +470,12 @@ namespace economy_sim
                 if (terrain == null) return;
                 using SKBitmap mapSk = CombineMaps(terrain, city);
                 if (mapSk == null) return;
-                using var map = SkiaBitmapUtil.ToGdiBitmap(mapSk);
 
                 void setImage()
                 {
-                    pictureBox1.Image?.Dispose();
-                    pictureBox1.Image = (SD.Bitmap)map.Clone();
+                    _currentMapView?.Dispose();
+                    _currentMapView = mapSk.Copy();
+                    pictureBox1.Invalidate();
                     mapRenderInProgress = false;
                     if (mapRenderQueued)
                     {
@@ -978,10 +987,10 @@ namespace economy_sim
         {
             var swSim = Stopwatch.StartNew();
             simTurn++;
-            labelSimTime.Text = $"Turn: {simTurn}";
+            this.Invoke((Action)(() => labelSimTime.Text = $"Turn: {simTurn}"));
 
-            // Get the currently selected city for UI before any updates this tick
-            var cityCurrentlySelectedForUI = GetSelectedCity();
+            StrategyGame.City cityCurrentlySelectedForUI = null;
+            this.Invoke((Action)(() => { cityCurrentlySelectedForUI = GetSelectedCity(); }));
 
             // 1. Capture Previous Stats for the Selected City (if any, and not the first tick)
             if (cityCurrentlySelectedForUI != null && !firstTick)
@@ -1010,7 +1019,8 @@ namespace economy_sim
                         prevMarketDemand[goodName] = cityCurrentlySelectedForUI.LocalDemand.ContainsKey(goodName) ? cityCurrentlySelectedForUI.LocalDemand[goodName] : 0;
                     }
                 }
-                var selectedState = GetSelectedState(); // If state/country budgets also have indicators
+                State selectedState = null;
+                this.Invoke((Action)(() => { selectedState = GetSelectedState(); }));
                 if (selectedState != null) { prevStateBudget = selectedState.Budget; }
                 if (playerCountry != null) { prevCountryBudget = playerCountry.Budget; }
             }
@@ -1228,30 +1238,33 @@ namespace economy_sim
             // 4. Refresh UI elements
             // The GetSelectedCity() here will get the same city as cityCurrentlySelectedForUI,
             // but its data has now been updated by the simulation loop.
-            UpdateOrderLists();
-            UpdateCityAndFactoryStats();
-            UpdateMarketStats();
-            UpdateStateStats();
-            UpdateCountryStats();
-
-            if (cityCurrentlySelectedForUI != null) // Use the city selected at start of tick for populating forms
+            this.Invoke((Action)(() =>
             {
-                if (popStatsForm != null && popStatsForm.Visible)
+                UpdateOrderLists();
+                UpdateCityAndFactoryStats();
+                UpdateMarketStats();
+                UpdateStateStats();
+                UpdateCountryStats();
+
+                if (cityCurrentlySelectedForUI != null)
                 {
-                    popStatsForm.UpdateStats(cityCurrentlySelectedForUI); // Pass the (now updated) selected city
+                    if (popStatsForm != null && popStatsForm.Visible)
+                    {
+                        popStatsForm.UpdateStats(cityCurrentlySelectedForUI);
+                    }
+                    if (factoryStatsForm != null && factoryStatsForm.Visible)
+                    {
+                        factoryStatsForm.UpdateStats(cityCurrentlySelectedForUI);
+                    }
                 }
-                if (factoryStatsForm != null && factoryStatsForm.Visible)
-                {
-                    factoryStatsForm.UpdateStats(cityCurrentlySelectedForUI); // Pass the (now updated) selected city
-                }
-            }
+            }));
             firstTick = false;
 
             // Process end-of-turn for diplomacy
             if (diplomacyManager != null)
             {
                 diplomacyManager.ProcessTurnEnd();
-                UpdateDiplomacyTab(); // Update the diplomacy UI after processing
+                this.Invoke((Action)(UpdateDiplomacyTab));
             }
 
             // Process financial systems and monetary effects
@@ -1262,17 +1275,20 @@ namespace economy_sim
             }
 
             // Refresh finance tab if it's visible so data stays current
-            if (tabControlMain.SelectedTab == tabPageFinance)
+            this.Invoke((Action)(() =>
             {
-                UpdateFinanceTab();
-            }
-            if (tabControlMain.SelectedTab == tabPageGovernment)
-            {
-                UpdateGovernmentTab();
-            }
+                if (tabControlMain.SelectedTab == tabPageFinance)
+                {
+                    UpdateFinanceTab();
+                }
+                if (tabControlMain.SelectedTab == tabPageGovernment)
+                {
+                    UpdateGovernmentTab();
+                }
+            }));
 
             // Update urban area status each tick
-            UpdateUrbanAreaStatus();
+            this.Invoke((Action)(UpdateUrbanAreaStatus));
 
             // Process AI trade proposals (temporary simple logic)
             if (diplomacyManager != null && playerCountry != null && random.Next(100) < 20) // 20% chance each turn
@@ -1303,6 +1319,15 @@ namespace economy_sim
                 }
             }
             PerformanceTracker.Record("GameSimulation", swSim.Elapsed);
+        }
+
+        private async Task RunGameSimulationLoop(CancellationToken token)
+        {
+            while (!token.IsCancellationRequested)
+            {
+                TimerSim_Tick(this, EventArgs.Empty);
+                await Task.Delay(1000, token);
+            }
         }
 
         private string FormatValueWithChange(double currentValue, double previousValue, string formatSpecifier, bool calculateDiff, double tolerance = 0.001)
@@ -2453,6 +2478,14 @@ namespace economy_sim
                 isPanning = false;
                 Cursor = Cursors.Default;
                 PreloadMapTiles();
+            }
+        }
+
+        private void PictureBox1_Paint(object sender, PaintEventArgs e)
+        {
+            if (_currentMapView != null)
+            {
+                SkiaSharp.Views.Desktop.Extensions.DrawToBitmap(_currentMapView, e.Graphics, new SKRectI(0, 0, _currentMapView.Width, _currentMapView.Height));
             }
         }
 

--- a/MultiResolutionMapManager.cs
+++ b/MultiResolutionMapManager.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing.Drawing2D;
 using System.Drawing.Imaging;
+using SkiaSharp;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -51,6 +52,23 @@ namespace StrategyGame
         private readonly LinkedList<(int cellSize, int x, int y)> _tileLru = new();
         private readonly object _cacheLock = new();
         private readonly object _assembleLock = new();
+        private readonly object _textureLock = new();
+        private readonly Dictionary<(int cellSize, int x, int y), SKBitmap> _tileTextures = new();
+
+        public static readonly bool GpuAvailable;
+
+        static MultiResolutionMapManager()
+        {
+            try
+            {
+                using var ctx = GRContext.CreateGl();
+                GpuAvailable = ctx != null;
+            }
+            catch
+            {
+                GpuAvailable = false;
+            }
+        }
 
         /// <summary>
         /// Raised during tile cache generation. The first parameter is the
@@ -249,6 +267,7 @@ namespace StrategyGame
                     _tileLru.AddLast(key);
                     EnforceTileLimit();
                 }
+                UploadTileTexture(key, bmp);
             }
 
             return bmp;
@@ -299,7 +318,7 @@ namespace StrategyGame
         /// <summary>
         /// Assemble a view rectangle from cached tiles.
         /// </summary>
-        public System.Drawing.Bitmap AssembleView(float zoom, System.Drawing.Rectangle viewArea, Action triggerRefresh = null)
+        public SKBitmap AssembleView(float zoom, System.Drawing.Rectangle viewArea, Action triggerRefresh = null)
         {
             lock (_assembleLock)
             {
@@ -307,88 +326,86 @@ namespace StrategyGame
                 int tileSize = TileSizePx;
 
                 if (viewArea.Width <= 0 || viewArea.Height <= 0 || cellSize <= 0)
-                    return new System.Drawing.Bitmap(1, 1); // Safe fallback
+                    return new SKBitmap(1, 1); // Safe fallback
 
                 int tileStartX = Math.Max(0, viewArea.X / tileSize);
                 int tileStartY = Math.Max(0, viewArea.Y / tileSize);
                 int tileEndX = (viewArea.Right + tileSize - 1) / tileSize;
                 int tileEndY = (viewArea.Bottom + tileSize - 1) / tileSize;
 
-                var output = new System.Drawing.Bitmap(viewArea.Width, viewArea.Height);
-                using var g = System.Drawing.Graphics.FromImage(output);
-                g.Clear(System.Drawing.Color.DarkGray); // Use a placeholder color
+                var info = new SKImageInfo(viewArea.Width, viewArea.Height);
+                using var context = GpuAvailable ? GRContext.CreateGl() : null;
+                using var surface = context != null ? SKSurface.Create(context, false, info) : SKSurface.Create(info);
+                var canvas = surface.Canvas;
+                canvas.Clear(SKColors.DarkGray);
 
                 for (int ty = tileStartY; ty < tileEndY; ty++)
                 {
                     for (int tx = tileStartX; tx < tileEndX; tx++)
                     {
                         var key = (cellSize, tx, ty);
-                        var rect = new System.Drawing.Rectangle(
+                        var rect = new SKRect(
                             tx * tileSize - viewArea.X,
                             ty * tileSize - viewArea.Y,
-                            tileSize,
-                            tileSize
+                            tx * tileSize - viewArea.X + tileSize,
+                            ty * tileSize - viewArea.Y + tileSize
                         );
 
                         if (rect.Width <= 0 || rect.Height <= 0)
                             continue;
 
-                        System.Drawing.Bitmap tile = null;
-                        lock (_cacheLock)
-                        {
-                            // First, try to get the tile from the in-memory cache.
-                            _tileCache.TryGetValue(key, out tile);
-                        }
+                        SKBitmap texture = null;
+                        lock (_textureLock)
+                            _tileTextures.TryGetValue(key, out texture);
 
-                        if (tile != null && tile.Width > 0 && tile.Height > 0)
+                        if (texture != null)
                         {
-                            // If the tile was in the cache, draw it.
-                            try
-                            {
-                                g.DrawImage(tile, rect);
-                            }
-                            catch (ExternalException ex)
-                            {
-                                Debug.WriteLine($"DrawImage ExternalException at ({tx},{ty}): {ex.Message}");
-                            }
+                            canvas.DrawBitmap(texture, rect);
                         }
                         else
                         {
-                            // --- This is the new non-blocking logic ---
-                            // If the tile is NOT in the cache, request it asynchronously.
-                            // Do NOT block to wait for it. The UI will remain responsive.
-                            lock (_tileLoadLock)
+                            SystemDrawing.Bitmap tile = null;
+                            lock (_cacheLock)
+                                _tileCache.TryGetValue(key, out tile);
+
+                            if (tile != null && tile.Width > 0 && tile.Height > 0)
                             {
-                                if (!_tilesBeingLoaded.Contains(key))
+                                texture = SkiaBitmapUtil.ToSKBitmap(tile);
+                                lock (_textureLock) _tileTextures[key] = texture;
+                                canvas.DrawBitmap(texture, rect);
+                            }
+                            else
+                            {
+                                lock (_tileLoadLock)
                                 {
-                                    _tilesBeingLoaded.Add(key);
-                                    // GetTileAsync will load from disk or generate if needed.
-                                    _ = Task.Run(async () =>
+                                    if (!_tilesBeingLoaded.Contains(key))
                                     {
-                                        try
+                                        _tilesBeingLoaded.Add(key);
+                                        _ = Task.Run(async () =>
                                         {
-                                            // This runs in the background.
-                                            await GetTileAsync(zoom, tx, ty, CancellationToken.None);
-                                            // Once the tile is loaded/generated, trigger a refresh to draw it.
-                                            triggerRefresh?.Invoke();
-                                            Debug.WriteLine($"[TILE] Triggering redraw for tile ({tx},{ty})");
-                                        }
-                                        finally
-                                        {
-                                            lock (_tileLoadLock)
+                                            try
                                             {
-                                                _tilesBeingLoaded.Remove(key);
+                                                var t = await GetTileAsync(zoom, tx, ty, CancellationToken.None);
+                                                if (t != null)
+                                                    UploadTileTexture(key, t);
+                                                triggerRefresh?.Invoke();
                                             }
-                                        }
-                                    });
+                                            finally
+                                            {
+                                                lock (_tileLoadLock)
+                                                    _tilesBeingLoaded.Remove(key);
+                                            }
+                                        });
+                                    }
                                 }
                             }
-                            // A placeholder (the gray background) is drawn for the missing tile for now.
                         }
                     }
                 }
 
-                return output;
+                var result = new SKBitmap(info);
+                surface.ReadPixels(result.Info, result.GetPixels(), result.RowBytes, 0, 0);
+                return result;
             }
         }
 
@@ -597,6 +614,17 @@ namespace StrategyGame
             return bmp;
         }
 
+        private void UploadTileTexture((int cellSize, int x, int y) key, SystemDrawing.Bitmap bmp)
+        {
+            var sk = SkiaBitmapUtil.ToSKBitmap(bmp);
+            lock (_textureLock)
+            {
+                if (_tileTextures.TryGetValue(key, out var old))
+                    old.Dispose();
+                _tileTextures[key] = sk;
+            }
+        }
+
         /// <summary>
         /// Dispose all cached bitmaps without affecting tile caches.
         /// </summary>
@@ -618,6 +646,14 @@ namespace StrategyGame
                 {
                     oldBmp.Dispose();
                     _tileCache.Remove(oldest);
+                }
+                lock (_textureLock)
+                {
+                    if (_tileTextures.TryGetValue(oldest, out var tex))
+                    {
+                        tex.Dispose();
+                        _tileTextures.Remove(oldest);
+                    }
                 }
             }
         }

--- a/MultiResolutionMapManager.cs
+++ b/MultiResolutionMapManager.cs
@@ -56,13 +56,14 @@ namespace StrategyGame
         private readonly Dictionary<(int cellSize, int x, int y), SKBitmap> _tileTextures = new();
 
         public static readonly bool GpuAvailable;
+        internal static readonly GRContext? SharedContext;
 
         static MultiResolutionMapManager()
         {
             try
             {
-                using var ctx = GRContext.CreateGl();
-                GpuAvailable = ctx != null;
+                SharedContext = GRContext.CreateGl();
+                GpuAvailable = SharedContext != null;
             }
             catch
             {
@@ -334,7 +335,7 @@ namespace StrategyGame
                 int tileEndY = (viewArea.Bottom + tileSize - 1) / tileSize;
 
                 var info = new SKImageInfo(viewArea.Width, viewArea.Height);
-                using var context = GpuAvailable ? GRContext.CreateGl() : null;
+                var context = GpuAvailable ? SharedContext : null;
                 using var surface = context != null ? SKSurface.Create(context, false, info) : SKSurface.Create(info);
                 var canvas = surface.Canvas;
                 canvas.Clear(SKColors.DarkGray);

--- a/MultiResolutionMapManager.cs
+++ b/MultiResolutionMapManager.cs
@@ -365,21 +365,17 @@ namespace StrategyGame
                         }
                         else
                         {
-                            SystemDrawing.Bitmap tile = null;
                             lock (_cacheLock)
                             {
-                                _tileCache.TryGetValue(key, out tile);
-                                if (tile != null && tile.Width > 0 && tile.Height > 0)
-                                    tile = (SystemDrawing.Bitmap)tile.Clone();
-                                else
-                                    tile = null;
+                                if (_tileCache.TryGetValue(key, out var tile) && tile.Width > 0 && tile.Height > 0)
+                                {
+                                    texture = SkiaBitmapUtil.ToSKBitmap(tile);
+                                    _tileTextures[key] = texture;
+                                }
                             }
 
-                            if (tile != null)
+                            if (texture != null)
                             {
-                                texture = SkiaBitmapUtil.ToSKBitmap(tile);
-                                tile.Dispose();
-                                lock (_textureLock) _tileTextures[key] = texture;
                                 canvas.DrawBitmap(texture, rect);
                             }
                             else

--- a/MultiResolutionMapManager.cs
+++ b/MultiResolutionMapManager.cs
@@ -367,11 +367,18 @@ namespace StrategyGame
                         {
                             SystemDrawing.Bitmap tile = null;
                             lock (_cacheLock)
+                            {
                                 _tileCache.TryGetValue(key, out tile);
+                                if (tile != null && tile.Width > 0 && tile.Height > 0)
+                                    tile = (SystemDrawing.Bitmap)tile.Clone();
+                                else
+                                    tile = null;
+                            }
 
-                            if (tile != null && tile.Width > 0 && tile.Height > 0)
+                            if (tile != null)
                             {
                                 texture = SkiaBitmapUtil.ToSKBitmap(tile);
+                                tile.Dispose();
                                 lock (_textureLock) _tileTextures[key] = texture;
                                 canvas.DrawBitmap(texture, rect);
                             }

--- a/MultiResolutionMapManager.cs
+++ b/MultiResolutionMapManager.cs
@@ -365,17 +365,19 @@ namespace StrategyGame
                         }
                         else
                         {
+                            SD.Bitmap clone = null;
                             lock (_cacheLock)
                             {
                                 if (_tileCache.TryGetValue(key, out var tile) && tile.Width > 0 && tile.Height > 0)
-                                {
-                                    texture = SkiaBitmapUtil.ToSKBitmap(tile);
-                                    _tileTextures[key] = texture;
-                                }
+                                    clone = (SD.Bitmap)tile.Clone();
                             }
 
-                            if (texture != null)
+                            if (clone != null)
                             {
+                                texture = SkiaBitmapUtil.ToSKBitmap(clone);
+                                clone.Dispose();
+                                lock (_textureLock)
+                                    _tileTextures[key] = texture;
                                 canvas.DrawBitmap(texture, rect);
                             }
                             else

--- a/MultiResolutionMapManager.cs
+++ b/MultiResolutionMapManager.cs
@@ -365,20 +365,40 @@ namespace StrategyGame
                         }
                         else
                         {
-                            SD.Bitmap clone = null;
+                            // Try to safely create texture from cached bitmap
+                            SKBitmap newTexture = null;
                             lock (_cacheLock)
                             {
-                                if (_tileCache.TryGetValue(key, out var tile) && tile.Width > 0 && tile.Height > 0)
-                                    clone = (SD.Bitmap)tile.Clone();
+                                if (_tileCache.TryGetValue(key, out var tile))
+                                {
+                                    try
+                                    {
+                                        // Check dimensions inside the lock to avoid concurrent access
+                                        if (tile.Width > 0 && tile.Height > 0)
+                                        {
+                                            // Create texture directly from the cached bitmap while holding the lock
+                                            // This reduces the window for concurrent access issues
+                                            newTexture = SkiaBitmapUtil.ToSKBitmap(tile);
+                                        }
+                                    }
+                                    catch (InvalidOperationException)
+                                    {
+                                        // Bitmap was disposed or being used elsewhere, skip this tile
+                                        newTexture = null;
+                                    }
+                                    catch (ArgumentException)
+                                    {
+                                        // Bitmap properties became invalid
+                                        newTexture = null;
+                                    }
+                                }
                             }
 
-                            if (clone != null)
+                            if (newTexture != null)
                             {
-                                texture = SkiaBitmapUtil.ToSKBitmap(clone);
-                                clone.Dispose();
                                 lock (_textureLock)
-                                    _tileTextures[key] = texture;
-                                canvas.DrawBitmap(texture, rect);
+                                    _tileTextures[key] = newTexture;
+                                canvas.DrawBitmap(newTexture, rect);
                             }
                             else
                             {
@@ -527,6 +547,7 @@ namespace StrategyGame
                     row[ix] = color;
             }
         }
+
         private static void DrawLine(Image<Rgba32> img, int x0, int y0, int x1, int y1, SixLabors.ImageSharp.Color color, int thickness = 1)
         {
             int dx = Math.Abs(x1 - x0), sx = x0 < x1 ? 1 : -1;
@@ -575,11 +596,6 @@ namespace StrategyGame
                 }
             }
         }
-
-
-
-
-
 
         private int GetCellSize(float zoom)
         {
@@ -640,13 +656,10 @@ namespace StrategyGame
         /// <summary>
         /// Dispose all cached bitmaps without affecting tile caches.
         /// </summary>
-       
-
 
         /// <summary>
         /// Dispose all cached tiles and clear the tile cache.
         /// </summary>
-       
 
         private void EnforceTileLimit()
         {
@@ -675,44 +688,45 @@ namespace StrategyGame
             await _preloadSemaphore.WaitAsync(token).ConfigureAwait(false);
             try
             {
-            var size = GetMapSize(zoom);
-            int firstTileX = Math.Max(0, view.X / TileSizePx - radius);
-            int lastTileX = Math.Min((size.Width - 1) / TileSizePx, (view.Right - 1) / TileSizePx + radius);
-            int firstTileY = Math.Max(0, view.Y / TileSizePx - radius);
-            int lastTileY = Math.Min((size.Height - 1) / TileSizePx, (view.Bottom - 1) / TileSizePx + radius);
+                var size = GetMapSize(zoom);
+                int firstTileX = Math.Max(0, view.X / TileSizePx - radius);
+                int lastTileX = Math.Min((size.Width - 1) / TileSizePx, (view.Right - 1) / TileSizePx + radius);
+                int firstTileY = Math.Max(0, view.Y / TileSizePx - radius);
+                int lastTileY = Math.Min((size.Height - 1) / TileSizePx, (view.Bottom - 1) / TileSizePx + radius);
 
-            const int maxParallel = 4;
-            using var throttler = new SemaphoreSlim(maxParallel);
-            var tasks = new List<Task>();
+                const int maxParallel = 4;
+                using var throttler = new SemaphoreSlim(maxParallel);
+                var tasks = new List<Task>();
 
-            for (int tx = firstTileX; tx <= lastTileX; tx++)
-            {
-                for (int ty = firstTileY; ty <= lastTileY; ty++)
+                for (int tx = firstTileX; tx <= lastTileX; tx++)
                 {
-                    await throttler.WaitAsync(token).ConfigureAwait(false);
-                    var ttx = tx;
-                    var tty = ty;
-                    tasks.Add(Task.Run(async () =>
+                    for (int ty = firstTileY; ty <= lastTileY; ty++)
                     {
-                        try
+                        await throttler.WaitAsync(token).ConfigureAwait(false);
+                        var ttx = tx;
+                        var tty = ty;
+                        tasks.Add(Task.Run(async () =>
                         {
-                            await GetTileAsync(zoom, ttx, tty, token).ConfigureAwait(false);
-                        }
-                        finally
-                        {
-                            throttler.Release();
-                        }
-                    }, token));
+                            try
+                            {
+                                await GetTileAsync(zoom, ttx, tty, token).ConfigureAwait(false);
+                            }
+                            finally
+                            {
+                                throttler.Release();
+                            }
+                        }, token));
+                    }
                 }
-            }
 
-            await Task.WhenAll(tasks).ConfigureAwait(false);
+                await Task.WhenAll(tasks).ConfigureAwait(false);
+            }
+            finally
+            {
+                _preloadSemaphore.Release();
+            }
         }
-        finally
-        {
-            _preloadSemaphore.Release();
-        }
-        }
+
         // DONT CHANGE
         private static Image<Rgba32> ConvertBitmapToImageSharpFast(Bitmap bmp)
         {
@@ -764,7 +778,6 @@ namespace StrategyGame
             bmp.UnlockBits(bmpData);
             return image;
         }
-
 
         private void SaveTileToDisk(int cellSize, int tileX, int tileY, System.Drawing.Bitmap bmp)
         {

--- a/MultiResolutionMapManager.cs
+++ b/MultiResolutionMapManager.cs
@@ -385,19 +385,22 @@ namespace StrategyGame
                                     if (!_tilesBeingLoaded.Contains(key))
                                     {
                                         _tilesBeingLoaded.Add(key);
+                                        var ttx = tx;
+                                        var tty = ty;
+                                        var tileKey = key;
                                         _ = Task.Run(async () =>
                                         {
                                             try
                                             {
-                                                var t = await GetTileAsync(zoom, tx, ty, CancellationToken.None);
+                                                var t = await GetTileAsync(zoom, ttx, tty, CancellationToken.None);
                                                 if (t != null)
-                                                    UploadTileTexture(key, t);
+                                                    UploadTileTexture(tileKey, t);
                                                 triggerRefresh?.Invoke();
                                             }
                                             finally
                                             {
                                                 lock (_tileLoadLock)
-                                                    _tilesBeingLoaded.Remove(key);
+                                                    _tilesBeingLoaded.Remove(tileKey);
                                             }
                                         });
                                     }
@@ -416,6 +419,9 @@ namespace StrategyGame
         private static void OverlayFeatures(SystemDrawing.Bitmap bmp, ZoomLevel level)
         {
             using SystemDrawing.Graphics g = SystemDrawing.Graphics.FromImage(bmp);
+            g.SmoothingMode = SystemDrawing.Drawing2D.SmoothingMode.None;
+            g.PixelOffsetMode = SystemDrawing.Drawing2D.PixelOffsetMode.None;
+            g.CompositingQuality = SystemDrawing.Drawing2D.CompositingQuality.HighSpeed;
             Random rng = new Random(42);
             switch (level)
             {
@@ -443,7 +449,7 @@ namespace StrategyGame
                     break;
                 case ZoomLevel.City:
                     // Add buildings and cars without drawing a full grid of road lines
-                    for (int i = 0; i < 50; i++)
+                    for (int i = 0; i < 20; i++)
                     {
                         int w = rng.Next(4, 8);
                         int h = rng.Next(4, 8);
@@ -451,7 +457,7 @@ namespace StrategyGame
                         int y = rng.Next(bmp.Height - h);
                         g.FillRectangle(SystemDrawing.Brushes.DarkSlateBlue, x, y, w, h);
                     }
-                    for (int i = 0; i < 20; i++)
+                    for (int i = 0; i < 10; i++)
                     {
                         int x = rng.Next(bmp.Width - 3);
                         int y = rng.Next(bmp.Height - 2);

--- a/PerformanceStatsForm.Designer.cs
+++ b/PerformanceStatsForm.Designer.cs
@@ -1,0 +1,34 @@
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace economy_sim
+{
+    public partial class PerformanceStatsForm : Form
+    {
+        private DataGridView dataGridView;
+
+        private void InitializeComponent()
+        {
+            dataGridView = new DataGridView();
+            SuspendLayout();
+
+            dataGridView.Dock = DockStyle.Fill;
+            dataGridView.AllowUserToAddRows = false;
+            dataGridView.AllowUserToDeleteRows = false;
+            dataGridView.ReadOnly = true;
+            dataGridView.RowHeadersVisible = false;
+            dataGridView.ColumnHeadersHeightSizeMode = DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            dataGridView.Columns.Add("Area", "Area");
+            dataGridView.Columns.Add("Count", "Count");
+            dataGridView.Columns.Add("AverageMs", "Avg ms");
+
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(400, 300);
+            Controls.Add(dataGridView);
+            Name = "PerformanceStatsForm";
+            Text = "Performance Stats";
+            ResumeLayout(false);
+        }
+    }
+}

--- a/PerformanceStatsForm.cs
+++ b/PerformanceStatsForm.cs
@@ -6,12 +6,12 @@ namespace economy_sim
 {
     public partial class PerformanceStatsForm : Form
     {
-        private readonly Timer refreshTimer;
+        private readonly System.Windows.Forms.Timer refreshTimer;
 
         public PerformanceStatsForm()
         {
             InitializeComponent();
-            refreshTimer = new Timer { Interval = 1000 };
+            refreshTimer = new System.Windows.Forms.Timer { Interval = 1000 };
             refreshTimer.Tick += (s, e) => UpdateStats();
             refreshTimer.Start();
         }

--- a/PerformanceStatsForm.cs
+++ b/PerformanceStatsForm.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Windows.Forms;
+using System.Linq;
+
+namespace economy_sim
+{
+    public partial class PerformanceStatsForm : Form
+    {
+        private readonly Timer refreshTimer;
+
+        public PerformanceStatsForm()
+        {
+            InitializeComponent();
+            refreshTimer = new Timer { Interval = 1000 };
+            refreshTimer.Tick += (s, e) => UpdateStats();
+            refreshTimer.Start();
+        }
+
+        private void UpdateStats()
+        {
+            var stats = PerformanceTracker.GetStats().ToList();
+            dataGridView.Rows.Clear();
+            foreach (var (area, count, avg) in stats)
+            {
+                dataGridView.Rows.Add(area, count, avg.ToString("0.00"));
+            }
+        }
+
+        protected override void OnFormClosing(FormClosingEventArgs e)
+        {
+            e.Cancel = true;
+            Hide();
+        }
+    }
+}

--- a/PerformanceTracker.cs
+++ b/PerformanceTracker.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace economy_sim
+{
+    public static class PerformanceTracker
+    {
+        private class Stat
+        {
+            public long TotalTicks;
+            public int Count;
+            public double AverageMs => TotalTicks / (double)Count / TimeSpan.TicksPerMillisecond;
+        }
+
+        private static readonly Dictionary<string, Stat> stats = new();
+        private static readonly object lockObj = new();
+
+        public static void Record(string area, TimeSpan duration)
+        {
+            lock (lockObj)
+            {
+                if (!stats.TryGetValue(area, out var stat))
+                {
+                    stat = new Stat();
+                    stats[area] = stat;
+                }
+                stat.TotalTicks += duration.Ticks;
+                stat.Count++;
+            }
+        }
+
+        public static IEnumerable<(string Area, int Count, double AvgMs)> GetStats()
+        {
+            lock (lockObj)
+            {
+                return stats.Select(kv => (kv.Key, kv.Value.Count, kv.Value.AverageMs)).ToList();
+            }
+        }
+
+        public static void Clear()
+        {
+            lock (lockObj)
+            {
+                stats.Clear();
+            }
+        }
+    }
+}

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -10,6 +10,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using SixLabors.ImageSharp.Drawing;
+using System.Diagnostics;
+using economy_sim;
 
 namespace StrategyGame
 {
@@ -32,10 +34,12 @@ namespace StrategyGame
 
         public static async Task<Image<Rgba32>> RenderCityTileAsync(GeoBounds tileBounds, int cellSize)
         {
+            var swTotal = Stopwatch.StartNew();
             try
             {
                 Console.WriteLine($"[Debug] RenderCityTileAsync: Bounds={{MinLon={tileBounds.MinLon},MaxLon={tileBounds.MaxLon},MinLat={tileBounds.MinLat},MaxLat={tileBounds.MaxLat}}}, cellSize={cellSize}");
 
+                var swInit = Stopwatch.StartNew();
                 var img = new Image<Rgba32>(Configuration.Default,
                     MultiResolutionMapManager.TileSizePx,
                     MultiResolutionMapManager.TileSizePx,
@@ -61,18 +65,43 @@ namespace StrategyGame
                     }
                 }
                 var tilePoly = ToPolygon(tileBounds);
+                PerformanceTracker.Record("CityRenderer-Initialization", swInit.Elapsed);
 
+                int urbanAreasProcessed = 0;
+                int urbanAreasSkipped = 0;
+                int totalRoads = 0;
+                int totalBuildings = 0;
+
+                var swUrbanProcessing = Stopwatch.StartNew();
                 foreach (var urban in UrbanAreaManager.UrbanPolygons)
                 {
+                    var swSpatialCheck = Stopwatch.StartNew();
                     if (!urban.EnvelopeInternal.Intersects(tilePoly.EnvelopeInternal) || !urban.Intersects(tilePoly))
+                    {
+                        urbanAreasSkipped++;
+                        PerformanceTracker.Record("CityRenderer-SpatialCheck-Skipped", swSpatialCheck.Elapsed);
                         continue;
+                    }
+                    PerformanceTracker.Record("CityRenderer-SpatialCheck-Passed", swSpatialCheck.Elapsed);
 
+                    var swModel = Stopwatch.StartNew();
                     var model = await RoadNetworkGenerator.GenerateModelAsync(urban, cellSize).ConfigureAwait(false);
                     if (model == null)
+                    {
+                        PerformanceTracker.Record("CityRenderer-ModelGeneration-Failed", swModel.Elapsed);
                         continue;
+                    }
+                    PerformanceTracker.Record("CityRenderer-ModelGeneration", swModel.Elapsed);
+                    urbanAreasProcessed++;
 
+                    var swRoads = Stopwatch.StartNew();
+                    int roadCount = model.RoadNetwork.Count();
+                    totalRoads += roadCount;
                     DrawRoads(img, canvas, model.RoadNetwork, tileBounds);
+                    PerformanceTracker.Record("CityRenderer-RoadDrawing", swRoads.Elapsed);
+                    PerformanceTracker.Record("CityRenderer-RoadCount", TimeSpan.FromMilliseconds(roadCount));
 
+                    var swBuildings = Stopwatch.StartNew();
                     var drawList = new List<(Nts.Polygon Poly, LandUseType Use)>();
                     Parallel.ForEach(model.Buildings, b =>
                     {
@@ -92,7 +121,10 @@ namespace StrategyGame
                             }
                         }
                     });
+                    totalBuildings += drawList.Count;
+                    PerformanceTracker.Record("CityRenderer-BuildingFiltering", swBuildings.Elapsed);
 
+                    var swRendering = Stopwatch.StartNew();
                     if (canvas != null)
                     {
                         foreach (var grp in drawList.GroupBy(d => d.Use))
@@ -116,8 +148,15 @@ namespace StrategyGame
                         foreach (var item in drawList)
                             RenderPolygon(img, null, item.Poly, tileBounds, GetBuildingColor(item.Use));
                     }
+                    PerformanceTracker.Record("CityRenderer-BuildingRendering", swRendering.Elapsed);
                 }
+                PerformanceTracker.Record("CityRenderer-UrbanProcessing", swUrbanProcessing.Elapsed);
+                PerformanceTracker.Record("CityRenderer-UrbanAreasProcessed", TimeSpan.FromMilliseconds(urbanAreasProcessed));
+                PerformanceTracker.Record("CityRenderer-UrbanAreasSkipped", TimeSpan.FromMilliseconds(urbanAreasSkipped));
+                PerformanceTracker.Record("CityRenderer-TotalRoads", TimeSpan.FromMilliseconds(totalRoads));
+                PerformanceTracker.Record("CityRenderer-TotalBuildings", TimeSpan.FromMilliseconds(totalBuildings));
 
+                var swFinalize = Stopwatch.StartNew();
                 if (surface != null)
                 {
                     using var snapshot = surface.Snapshot();
@@ -125,23 +164,28 @@ namespace StrategyGame
                     img.Dispose();
                     img = SixLabors.ImageSharp.Image.Load<Rgba32>(data.AsStream());
                 }
+                PerformanceTracker.Record("CityRenderer-Finalization", swFinalize.Elapsed);
+                PerformanceTracker.Record("CityRenderer-Total", swTotal.Elapsed);
 
                 return img;
             }
             catch (ArgumentException ex)
             {
                 Console.WriteLine($"[Error] RenderCityTileAsync ArgumentException: {ex.Message}");
+                PerformanceTracker.Record("CityRenderer-ArgumentException", swTotal.Elapsed);
                 throw;
             }
             catch (Exception ex)
             {
                 Console.WriteLine($"[Error] RenderCityTileAsync Exception: {ex.Message}");
+                PerformanceTracker.Record("CityRenderer-Exception", swTotal.Elapsed);
                 throw;
             }
         }
 
         private static void DrawRoads(Image<Rgba32> img, SKCanvas? canvas, IEnumerable<LineSegment> roads, GeoBounds bounds)
         {
+            var sw = Stopwatch.StartNew();
             if (canvas != null)
             {
                 foreach (var seg in roads)
@@ -158,6 +202,7 @@ namespace StrategyGame
                     var p2 = ToSKPoint(seg.X2, seg.Y2, bounds);
                     canvas.DrawLine(p1, p2, paint);
                 }
+                PerformanceTracker.Record("DrawRoads-Skia", sw.Elapsed);
             }
             else
             {
@@ -172,6 +217,7 @@ namespace StrategyGame
                         ctx.DrawLine(pen, p1, p2);
                     }
                 });
+                PerformanceTracker.Record("DrawRoads-ImageSharp", sw.Elapsed);
             }
         }
 
@@ -217,11 +263,12 @@ namespace StrategyGame
 
         private static Nts.Polygon ToPolygon(GeoBounds b)
         {
+            var sw = Stopwatch.StartNew();
             if (b.MinLon >= b.MaxLon || b.MinLat >= b.MaxLat)
                 throw new ArgumentException("Invalid GeoBounds: Min must be less than Max.");
 
             var gf = Nts.GeometryFactory.Default;
-            return gf.CreatePolygon(new[]
+            var result = gf.CreatePolygon(new[]
             {
                 new Nts.Coordinate(b.MinLon, b.MinLat),
                 new Nts.Coordinate(b.MaxLon, b.MinLat),
@@ -229,10 +276,13 @@ namespace StrategyGame
                 new Nts.Coordinate(b.MinLon, b.MaxLat),
                 new Nts.Coordinate(b.MinLon, b.MinLat)
             });
+            PerformanceTracker.Record("ToPolygon", sw.Elapsed);
+            return result;
         }
 
         private static void RenderPolygon(Image<Rgba32> img, SKCanvas? canvas, Nts.Polygon poly, GeoBounds bounds, Rgba32 color)
         {
+            var sw = Stopwatch.StartNew();
             if (canvas != null)
             {
                 using var path = new SKPath();
@@ -244,11 +294,13 @@ namespace StrategyGame
                     IsAntialias = true
                 };
                 canvas.DrawPath(path, paint);
+                PerformanceTracker.Record("RenderPolygon-Skia", sw.Elapsed);
             }
             else
             {
                 var coords = poly.ExteriorRing.Coordinates.Select(c => ToPointF(c.X, c.Y, bounds)).ToArray();
                 img.Mutate(ctx => ctx.Fill(color, new Polygon(coords)));
+                PerformanceTracker.Record("RenderPolygon-ImageSharp", sw.Elapsed);
             }
         }
     }

--- a/SkiaBitmapUtil.cs
+++ b/SkiaBitmapUtil.cs
@@ -9,8 +9,14 @@ namespace StrategyGame
     {
         public static SKBitmap ToSKBitmap(Bitmap bmp)
         {
+            if (bmp == null || bmp.Width <= 0 || bmp.Height <= 0)
+                return new SKBitmap(1, 1); // avoid GDI+ errors on invalid input
+
             using var ms = new MemoryStream();
-            bmp.Save(ms, ImageFormat.Png);
+            // Saving as BMP is broadly supported even when libgdiplus is used on
+            // non‑Windows platforms, preventing 'Generic error in GDI+' issues
+            // that sometimes occur with the PNG encoder.
+            bmp.Save(ms, ImageFormat.Bmp);
             ms.Position = 0;
             return SKBitmap.Decode(ms);
         }

--- a/SkiaBitmapUtil.cs
+++ b/SkiaBitmapUtil.cs
@@ -7,18 +7,43 @@ namespace StrategyGame
 {
     internal static class SkiaBitmapUtil
     {
-        public static SKBitmap ToSKBitmap(Bitmap bmp)
+        public static unsafe SKBitmap ToSKBitmap(Bitmap bmp)
         {
             if (bmp == null || bmp.Width <= 0 || bmp.Height <= 0)
-                return new SKBitmap(1, 1); // avoid GDI+ errors on invalid input
+                return new SKBitmap(1, 1);
 
-            using var ms = new MemoryStream();
-            // Saving as BMP is broadly supported even when libgdiplus is used on
-            // non‑Windows platforms, preventing 'Generic error in GDI+' issues
-            // that sometimes occur with the PNG encoder.
-            bmp.Save(ms, ImageFormat.Bmp);
-            ms.Position = 0;
-            return SKBitmap.Decode(ms);
+            Bitmap src = bmp;
+            Bitmap? converted = null;
+            PixelFormat fmt = bmp.PixelFormat;
+            if (fmt != PixelFormat.Format32bppArgb && fmt != PixelFormat.Format32bppPArgb)
+            {
+                converted = new Bitmap(bmp.Width, bmp.Height, PixelFormat.Format32bppArgb);
+                using (var g = Graphics.FromImage(converted))
+                    g.DrawImage(bmp, 0, 0, bmp.Width, bmp.Height);
+                src = converted;
+                fmt = PixelFormat.Format32bppArgb;
+            }
+
+            var rect = new Rectangle(0, 0, src.Width, src.Height);
+            var data = src.LockBits(rect, ImageLockMode.ReadOnly, fmt);
+            try
+            {
+                var info = new SKImageInfo(src.Width, src.Height, SKColorType.Bgra8888, SKAlphaType.Premul);
+                var sk = new SKBitmap(info);
+                byte* dst = (byte*)sk.GetPixels().ToPointer();
+                for (int y = 0; y < info.Height; y++)
+                {
+                    byte* srcRow = (byte*)data.Scan0 + y * data.Stride;
+                    byte* dstRow = dst + y * sk.Info.RowBytes;
+                    Buffer.MemoryCopy(srcRow, dstRow, sk.Info.RowBytes, info.BytesPerPixel * info.Width);
+                }
+                return sk;
+            }
+            finally
+            {
+                src.UnlockBits(data);
+                converted?.Dispose();
+            }
         }
 
         public static Bitmap ToGdiBitmap(SKBitmap skBmp)

--- a/SkiaBitmapUtil.cs
+++ b/SkiaBitmapUtil.cs
@@ -1,0 +1,26 @@
+using SkiaSharp;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+
+namespace StrategyGame
+{
+    internal static class SkiaBitmapUtil
+    {
+        public static SKBitmap ToSKBitmap(Bitmap bmp)
+        {
+            using var ms = new MemoryStream();
+            bmp.Save(ms, ImageFormat.Png);
+            ms.Position = 0;
+            return SKBitmap.Decode(ms);
+        }
+
+        public static Bitmap ToGdiBitmap(SKBitmap skBmp)
+        {
+            using var image = SKImage.FromBitmap(skBmp);
+            using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+            using var ms = data.AsStream();
+            return new Bitmap(ms);
+        }
+    }
+}

--- a/SkiaBitmapUtil.cs
+++ b/SkiaBitmapUtil.cs
@@ -9,39 +9,153 @@ namespace StrategyGame
     {
         public static unsafe SKBitmap ToSKBitmap(Bitmap bmp)
         {
-            if (bmp == null || bmp.Width <= 0 || bmp.Height <= 0)
+            if (bmp == null)
                 return new SKBitmap(1, 1);
+
+            // Thread-safe validation: check if bitmap is accessible before proceeding
+            int width, height;
+            PixelFormat pixelFormat;
+            
+            try
+            {
+                // These property accesses can throw if bitmap is disposed or being modified
+                width = bmp.Width;
+                height = bmp.Height;
+                pixelFormat = bmp.PixelFormat;
+                
+                if (width <= 0 || height <= 0)
+                    return new SKBitmap(1, 1);
+            }
+            catch (ArgumentException)
+            {
+                // Bitmap was disposed or corrupted
+                return new SKBitmap(1, 1);
+            }
+            catch (InvalidOperationException)
+            {
+                // Bitmap is being used by another thread
+                return new SKBitmap(1, 1);
+            }
 
             Bitmap src = bmp;
             Bitmap? converted = null;
-            PixelFormat fmt = bmp.PixelFormat;
+            PixelFormat fmt = pixelFormat;
+            
+            // Convert to compatible format if needed
             if (fmt != PixelFormat.Format32bppArgb && fmt != PixelFormat.Format32bppPArgb)
             {
-                converted = new Bitmap(bmp.Width, bmp.Height, PixelFormat.Format32bppArgb);
-                using (var g = Graphics.FromImage(converted))
-                    g.DrawImage(bmp, 0, 0, bmp.Width, bmp.Height);
-                src = converted;
-                fmt = PixelFormat.Format32bppArgb;
+                try
+                {
+                    converted = new Bitmap(width, height, PixelFormat.Format32bppArgb);
+                    using (var g = Graphics.FromImage(converted))
+                        g.DrawImage(bmp, 0, 0, width, height);
+                    src = converted;
+                    fmt = PixelFormat.Format32bppArgb;
+                }
+                catch (InvalidOperationException)
+                {
+                    // Source bitmap became invalid during conversion
+                    converted?.Dispose();
+                    return new SKBitmap(1, 1);
+                }
+                catch (ArgumentException)
+                {
+                    // Source bitmap was disposed
+                    converted?.Dispose();
+                    return new SKBitmap(1, 1);
+                }
             }
 
             var rect = new Rectangle(0, 0, src.Width, src.Height);
-            var data = src.LockBits(rect, ImageLockMode.ReadOnly, fmt);
+            BitmapData? data = null;
+            
             try
             {
+                // Lock the bitmap for reading - this is the critical section
+                data = src.LockBits(rect, ImageLockMode.ReadOnly, fmt);
+                
+                // Validate the locked data
+                if (data.Scan0 == IntPtr.Zero || data.Stride <= 0)
+                {
+                    return new SKBitmap(1, 1);
+                }
+                
                 var info = new SKImageInfo(src.Width, src.Height, SKColorType.Bgra8888, SKAlphaType.Premul);
                 var sk = new SKBitmap(info);
+                
+                if (sk.GetPixels() == IntPtr.Zero)
+                {
+                    sk.Dispose();
+                    return new SKBitmap(1, 1);
+                }
+                
                 byte* dst = (byte*)sk.GetPixels().ToPointer();
+                
+                // Copy data row by row with validation
                 for (int y = 0; y < info.Height; y++)
                 {
-                    byte* srcRow = (byte*)data.Scan0 + y * data.Stride;
-                    byte* dstRow = dst + y * sk.Info.RowBytes;
-                    Buffer.MemoryCopy(srcRow, dstRow, sk.Info.RowBytes, info.BytesPerPixel * info.Width);
+                    try
+                    {
+                        byte* srcRow = (byte*)data.Scan0 + y * data.Stride;
+                        byte* dstRow = dst + y * sk.Info.RowBytes;
+                        int bytesToCopy = info.BytesPerPixel * info.Width;
+                        
+                        // Ensure we don't copy more bytes than available in either buffer
+                        int maxSrcBytes = data.Stride;
+                        int maxDstBytes = sk.Info.RowBytes;
+                        bytesToCopy = Math.Min(bytesToCopy, Math.Min(maxSrcBytes, maxDstBytes));
+                        
+                        if (bytesToCopy > 0)
+                        {
+                            Buffer.MemoryCopy(srcRow, dstRow, maxDstBytes, bytesToCopy);
+                        }
+                    }
+                    catch (AccessViolationException)
+                    {
+                        // Memory access failed - bitmap may have been disposed during copy
+                        sk.Dispose();
+                        return new SKBitmap(1, 1);
+                    }
                 }
+                
                 return sk;
+            }
+            catch (ArgumentException)
+            {
+                // Bitmap was disposed or parameters were invalid
+                return new SKBitmap(1, 1);
+            }
+            catch (InvalidOperationException)
+            {
+                // Bitmap is being used by another thread or was disposed
+                return new SKBitmap(1, 1);
+            }
+            catch (AccessViolationException)
+            {
+                // Memory access violation during LockBits
+                return new SKBitmap(1, 1);
+            }
+            catch (OutOfMemoryException)
+            {
+                // Not enough memory to lock bitmap
+                return new SKBitmap(1, 1);
             }
             finally
             {
-                src.UnlockBits(data);
+                // Always unlock the bitmap if it was locked
+                if (data != null)
+                {
+                    try
+                    {
+                        src.UnlockBits(data);
+                    }
+                    catch
+                    {
+                        // Ignore errors during unlock - bitmap may already be disposed
+                    }
+                }
+                
+                // Clean up converted bitmap
                 converted?.Dispose();
             }
         }

--- a/SkiaBitmapUtil.cs
+++ b/SkiaBitmapUtil.cs
@@ -2,6 +2,8 @@ using SkiaSharp;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
+using System.Diagnostics;
+using economy_sim;
 
 namespace StrategyGame
 {
@@ -9,8 +11,13 @@ namespace StrategyGame
     {
         public static unsafe SKBitmap ToSKBitmap(Bitmap bmp)
         {
+            var sw = Stopwatch.StartNew();
+            
             if (bmp == null)
+            {
+                PerformanceTracker.Record("ToSKBitmap-NullBitmap", sw.Elapsed);
                 return new SKBitmap(1, 1);
+            }
 
             // Thread-safe validation: check if bitmap is accessible before proceeding
             int width, height;
@@ -24,16 +31,21 @@ namespace StrategyGame
                 pixelFormat = bmp.PixelFormat;
                 
                 if (width <= 0 || height <= 0)
+                {
+                    PerformanceTracker.Record("ToSKBitmap-InvalidDimensions", sw.Elapsed);
                     return new SKBitmap(1, 1);
+                }
             }
             catch (ArgumentException)
             {
                 // Bitmap was disposed or corrupted
+                PerformanceTracker.Record("ToSKBitmap-ArgumentException", sw.Elapsed);
                 return new SKBitmap(1, 1);
             }
             catch (InvalidOperationException)
             {
                 // Bitmap is being used by another thread
+                PerformanceTracker.Record("ToSKBitmap-InvalidOperationException", sw.Elapsed);
                 return new SKBitmap(1, 1);
             }
 
@@ -41,6 +53,7 @@ namespace StrategyGame
             Bitmap? converted = null;
             PixelFormat fmt = pixelFormat;
             
+            var swConversion = Stopwatch.StartNew();
             // Convert to compatible format if needed
             if (fmt != PixelFormat.Format32bppArgb && fmt != PixelFormat.Format32bppPArgb)
             {
@@ -56,19 +69,25 @@ namespace StrategyGame
                 {
                     // Source bitmap became invalid during conversion
                     converted?.Dispose();
+                    PerformanceTracker.Record("ToSKBitmap-ConversionFailed-InvalidOp", swConversion.Elapsed);
+                    PerformanceTracker.Record("ToSKBitmap", sw.Elapsed);
                     return new SKBitmap(1, 1);
                 }
                 catch (ArgumentException)
                 {
                     // Source bitmap was disposed
                     converted?.Dispose();
+                    PerformanceTracker.Record("ToSKBitmap-ConversionFailed-ArgEx", swConversion.Elapsed);
+                    PerformanceTracker.Record("ToSKBitmap", sw.Elapsed);
                     return new SKBitmap(1, 1);
                 }
             }
+            PerformanceTracker.Record("ToSKBitmap-FormatConversion", swConversion.Elapsed);
 
             var rect = new Rectangle(0, 0, src.Width, src.Height);
             BitmapData? data = null;
             
+            var swLock = Stopwatch.StartNew();
             try
             {
                 // Lock the bitmap for reading - this is the critical section
@@ -77,6 +96,8 @@ namespace StrategyGame
                 // Validate the locked data
                 if (data.Scan0 == IntPtr.Zero || data.Stride <= 0)
                 {
+                    PerformanceTracker.Record("ToSKBitmap-InvalidLockedData", swLock.Elapsed);
+                    PerformanceTracker.Record("ToSKBitmap", sw.Elapsed);
                     return new SKBitmap(1, 1);
                 }
                 
@@ -86,11 +107,14 @@ namespace StrategyGame
                 if (sk.GetPixels() == IntPtr.Zero)
                 {
                     sk.Dispose();
+                    PerformanceTracker.Record("ToSKBitmap-SKBitmapAllocationFailed", swLock.Elapsed);
+                    PerformanceTracker.Record("ToSKBitmap", sw.Elapsed);
                     return new SKBitmap(1, 1);
                 }
                 
                 byte* dst = (byte*)sk.GetPixels().ToPointer();
                 
+                var swCopy = Stopwatch.StartNew();
                 // Copy data row by row with validation
                 for (int y = 0; y < info.Height; y++)
                 {
@@ -114,34 +138,46 @@ namespace StrategyGame
                     {
                         // Memory access failed - bitmap may have been disposed during copy
                         sk.Dispose();
+                        PerformanceTracker.Record("ToSKBitmap-MemoryCopyFailed", swCopy.Elapsed);
+                        PerformanceTracker.Record("ToSKBitmap", sw.Elapsed);
                         return new SKBitmap(1, 1);
                     }
                 }
-                
+                PerformanceTracker.Record("ToSKBitmap-MemoryCopy", swCopy.Elapsed);
+                PerformanceTracker.Record("ToSKBitmap", sw.Elapsed);
                 return sk;
             }
             catch (ArgumentException)
             {
                 // Bitmap was disposed or parameters were invalid
+                PerformanceTracker.Record("ToSKBitmap-LockFailed-ArgEx", swLock.Elapsed);
+                PerformanceTracker.Record("ToSKBitmap", sw.Elapsed);
                 return new SKBitmap(1, 1);
             }
             catch (InvalidOperationException)
             {
                 // Bitmap is being used by another thread or was disposed
+                PerformanceTracker.Record("ToSKBitmap-LockFailed-InvalidOp", swLock.Elapsed);
+                PerformanceTracker.Record("ToSKBitmap", sw.Elapsed);
                 return new SKBitmap(1, 1);
             }
             catch (AccessViolationException)
             {
                 // Memory access violation during LockBits
+                PerformanceTracker.Record("ToSKBitmap-LockFailed-AccessViolation", swLock.Elapsed);
+                PerformanceTracker.Record("ToSKBitmap", sw.Elapsed);
                 return new SKBitmap(1, 1);
             }
             catch (OutOfMemoryException)
             {
                 // Not enough memory to lock bitmap
+                PerformanceTracker.Record("ToSKBitmap-LockFailed-OutOfMemory", swLock.Elapsed);
+                PerformanceTracker.Record("ToSKBitmap", sw.Elapsed);
                 return new SKBitmap(1, 1);
             }
             finally
             {
+                var swUnlock = Stopwatch.StartNew();
                 // Always unlock the bitmap if it was locked
                 if (data != null)
                 {
@@ -157,15 +193,19 @@ namespace StrategyGame
                 
                 // Clean up converted bitmap
                 converted?.Dispose();
+                PerformanceTracker.Record("ToSKBitmap-Unlock", swUnlock.Elapsed);
             }
         }
 
         public static Bitmap ToGdiBitmap(SKBitmap skBmp)
         {
+            var sw = Stopwatch.StartNew();
             using var image = SKImage.FromBitmap(skBmp);
             using var data = image.Encode(SKEncodedImageFormat.Png, 100);
             using var ms = data.AsStream();
-            return new Bitmap(ms);
+            var result = new Bitmap(ms);
+            PerformanceTracker.Record("ToGdiBitmap", sw.Elapsed);
+            return result;
         }
     }
 }

--- a/economy sim.csproj
+++ b/economy sim.csproj
@@ -18,6 +18,7 @@
                 <Nullable>enable</Nullable>
                 <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<UseWindowsForms>true</UseWindowsForms>
+		
 		<!-- Disable auto-generated assembly attributes to avoid duplicates -->
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 
@@ -79,6 +80,7 @@
 		<PackageReference Include="NetTopologySuite.IO.ShapeFile" Version="2.1.0" />
 		<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.6" />
 		<PackageReference Include="SkiaSharp" Version="3.119.0" />
+		<PackageReference Include="SkiaSharp.Views.WindowsForms" Version="2.88.3" />
 		<PackageReference Include="System.Buffers" Version="4.5.1" />
 		<PackageReference Include="System.IO.Pipelines" Version="9.0.4" />
 		<PackageReference Include="System.Memory" Version="4.5.5" />


### PR DESCRIPTION
## Summary
- add `SkiaBitmapUtil` helper for conversion between `Bitmap` and `SKBitmap`
- cache Skia textures and render tiles with GPU surfaces
- batch terrain and city tiles together using `CombineMaps`
- update WinForms code to use Skia bitmaps

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0` *(succeeds)*
- `dotnet build "economy sim.sln" -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_6867347f36d4832393daed54932fb4a6