### PR TITLE
Add configurable city data generation

### DIFF
--- a/CityGenerationSettingsForm.Designer.cs
+++ b/CityGenerationSettingsForm.Designer.cs
@@ -1,0 +1,61 @@
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace economy_sim
+{
+    public partial class CityGenerationSettingsForm : Form
+    {
+        private CheckedListBox checkedListBoxCountries;
+        private Button buttonGenerate;
+        private Button buttonCancel;
+        private Label labelInfo;
+
+        private void InitializeComponent()
+        {
+            checkedListBoxCountries = new CheckedListBox();
+            buttonGenerate = new Button();
+            buttonCancel = new Button();
+            labelInfo = new Label();
+            SuspendLayout();
+            //
+            // labelInfo
+            //
+            labelInfo.AutoSize = true;
+            labelInfo.Text = "Select countries for city generation:";
+            labelInfo.Location = new Point(12, 9);
+            //
+            // checkedListBoxCountries
+            //
+            checkedListBoxCountries.CheckOnClick = true;
+            checkedListBoxCountries.FormattingEnabled = true;
+            checkedListBoxCountries.Location = new Point(12, 35);
+            checkedListBoxCountries.Size = new Size(220, 184);
+            //
+            // buttonGenerate
+            //
+            buttonGenerate.Text = "Generate";
+            buttonGenerate.Location = new Point(12, 230);
+            buttonGenerate.Click += ButtonGenerate_Click;
+            //
+            // buttonCancel
+            //
+            buttonCancel.Text = "Cancel";
+            buttonCancel.Location = new Point(110, 230);
+            buttonCancel.Click += (s, e) => { DialogResult = DialogResult.Cancel; Close(); };
+            //
+            // CityGenerationSettingsForm
+            //
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(244, 270);
+            Controls.Add(labelInfo);
+            Controls.Add(checkedListBoxCountries);
+            Controls.Add(buttonGenerate);
+            Controls.Add(buttonCancel);
+            Name = "CityGenerationSettingsForm";
+            Text = "City Data Options";
+            ResumeLayout(false);
+            PerformLayout();
+        }
+    }
+}

--- a/CityGenerationSettingsForm.cs
+++ b/CityGenerationSettingsForm.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace economy_sim
+{
+    public partial class CityGenerationSettingsForm : Form
+    {
+        public List<string> SelectedCountries { get; private set; } = new();
+
+        public CityGenerationSettingsForm(IEnumerable<string> countries)
+        {
+            InitializeComponent();
+            foreach (var c in countries)
+            {
+                checkedListBoxCountries.Items.Add(c, true);
+            }
+        }
+
+        private void ButtonGenerate_Click(object sender, EventArgs e)
+        {
+            SelectedCountries = checkedListBoxCountries.CheckedItems.Cast<string>().ToList();
+            DialogResult = DialogResult.OK;
+            Close();
+        }
+    }
+}

