### PR TITLE
Enable WinForms timer for simulation

### DIFF
--- a/MainGame.cs
+++ b/MainGame.cs
@@ -56,6 +56,8 @@ namespace economy_sim
 
         private bool isDetailedDebugMode = false; // Flag to track the current debug mode
 
+        private CancellationTokenSource simCts; // manages the background simulation loop
+
         private int mapZoom = 1;
 
         private SD.Bitmap baseMap;
@@ -201,8 +203,10 @@ namespace economy_sim
             Console.WriteLine($"[Startup] UpdateOrderLists took {sw.Elapsed.TotalSeconds:F2} seconds");
             pictureBox1.Dock = DockStyle.Fill;
             pictureBox1.SizeMode = PictureBoxSizeMode.Normal;
-            timerSim.Tick += TimerSim_Tick;
-            timerSim.Start();
+            timerSim.Tick += TimerSim_Tick; // legacy timer unused
+            //timerSim.Start();
+            simCts = new CancellationTokenSource();
+            _ = RunGameSimulationLoop(simCts.Token);
 
             int buttonsTargetX = 30;
             int buttonsTargetY = 411;
@@ -1319,9 +1323,15 @@ namespace economy_sim
             PerformanceTracker.Record("GameSimulation", swSim.Elapsed);
         }
 
-        // Legacy asynchronous loop previously drove TimerSim_Tick when running
-        // the UI on a dedicated thread. With the built-in WinForms timer
-        // resumed, this method is currently unused.
+        // Run the simulation loop on a background thread so the UI remains responsive
+        private async Task RunGameSimulationLoop(CancellationToken token)
+        {
+            while (!token.IsCancellationRequested)
+            {
+                TimerSim_Tick(this, EventArgs.Empty);
+                await Task.Delay(1000, token);
+            }
+        }
 
         private string FormatValueWithChange(double currentValue, double previousValue, string formatSpecifier, bool calculateDiff, double tolerance = 0.001)
         {
@@ -2011,6 +2021,7 @@ namespace economy_sim
             {
                 DebugLogger.LogDetailedCityData(selectedCity); // Log detailed data for the selected city
             }
+            simCts?.Cancel();
             DebugLogger.FinalizeLog(allCountries); // Pass the list of countries to the logger
             base.OnFormClosing(e);
         }

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -202,9 +202,7 @@ namespace economy_sim
             pictureBox1.Dock = DockStyle.Fill;
             pictureBox1.SizeMode = PictureBoxSizeMode.Normal;
             timerSim.Tick += TimerSim_Tick; // legacy timer unused
-            timerSim.Start();
-            //var simCts = new CancellationTokenSource();
-            //_ = RunGameSimulationLoop(simCts.Token);
+            //timerSim.Start();
 
             int buttonsTargetX = 30;
             int buttonsTargetY = 411;
@@ -1321,7 +1319,7 @@ namespace economy_sim
             PerformanceTracker.Record("GameSimulation", swSim.Elapsed);
         }
 
