### PR TITLE
Optimize parcel generation and add spatial index

### DIFF
--- a/CityGeneration.cs
+++ b/CityGeneration.cs
@@ -82,10 +82,7 @@ namespace StrategyGame
             {
                 if (geom is Nts.Polygon poly && poly.IsValid && poly.Area > 1e-9)
                 {
-                    if (poly.Area > 0.0001)
-                        RecursiveOBBSplitting(poly, parcels, 0);
-                    else
-                        parcels.Add(new Parcel { Shape = poly });
+                    SubdividePolygon(poly, parcels);
                 }
             }
 
@@ -93,55 +90,47 @@ namespace StrategyGame
             return parcels;
         }
 
-        private static void RecursiveOBBSplitting(Nts.Polygon poly, List<Parcel> output, int depth)
+        private static void SubdividePolygon(Nts.Polygon poly, List<Parcel> output)
         {
-            const double MinArea = 0.00005;
-            const int MaxDepth = 4;
-
-            if (poly.Area < MinArea || depth > MaxDepth)
+            const double DesiredParcelArea = 0.0001;
+            if (poly.Area < DesiredParcelArea * 1.5)
             {
-                if (poly.IsValid && poly.Area > 1e-9)
-                    output.Add(new Parcel { Shape = poly });
+                output.Add(new Parcel { Shape = poly });
                 return;
             }
 
-            var env = poly.EnvelopeInternal;
-            bool splitVertical = env.Width > env.Height;
+            var envelope = poly.EnvelopeInternal;
+            int xSplits = (int)Math.Max(1, Math.Round(envelope.Width / Math.Sqrt(DesiredParcelArea)));
+            int ySplits = (int)Math.Max(1, Math.Round(envelope.Height / Math.Sqrt(DesiredParcelArea)));
+
+            double dx = envelope.Width / xSplits;
+            double dy = envelope.Height / ySplits;
+
             var gf = Nts.GeometryFactory.Default;
-
-            try
+            for (int i = 0; i < xSplits; i++)
             {
-                Nts.Geometry splitLine;
-                if (splitVertical)
+                for (int j = 0; j < ySplits; j++)
                 {
-                    double midX = env.MinX + env.Width / 2;
-                    splitLine = gf.CreateLineString(new[] { new Nts.Coordinate(midX, env.MinY), new Nts.Coordinate(midX, env.MaxY) });
-                }
-                else
-                {
-                    double midY = env.MinY + env.Height / 2;
-                    splitLine = gf.CreateLineString(new[] { new Nts.Coordinate(env.MinX, midY), new Nts.Coordinate(env.MaxX, midY) });
-                }
+                    var subEnvelope = new Nts.Envelope(
+                        envelope.MinX + i * dx,
+                        envelope.MinX + (i + 1) * dx,
+                        envelope.MinY + j * dy,
+                        envelope.MinY + (j + 1) * dy);
 
-                var splitPolygons = poly.Difference(splitLine);
-                if (splitPolygons is Nts.MultiPolygon multiPoly)
-                {
-                    foreach (var geom in multiPoly.Geometries)
+                    try
                     {
-                        if (geom is Nts.Polygon splitPoly && splitPoly.IsValid)
-                            RecursiveOBBSplitting(splitPoly, output, depth + 1);
+                        var envPoly = gf.ToGeometry(subEnvelope);
+                        var parcelGeom = poly.Intersection(envPoly);
+                        if (parcelGeom is Nts.Polygon p && !p.IsEmpty)
+                        {
+                            output.Add(new Parcel { Shape = p });
+                        }
+                    }
+                    catch
+                    {
+                        // Intersection can fail, just skip this sub-parcel
                     }
                 }
-                else
-                {
-                    if (poly.IsValid && poly.Area > 1e-9)
-                        output.Add(new Parcel { Shape = poly });
-                }
-            }
-            catch
-            {
-                if (poly.IsValid && poly.Area > 1e-9)
-                    output.Add(new Parcel { Shape = poly });
             }
         }
     }

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -1336,25 +1336,44 @@ namespace economy_sim
                 var swSim = Stopwatch.StartNew();
                 simTurn++;
 
