### PR TITLE
Improve city model loading and caching

### DIFF
--- a/CityDataModel.cs
+++ b/CityDataModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Nts = NetTopologySuite.Geometries;
 
 namespace StrategyGame
 {
@@ -7,6 +8,7 @@ namespace StrategyGame
     {
         public Guid Id { get; set; }
         public List<LineSegment> RoadNetwork { get; set; } = new();
+        public List<Nts.Polygon> RawBlocks { get; set; } = new();
         public List<Parcel> Parcels { get; set; } = new();
         public List<Building> Buildings { get; set; } = new();
     }

--- a/CityGeneration.cs
+++ b/CityGeneration.cs
@@ -56,6 +56,11 @@ namespace StrategyGame
     {
         public static List<Parcel> GenerateParcels(CityDataModel model)
         {
+            if (model.RawBlocks != null && model.RawBlocks.Count > 0)
+            {
+                return GenerateParcelsFromBlocks(model.RawBlocks);
+            }
+
             var parcels = new List<Parcel>();
             if (model.RoadNetwork == null || !model.RoadNetwork.Any())
                 return parcels;
@@ -78,15 +83,26 @@ namespace StrategyGame
             var rawPolys = polygonizer.GetPolygons();
             Debug.WriteLine($"[ParcelGenerator] Polygonizer produced {rawPolys.Count} raw polygons");
 
-            foreach (var geom in rawPolys)
-            {
-                if (geom is Nts.Polygon poly && poly.IsValid && poly.Area > 1e-9)
-                {
-                    SubdividePolygon(poly, parcels);
-                }
-            }
+            var blocks = rawPolys.OfType<Nts.Polygon>()
+                .Where(p => p.IsValid && p.Area > 1e-9)
+                .ToList();
+
+            model.RawBlocks = blocks;
+
+            parcels = GenerateParcelsFromBlocks(blocks);
 
             Debug.WriteLine($"[ParcelGenerator] Final parcel count: {parcels.Count}");
+            return parcels;
+        }
+
+        public static List<Parcel> GenerateParcelsFromBlocks(List<Nts.Polygon> blocks)
+        {
+            var parcels = new List<Parcel>();
+            foreach (var block in blocks)
+            {
+                if (block.IsValid && !block.IsEmpty && block.Area > 1e-9)
+                    SubdividePolygon(block, parcels);
+            }
             return parcels;
         }
 

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -32,7 +32,7 @@ namespace StrategyGame
             }
         }
 
-        public static async Task<Image<Rgba32>> RenderCityTileAsync(GeoBounds tileBounds, int cellSize)
+        public static Task<Image<Rgba32>> RenderCityTileAsync(GeoBounds tileBounds, int cellSize)
         {
             var swTotal = Stopwatch.StartNew();
             try
@@ -86,7 +86,14 @@ namespace StrategyGame
                     PerformanceTracker.Record("CityRenderer-SpatialCheck-Passed", swSpatialCheck.Elapsed);
 
                     var swModel = Stopwatch.StartNew();
-                    var model = await RoadNetworkGenerator.GenerateModelAsync(urban, cellSize).ConfigureAwait(false);
+                    var modelId = RoadNetworkGenerator.GetCityDataModelId(urban);
+                    if (!modelId.HasValue)
+                    {
+                        PerformanceTracker.Record("CityRenderer-ModelGeneration-Failed", swModel.Elapsed);
+                        continue;
+                    }
+
+                    var model = RoadNetworkGenerator.LoadCityDataModel(modelId.Value);
                     if (model == null)
                     {
                         PerformanceTracker.Record("CityRenderer-ModelGeneration-Failed", swModel.Elapsed);
@@ -168,7 +175,7 @@ namespace StrategyGame
                 PerformanceTracker.Record("CityRenderer-Finalization", swFinalize.Elapsed);
                 PerformanceTracker.Record("CityRenderer-Total", swTotal.Elapsed);
 
-                return img;
+                return Task.FromResult(img);
             }
             catch (ArgumentException ex)
             {

--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -69,7 +69,8 @@ namespace StrategyGame
                     new LineSegment(s.X, s.Y, e.X, e.Y, tuple.Type)))
                 .ToList();
 
-            result.Parcels = ParcelGenerator.GenerateParcels(result);
+            result.RawBlocks = PolygonizeRoadNetwork(result.RoadNetwork);
+            result.Parcels = ParcelGenerator.GenerateParcelsFromBlocks(result.RawBlocks);
             LandUseSimulator.Run(result);
             result.Buildings = BuildingGenerator.GenerateBuildings(result);
             BuildingRefiner.RefineBuildings(result);
@@ -229,6 +230,28 @@ namespace StrategyGame
             return tree;
         }
 
+        private static List<Nts.Polygon> PolygonizeRoadNetwork(List<LineSegment> roads)
+        {
+            var gf = Nts.GeometryFactory.Default;
+            var lineStrings = roads.Select(seg =>
+                gf.CreateLineString(new[]
+                {
+                    new Nts.Coordinate(seg.X1, seg.Y1),
+                    new Nts.Coordinate(seg.X2, seg.Y2)
+                })).ToArray();
+
+            if (lineStrings.Length == 0)
+                return new List<Nts.Polygon>();
+
+            var nodedLines = UnaryUnionOp.Union(lineStrings);
+            var polygonizer = new Polygonizer();
+            polygonizer.Add(nodedLines);
+            var rawPolys = polygonizer.GetPolygons();
+            return rawPolys.OfType<Nts.Polygon>()
+                .Where(p => p.IsValid && p.Area > 1e-9)
+                .ToList();
+        }
+
         private static string ComputeHash(Nts.Polygon area)
         {
             var e = area.EnvelopeInternal;
@@ -362,6 +385,25 @@ namespace StrategyGame
             }
             
             return (inMemoryCount, diskCount, totalUnique);
+        }
+
+        public static CityDataModel? LoadCityDataModel(Guid id)
+        {
+            string cacheDir = GetCacheDir();
+            string modelPath = Path.Combine(cacheDir, $"{id}.json");
+            if (!File.Exists(modelPath))
+                return null;
+
+            try
+            {
+                string json = File.ReadAllText(modelPath);
+                return JsonSerializer.Deserialize<CityDataModel>(json, jsonOptions);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[Error] Failed to load CityDataModel {id}: {ex.Message}");
+                return null;
+            }
         }
     }
 }

--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -1,6 +1,7 @@
 ﻿using Nts = NetTopologySuite.Geometries;
 using NetTopologySuite.Geometries.Prepared;
 using NetTopologySuite.Operation.Union;
+using NetTopologySuite.Operation.Polygonize;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;


### PR DESCRIPTION
## Summary
- add RawBlocks polygon cache to `CityDataModel`
- refactor `ParcelGenerator` to use cached blocks and expose `GenerateParcelsFromBlocks`
- polygonize roads once in `RoadNetworkGenerator` and load models from disk
- update `ProceduralCityRenderer` to load pre-generated models rather than generating them each frame

## Testing
- `dotnet build "economy sim.sln" -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_687229ad2ca48323adff99521a94ac80