-        private async Task RunGameSimulationLoop(CancellationToken token)
+        public async Task RunGameSimulationLoop(CancellationToken token)
         {
             while (!token.IsCancellationRequested)
             {

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -203,11 +203,11 @@ namespace economy_sim
             Console.WriteLine($"[Startup] UpdateOrderLists took {sw.Elapsed.TotalSeconds:F2} seconds");
             pictureBox1.Dock = DockStyle.Fill;
             pictureBox1.SizeMode = PictureBoxSizeMode.Normal;
-            timerSim.Tick += TimerSim_Tick; // legacy timer unused
-            //timerSim.Start();
-            simCts = new CancellationTokenSource();
-            // start the simulation loop on a background thread
-            _ = Task.Run(() => RunGameSimulationLoop(simCts.Token));
+            timerSim.Tick += TimerSim_Tick;
+            timerSim.Start(); // fire TimerSim_Tick every second
+            //simCts = new CancellationTokenSource();
+            //// start the simulation loop on a background thread
+            //_ = Task.Run(() => RunGameSimulationLoop(simCts.Token));
 
             int buttonsTargetX = 30;
             int buttonsTargetY = 411;

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -206,7 +206,8 @@ namespace economy_sim
             timerSim.Tick += TimerSim_Tick; // legacy timer unused
             //timerSim.Start();
             simCts = new CancellationTokenSource();
-            _ = RunGameSimulationLoop(simCts.Token);
+            // start the simulation loop on a background thread
+            _ = Task.Run(() => RunGameSimulationLoop(simCts.Token));
 
             int buttonsTargetX = 30;
             int buttonsTargetY = 411;

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -203,11 +203,10 @@ namespace economy_sim
             Console.WriteLine($"[Startup] UpdateOrderLists took {sw.Elapsed.TotalSeconds:F2} seconds");
             pictureBox1.Dock = DockStyle.Fill;
             pictureBox1.SizeMode = PictureBoxSizeMode.Normal;
-            timerSim.Tick += TimerSim_Tick;
-            timerSim.Start(); // fire TimerSim_Tick every second
-            //simCts = new CancellationTokenSource();
-            //// start the simulation loop on a background thread
-            //_ = Task.Run(() => RunGameSimulationLoop(simCts.Token));
+            timerSim.Tick += TimerSim_Tick; // hook but don't start WinForms timer
+            // run the simulation loop on a background thread so the UI remains responsive
+            simCts = new CancellationTokenSource();
+            _ = Task.Run(() => RunGameSimulationLoop(simCts.Token));
 
             int buttonsTargetX = 30;
             int buttonsTargetY = 411;

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -184,6 +184,7 @@ namespace economy_sim
             pictureBox1.MouseDown += PictureBox1_MouseDown;
             pictureBox1.MouseMove += PictureBox1_MouseMove;
             pictureBox1.MouseUp += PictureBox1_MouseUp;
+            pictureBox1.MouseClick += PictureBox1_MouseClick;
             pictureBox1.Paint += PictureBox1_Paint;
 
             sw.Restart();
@@ -2483,6 +2484,68 @@ namespace economy_sim
                 Cursor = Cursors.Default;
                 PreloadMapTiles();
             }
+        }
+
+        private void PictureBox1_MouseClick(object sender, MouseEventArgs e)
+        {
+            if (allCitiesInWorld == null || allCitiesInWorld.Count == 0)
+                return;
+
+            int worldX, worldY;
+            lock (_zoomLock)
+            {
+                worldX = mapViewOrigin.X + e.X;
+                worldY = mapViewOrigin.Y + e.Y;
+            }
+
+            StrategyGame.City closestCity = null;
+            double closestDist = double.MaxValue;
+            foreach (var city in allCitiesInWorld)
+            {
+                double dx = city.X - worldX;
+                double dy = city.Y - worldY;
+                double dist = Math.Sqrt(dx * dx + dy * dy);
+                if (dist < closestDist)
+                {
+                    closestDist = dist;
+                    closestCity = city;
+                }
+            }
+
+            if (closestCity == null || closestDist > 15)
+                return;
+
+            StrategyGame.State parentState = null;
+            StrategyGame.Country parentCountry = null;
+            foreach (var country in allCountries ?? new List<StrategyGame.Country>())
+            {
+                foreach (var state in country.States)
+                {
+                    if (state.Cities.Contains(closestCity))
+                    {
+                        parentCountry = country;
+                        parentState = state;
+                        break;
+                    }
+                }
+                if (parentState != null) break;
+            }
+
+            if (parentCountry == null || parentState == null)
+                return;
+
+            if (comboBoxCountry.SelectedItem == null || comboBoxCountry.SelectedItem.ToString() != parentCountry.Name)
+                comboBoxCountry.SelectedItem = parentCountry.Name;
+
+            if (comboBoxStates.SelectedItem == null || comboBoxStates.SelectedItem.ToString() != parentState.Name)
+                comboBoxStates.SelectedItem = parentState.Name;
+
+            if (comboBoxCities.SelectedItem == null || comboBoxCities.SelectedItem.ToString() != closestCity.Name)
+                comboBoxCities.SelectedItem = closestCity.Name;
+
+            UpdateCountryStats();
+            UpdateStateStats();
+            UpdateCityAndFactoryStats();
         }
 
         private void PictureBox1_Paint(object sender, PaintEventArgs e)

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -202,9 +202,9 @@ namespace economy_sim
             pictureBox1.Dock = DockStyle.Fill;
             pictureBox1.SizeMode = PictureBoxSizeMode.Normal;
             timerSim.Tick += TimerSim_Tick; // legacy timer unused