-                // All simulation logic should happen here, off the UI thread.
-                // --- Corporation AI Update Phase ---
-                if (Market.AllCorporations != null && allCitiesInWorld != null && FactoryBlueprints.AllBlueprints.Any())
+                int citiesPerTick = 20;
+                int startIndex = ((simTurn - 1) * citiesPerTick) % (allCitiesInWorld?.Count ?? 1);
+                var citiesToUpdate = allCitiesInWorld?.Skip(startIndex).Take(citiesPerTick).ToList() ?? new List<StrategyGame.City>();
+                if (citiesToUpdate.Count == 0 && allCitiesInWorld != null)
+                    citiesToUpdate = allCitiesInWorld.Take(citiesPerTick).ToList();
+
+                await Task.Run(() =>
                 {
-                    List<Good> goodPrototypes = Market.GoodDefinitions.Values.ToList();
-                    foreach (var corp in Market.AllCorporations)
+                    if (Market.AllCorporations != null && allCitiesInWorld != null && FactoryBlueprints.AllBlueprints.Any())
                     {
-                        if (!corp.IsPlayerControlled)
+                        List<Good> goodPrototypes = Market.GoodDefinitions.Values.ToList();
+                        foreach (var corp in Market.AllCorporations)
                         {
-                            corp.UpdateAI(this.allCitiesInWorld, goodPrototypes, random);
+                            if (!corp.IsPlayerControlled)
+                                corp.UpdateAI(allCitiesInWorld, goodPrototypes, random);
                         }
                     }
-                }
 
-                // --- City Economies Update Phase ---
-                // ... (and all other simulation logic from TimerSim_Tick) ...
+                    foreach (var city in citiesToUpdate)
+                    {
+                        Market.ResetCitySupplyDemand(city);
+                        foreach (var factory in city.Factories)
+                            factory.Produce(city.Stockpile, city);
+                        StrategyGame.Economy.UpdateCityEconomy(city);
+                        city.ProgressConstruction();
+                        Market.UpdateCityPrices(city);
+                    }
 
-                // --- UI Update Phase ---
-                // Marshal all UI updates to the UI thread.
+                    if (allCitiesInWorld != null && allCitiesInWorld.Count > 1)
+                        Market.ResolveInterCityTrade(allCitiesInWorld, 0.1);
+
+                    tradeRouteManager?.UpdateAllRoutes();
+                    enhancedTradeManager?.ProcessTurnEnd();
+
+                    if (globalMarket != null && allCountries != null && allCitiesInWorld != null)
+                        globalMarket.UpdateGlobalMarket(allCitiesInWorld, allCountries, tradeRouteManager, enhancedTradeManager);
+                }, token);
+
                 this.Invoke((Action)(() =>
                 {
                     labelSimTime.Text = $"Turn: {simTurn}";
@@ -1368,22 +1387,14 @@ namespace economy_sim
                     if (cityCurrentlySelectedForUI != null)
                     {
                         if (popStatsForm != null && popStatsForm.Visible)
-                        {
                             popStatsForm.UpdateStats(cityCurrentlySelectedForUI);
-                        }
                         if (factoryStatsForm != null && factoryStatsForm.Visible)
-                        {
                             factoryStatsForm.UpdateStats(cityCurrentlySelectedForUI);
-                        }
                     }
                     if (tabControlMain.SelectedTab == tabPageFinance)
-                    {
                         UpdateFinanceTab();
-                    }
                     if (tabControlMain.SelectedTab == tabPageGovernment)
-                    {
                         UpdateGovernmentTab();
-                    }
                 }));
 
                 firstTick = false;
@@ -1391,11 +1402,11 @@ namespace economy_sim
 
                 try
                 {
-                    await Task.Delay(1000, token); // The delay between ticks.
+                    await Task.Delay(100, token);
                 }
                 catch (TaskCanceledException)
                 {
-                    break; // Exit the loop if the task is canceled.
+                    break;
                 }
             }
         }

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -73,7 +73,8 @@ namespace StrategyGame
                 int totalBuildings = 0;
 
                 var swUrbanProcessing = Stopwatch.StartNew();