--- a/CountryBorderManager.cs
+++ b/CountryBorderManager.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO;
+
+namespace StrategyGame
+{
+    public static class CountryBorderManager
+    {
+        private static readonly Dictionary<string, Geometry> countryPolygons = new();
+
+        private static readonly string RepoRoot =
+            Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "..", "..", ".."));
+        private static readonly string DataDir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+            "data");
+        private static readonly string RepoDataDir = Path.Combine(RepoRoot, "data");
+        private static readonly string DataFileList = Path.Combine(RepoRoot, "DataFileNames");
+        private static readonly Dictionary<string, string> DataFiles = LoadDataFiles();
+
+        public static IEnumerable<string> CountryNames
+        {
+            get
+            {
+                EnsureLoaded();
+                return countryPolygons.Keys;
+            }
+        }
+
+        public static void EnsureLoaded()
+        {
+            if (countryPolygons.Count > 0)
+                return;
+
+            string shp = GetDataFile("ne_10m_admin_0_countries.shp");
+            if (!File.Exists(shp))
+                return;
+
+            var reader = new ShapefileDataReader(shp, GeometryFactory.Default);
+            int nameIndex = -1;
+            var fields = reader.DbaseHeader.Fields;
+            for (int i = 0; i < fields.Length; i++)
+            {
+                var fname = fields[i].Name;
+                if (string.Equals(fname, "ADMIN", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(fname, "NAME", StringComparison.OrdinalIgnoreCase))
+                {
+                    nameIndex = i;
+                    break;
+                }
+            }
+            if (nameIndex == -1)
+                nameIndex = 0;
+
+            while (reader.Read())
+            {
+                string name = reader.GetString(nameIndex);
+                Geometry geom = reader.Geometry;
+                if (geom != null && !countryPolygons.ContainsKey(name))
+                    countryPolygons[name] = geom;
+            }
+        }
+
+        public static IEnumerable<Polygon> FilterUrbanAreasByCountries(IEnumerable<Polygon> areas, IEnumerable<string> countries)
+        {
+            EnsureLoaded();
+            var set = new HashSet<string>(countries);
+            foreach (var area in areas)
+            {
+                var centroid = area.Centroid;
+                foreach (var kvp in countryPolygons)
+                {
+                    if (!set.Contains(kvp.Key))
+                        continue;
+                    if (kvp.Value.Contains(centroid))
+                    {
+                        yield return area;
+                        break;
+                    }
+                }
+            }
+        }
+
+        private static string GetDataFile(string name)
+        {
+            if (DataFiles.TryGetValue(name, out var mapped) && File.Exists(mapped))
+                return mapped;
+
+            string userPath = Path.Combine(DataDir, name);
+            if (File.Exists(userPath))
+                return userPath;
+
+            if (Directory.Exists(DataDir))
+            {
+                var matches = Directory.GetFiles(DataDir, name, SearchOption.AllDirectories);
+                if (matches.Length > 0)
+                    return matches[0];
+            }
+
+            string repoPath = Path.Combine(RepoDataDir, name);
+            if (File.Exists(repoPath))
+                return repoPath;
+
+            if (Directory.Exists(RepoDataDir))
+            {
+                var matches = Directory.GetFiles(RepoDataDir, name, SearchOption.AllDirectories);
+                if (matches.Length > 0)
+                    return matches[0];
+            }
+
+            return userPath;
+        }
+
+        private static Dictionary<string, string> LoadDataFiles()
+        {
+            var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (File.Exists(DataFileList))
+            {
+                foreach (var line in File.ReadAllLines(DataFileList))
+                {
+                    var trimmed = line.Trim();
+                    if (string.IsNullOrEmpty(trimmed) || trimmed.StartsWith("#") || trimmed.StartsWith("files"))
+                        continue;
+
+                    string userPath = Path.Combine(DataDir, trimmed);
+                    if (File.Exists(userPath))
+                    {
+                        dict[trimmed] = userPath;
+                    }
+                    else
+                    {
+                        dict[trimmed] = Path.Combine(RepoDataDir, trimmed);
+                    }
+                }
+            }
+            return dict;
+        }
+    }
+}

--- a/CountryBorderManager.cs
+++ b/CountryBorderManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.Json;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.IO;
 
@@ -9,6 +10,7 @@ namespace StrategyGame
     public static class CountryBorderManager
     {
         private static readonly Dictionary<string, Geometry> countryPolygons = new();
+        private static readonly List<string> countryNames = new();
 
         private static readonly string RepoRoot =
             Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "..", "..", ".."));