-            //timerSim.Start();
-            var simCts = new CancellationTokenSource();
-            _ = RunGameSimulationLoop(simCts.Token);
+            timerSim.Start();
+            //var simCts = new CancellationTokenSource();
+            //_ = RunGameSimulationLoop(simCts.Token);
 
             int buttonsTargetX = 30;
             int buttonsTargetY = 411;

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -201,8 +201,8 @@ namespace economy_sim
             Console.WriteLine($"[Startup] UpdateOrderLists took {sw.Elapsed.TotalSeconds:F2} seconds");
             pictureBox1.Dock = DockStyle.Fill;
             pictureBox1.SizeMode = PictureBoxSizeMode.Normal;
-            timerSim.Tick += TimerSim_Tick; // legacy timer unused
-            //timerSim.Start();
+            timerSim.Tick += TimerSim_Tick;
+            timerSim.Start();
 
             int buttonsTargetX = 30;
             int buttonsTargetY = 411;
@@ -1319,14 +1319,9 @@ namespace economy_sim
             PerformanceTracker.Record("GameSimulation", swSim.Elapsed);
         }
 
-        public async Task RunGameSimulationLoop(CancellationToken token)
-        {
-            while (!token.IsCancellationRequested)
-            {
-                TimerSim_Tick(this, EventArgs.Empty);
-                await Task.Delay(1000, token);
-            }
-        }
+        // Legacy asynchronous loop previously drove TimerSim_Tick when running
+        // the UI on a dedicated thread. With the built-in WinForms timer
+        // resumed, this method is currently unused.
 
         private string FormatValueWithChange(double currentValue, double previousValue, string formatSpecifier, bool calculateDiff, double tolerance = 0.001)
         {

--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Windows.Forms;
 
 namespace StrategyGame
@@ -8,9 +9,20 @@ namespace StrategyGame
         [STAThread]
         static void Main()
         {
-            Application.EnableVisualStyles();
-            Application.SetCompatibleTextRenderingDefault(false);
-            Application.Run(new economy_sim.MainGame());
+            var mainGame = new economy_sim.MainGame();
+            var cts = new CancellationTokenSource();
+
+            var uiThread = new Thread(() =>
+            {
+                Application.EnableVisualStyles();
+                Application.SetCompatibleTextRenderingDefault(false);
+                Application.Run(mainGame);
+                cts.Cancel();
+            });
+            uiThread.SetApartmentState(ApartmentState.STA);
+            uiThread.Start();
+
+            mainGame.RunGameSimulationLoop(cts.Token).GetAwaiter().GetResult();
+            uiThread.Join();
         }
-    }
-} 
+    }} 

--- a/Program.cs
+++ b/Program.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading;
 using System.Windows.Forms;
 
 namespace StrategyGame
@@ -9,20 +8,7 @@ namespace StrategyGame
         [STAThread]
         static void Main()
         {
-            var mainGame = new economy_sim.MainGame();
-            var cts = new CancellationTokenSource();
-
-            var uiThread = new Thread(() =>
-            {
-                Application.EnableVisualStyles();
-                Application.SetCompatibleTextRenderingDefault(false);
-                Application.Run(mainGame);
-                cts.Cancel();
-            });
-            uiThread.SetApartmentState(ApartmentState.STA);
-            uiThread.Start();
-
-            mainGame.RunGameSimulationLoop(cts.Token).GetAwaiter().GetResult();
-            uiThread.Join();
-        }
-    }} 
+            Application.EnableVisualStyles();
+            Application.SetCompatibleTextRenderingDefault(false);
+            Application.Run(new economy_sim.MainGame());
+        }    }} 


### PR DESCRIPTION
## Summary
- start `timerSim` to use the built-in WinForms timer
- comment out the async simulation loop

## Testing
- `dotnet restore "economy sim.csproj"` *(fails: Microsoft.NET.Sdk.WindowsDesktop missing)*
- `dotnet build "economy sim.sln" -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet run --project "economy sim.csproj"` *(fails to build)*

------
https://chatgpt.com/codex/tasks/task_e_686e68f64b588323923fa58a34cc930f