### PR TITLE
Fix sim tick loop continuing in background

### DIFF
--- a/MainGame.cs
+++ b/MainGame.cs
@@ -487,7 +487,7 @@ namespace economy_sim
 
                 if (pictureBox1.InvokeRequired)
                 {
-                    pictureBox1.Invoke((Action)setImage);
+                    pictureBox1.BeginInvoke((Action)setImage);
                 }
                 else
                 {
@@ -988,7 +988,14 @@ namespace economy_sim
         {
             var swSim = Stopwatch.StartNew();
             simTurn++;
-            this.Invoke((Action)(() => labelSimTime.Text = $"Turn: {simTurn}"));
+            if (labelSimTime.InvokeRequired)
+            {
+                labelSimTime.BeginInvoke((Action)(() => labelSimTime.Text = $"Turn: {simTurn}"));
+            }
+            else
+            {
+                labelSimTime.Text = $"Turn: {simTurn}";
+            }
 
             StrategyGame.City cityCurrentlySelectedForUI = null;
             this.Invoke((Action)(() => { cityCurrentlySelectedForUI = GetSelectedCity(); }));
@@ -1239,8 +1246,10 @@ namespace economy_sim
             // 4. Refresh UI elements
             // The GetSelectedCity() here will get the same city as cityCurrentlySelectedForUI,
             // but its data has now been updated by the simulation loop.
-            this.Invoke((Action)(() =>
+            if (this.IsHandleCreated)
             {
+                this.BeginInvoke((Action)(() =>
+                {
                 UpdateOrderLists();
                 UpdateCityAndFactoryStats();
                 UpdateMarketStats();
@@ -1258,14 +1267,18 @@ namespace economy_sim
                         factoryStatsForm.UpdateStats(cityCurrentlySelectedForUI);
                     }
                 }
-            }));
+                }));
+            }
             firstTick = false;
 
             // Process end-of-turn for diplomacy
             if (diplomacyManager != null)
             {
                 diplomacyManager.ProcessTurnEnd();
-                this.Invoke((Action)(UpdateDiplomacyTab));
+                if (this.IsHandleCreated)
+                {
+                    this.BeginInvoke((Action)(UpdateDiplomacyTab));
+                }
             }
 
             // Process financial systems and monetary effects
@@ -1276,20 +1289,26 @@ namespace economy_sim
             }
 
             // Refresh finance tab if it's visible so data stays current
-            this.Invoke((Action)(() =>
+            if (this.IsHandleCreated)
             {
-                if (tabControlMain.SelectedTab == tabPageFinance)
+                this.BeginInvoke((Action)(() =>
                 {
-                    UpdateFinanceTab();
-                }
-                if (tabControlMain.SelectedTab == tabPageGovernment)
-                {
-                    UpdateGovernmentTab();
-                }
-            }));
+                    if (tabControlMain.SelectedTab == tabPageFinance)
+                    {
+                        UpdateFinanceTab();
+                    }
+                    if (tabControlMain.SelectedTab == tabPageGovernment)
+                    {
+                        UpdateGovernmentTab();
+                    }
+                }));
+            }
 
             // Update urban area status each tick
-            this.Invoke((Action)(UpdateUrbanAreaStatus));
+            if (this.IsHandleCreated)
+            {
+                this.BeginInvoke((Action)(UpdateUrbanAreaStatus));
+            }
 
             // Process AI trade proposals (temporary simple logic)
             if (diplomacyManager != null && playerCountry != null && random.Next(100) < 20) // 20% chance each turn

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -33,6 +33,7 @@ namespace economy_sim
         private FactoryStatsForm factoryStatsForm;
         private ConstructionForm constructionForm;
         private PerformanceStatsForm performanceStatsForm;
+        private CancellationTokenSource simCts;
         private List<State> states;
         private PlayerRoleManager playerRoleManager;
         private Random random = new Random(); // Add a Random instance for AI and other uses
@@ -203,8 +204,8 @@ namespace economy_sim
             pictureBox1.SizeMode = PictureBoxSizeMode.Normal;
             timerSim.Tick += TimerSim_Tick; // legacy timer unused
             //timerSim.Start();
-            var simCts = new CancellationTokenSource();
-            _ = RunGameSimulationLoop(simCts.Token);
+            simCts = new CancellationTokenSource();
+            _ = Task.Run(() => RunGameSimulationLoop(simCts.Token));
 
             int buttonsTargetX = 30;
             int buttonsTargetY = 411;
@@ -1325,8 +1326,23 @@ namespace economy_sim
         {
             while (!token.IsCancellationRequested)
             {
-                TimerSim_Tick(this, EventArgs.Empty);
-                await Task.Delay(1000, token);
+                try
+                {
+                    TimerSim_Tick(this, EventArgs.Empty);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Simulation tick error: {ex.Message}");
+                }
+
+                try
+                {
+                    await Task.Delay(1000, token);
+                }
+                catch (TaskCanceledException)
+                {
+                    break;
+                }
             }
         }
 
@@ -2013,6 +2029,7 @@ namespace economy_sim
 
         protected override void OnFormClosing(FormClosingEventArgs e)
         {
+            simCts?.Cancel();
             var selectedCity = GetSelectedCity(); // Retrieve the selected city
             if (selectedCity != null)
             {


### PR DESCRIPTION
## Summary
- run the simulation loop on a background thread
- expose `simCts` so the loop can be cancelled on shutdown
- handle errors inside the loop to keep ticking

## Testing
- `dotnet build "economy sim.sln" -v minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e8101e0f08323a55c86550f329eca