@@ -24,41 +26,63 @@ namespace StrategyGame
             get
             {
                 EnsureLoaded();
-                return countryPolygons.Keys;
+                return countryNames;
             }
         }
 
         public static void EnsureLoaded()
         {
-            if (countryPolygons.Count > 0)
+            if (countryNames.Count > 0 || countryPolygons.Count > 0)
                 return;
 
             string shp = GetDataFile("ne_10m_admin_0_countries.shp");
-            if (!File.Exists(shp))
-                return;
-
-            var reader = new ShapefileDataReader(shp, GeometryFactory.Default);
-            int nameIndex = -1;
-            var fields = reader.DbaseHeader.Fields;
-            for (int i = 0; i < fields.Length; i++)
+            if (File.Exists(shp))
             {
-                var fname = fields[i].Name;
-                if (string.Equals(fname, "ADMIN", StringComparison.OrdinalIgnoreCase) ||
-                    string.Equals(fname, "NAME", StringComparison.OrdinalIgnoreCase))
+                var reader = new ShapefileDataReader(shp, GeometryFactory.Default);
+                int nameIndex = -1;
+                var fields = reader.DbaseHeader.Fields;
+                for (int i = 0; i < fields.Length; i++)
                 {
-                    nameIndex = i;
-                    break;
+                    var fname = fields[i].Name;
+                    if (string.Equals(fname, "ADMIN", StringComparison.OrdinalIgnoreCase) ||
+                        string.Equals(fname, "NAME", StringComparison.OrdinalIgnoreCase))
+                    {
+                        nameIndex = i;
+                        break;
+                    }
                 }
-            }
-            if (nameIndex == -1)
-                nameIndex = 0;
+                if (nameIndex == -1)
+                    nameIndex = 0;
 
-            while (reader.Read())
+                while (reader.Read())
+                {
+                    string name = reader.GetString(nameIndex);
+                    Geometry geom = reader.Geometry;
+                    if (geom != null && !countryPolygons.ContainsKey(name))
+                    {
+                        countryPolygons[name] = geom;
+                        countryNames.Add(name);
+                    }
+                }
+                return;
+            }
+
+            // Fallback: if shapefile missing, try world_setup.json for names
+            string setupPath = Path.Combine(RepoRoot, "world_setup.json");
+            if (File.Exists(setupPath))
             {
-                string name = reader.GetString(nameIndex);
-                Geometry geom = reader.Geometry;
-                if (geom != null && !countryPolygons.ContainsKey(name))
-                    countryPolygons[name] = geom;
+                try
+                {
+                    using var doc = JsonDocument.Parse(File.ReadAllText(setupPath));
+                    foreach (var c in doc.RootElement.GetProperty("Countries").EnumerateArray())
+                    {
+                        if (c.TryGetProperty("Name", out var n))
+                        {
+                            countryNames.Add(n.GetString());
+                        }
+                    }
+                }
+                catch { }
             }
         }
 
@@ -66,6 +90,12 @@ namespace StrategyGame
         {
             EnsureLoaded();
             var set = new HashSet<string>(countries);
+            if (countryPolygons.Count == 0)
+            {
+                foreach (var a in areas)
+                    yield return a;
+                yield break;
+            }
             foreach (var area in areas)
             {
                 var centroid = area.Centroid;

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -2227,9 +2227,14 @@ namespace economy_sim
 
             if (missing.Count > 0)
             {
-                var result = MessageBox.Show($"{missing.Count} urban areas are missing procedural data. Generate now?", "Generate Missing City Data?", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
-                if (result == DialogResult.Yes)
-                    Task.Run(() => GenerateCityDataFor(missing));
+                StrategyGame.CountryBorderManager.EnsureLoaded();
+                using var form = new CityGenerationSettingsForm(StrategyGame.CountryBorderManager.CountryNames);
+                if (form.ShowDialog() == DialogResult.OK)
+                {
+                    var filtered = StrategyGame.CountryBorderManager.FilterUrbanAreasByCountries(missing, form.SelectedCountries).ToList();
+                    if (filtered.Count > 0)
+                        Task.Run(() => GenerateCityDataFor(filtered));
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- replace startup message box with a configuration form for city data generation
- add `CountryBorderManager` to load country borders from Natural Earth shapefile
- add `CityGenerationSettingsForm` to allow choosing which countries to generate
- use selected countries to filter missing urban areas

## Testing
- `dotnet build "economy sim.sln" -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870ec760ff48323b1f9860a48cc40e5