-                foreach (var urban in UrbanAreaManager.UrbanPolygons)
+                var relevantUrbanAreas = UrbanAreaManager.Query(tileBounds);
+                foreach (var urban in relevantUrbanAreas)
                 {
                     var swSpatialCheck = Stopwatch.StartNew();
                     if (!urban.EnvelopeInternal.Intersects(tilePoly.EnvelopeInternal) || !urban.Intersects(tilePoly))

--- a/UrbanAreaManager.cs
+++ b/UrbanAreaManager.cs
@@ -1,5 +1,6 @@
 using Nts = NetTopologySuite.Geometries;
 using NetTopologySuite.IO;
+using NetTopologySuite.Index.Strtree;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -11,6 +12,7 @@ namespace StrategyGame
     public static class UrbanAreaManager
     {
         public static List<Nts.Polygon> UrbanPolygons { get; private set; } = new();
+        private static STRtree<Nts.Polygon>? spatialIndex;
 
         private static readonly string RepoRoot =
             Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "..", "..", ".."));
@@ -45,6 +47,12 @@ namespace StrategyGame
                     UrbanPolygons.Add(p);
                 }
             }
+
+            spatialIndex = new STRtree<Nts.Polygon>();
+            foreach (var poly in UrbanPolygons)
+            {
+                spatialIndex.Insert(poly.EnvelopeInternal, poly);
+            }
         }
 
         public static void PrecomputeAllRoadNetworks()
@@ -59,6 +67,15 @@ namespace StrategyGame
 
             sw.Stop();
             Debug.WriteLine($"Finished pre-computing all road networks in {sw.Elapsed.TotalSeconds:F2} seconds.");
+        }
+
+        public static List<Nts.Polygon> Query(GeoBounds bounds)
+        {
+            if (spatialIndex == null)
+                return UrbanPolygons;
+
+            var env = new Nts.Envelope(bounds.MinLon, bounds.MaxLon, bounds.MinLat, bounds.MaxLat);
+            return spatialIndex.Query(env).Cast<Nts.Polygon>().ToList();
         }
 
         private static string GetDataFile(string name)

--- a/WorldDataGenerator.cs
+++ b/WorldDataGenerator.cs
@@ -967,9 +967,9 @@ new List<CountryTemplate>
                     {
                         Name = stateName,
                         TaxRate = Math.Round(RandomBetween(rnd, 0.04, Math.Max(countryData.TaxRate - 0.01, 0.04)), 2),
-                        StateExpenses = rnd.Next(50000, numStatesPerCountry > 0 ? countryData.NationalExpenses / (numStatesPerCountry + 2) : 50001),
+                        StateExpenses = rnd.Next(50000, numStatesPerCountry > 0 ? (int)(countryData.NationalExpenses / (numStatesPerCountry + 2)) : 50001),
                         InitialPopulation = 0,
-                        InitialBudget = rnd.Next(500000, numStatesPerCountry > 0 ? countryData.InitialBudget / (numStatesPerCountry + 2) : 500001),
+                        InitialBudget = rnd.Next(500000, numStatesPerCountry > 0 ? (int)(countryData.InitialBudget / (numStatesPerCountry + 2)) : 500001),
                         Cities = new List<CityData>()
                     };
 
@@ -1005,9 +1005,9 @@ new List<CountryTemplate>
                         {
                             Name = cityName,
                             InitialPopulation = cityPop,
-                            InitialBudget = rnd.Next(50000, numCitiesToGenerate > 0 ? stateData.InitialBudget / (numCitiesToGenerate + 1) : 50001),
+                            InitialBudget = rnd.Next(50000, numCitiesToGenerate > 0 ? (int)(stateData.InitialBudget / (numCitiesToGenerate + 1)) : 50001),
                             TaxRate = Math.Round(RandomBetween(rnd, 0.02, Math.Max(stateData.TaxRate - 0.01, 0.02)), 2),
-                            CityExpenses = rnd.Next(10000, Math.Max(stateData.StateExpenses / (numCitiesToGenerate + 1), 10000) + 1),
+                            CityExpenses = rnd.Next(10000, (int)Math.Max(stateData.StateExpenses / (numCitiesToGenerate + 1), 10000) + 1),
                             InitialFactories = new List<InitialFactoryData>()
                         };
 


### PR DESCRIPTION
## Summary
- simplify parcel generation using grid subdivision
- build STRtree index for urban areas and query it during rendering
- fetch relevant polygons for each city tile
- process city updates in small batches for smoother simulation

## Testing
- `apt-get install -y dotnet-sdk-8.0` *(passed)*
- `dotnet build "economy sim.sln" -v minimal` *(failed: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_68721b8d85dc8323ab4c5d05e20fc94f