### PR TITLE
Improve road generation scaling

### DIFF
--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -130,7 +130,9 @@ namespace StrategyGame
         private static List<Nts.LineString> GenerateLocalRoads(Nts.Polygon area, List<Nts.LineString> highways)
         {
             const double roadSegmentLength = 0.005;
-            const int maxIterations = 500;
+            // Make the iteration limit proportional to the area. Ensures small
+            // towns generate quickly while large cities have room to expand.
+            int maxIterations = (int)Math.Max(500, area.Area * 5000000);
             var gf = Nts.GeometryFactory.Default;
             var random = new Random();
             var roadNetwork = new List<Nts.LineString>(highways);
@@ -149,7 +151,25 @@ namespace StrategyGame
             }
             if (queue.Count == 0 && area.EnvelopeInternal.Width > 0)
             {
+                // Keep the original centroid seed
                 queue.Enqueue((area.Centroid.Coordinate, random.NextDouble() * 2 * Math.PI));
+
+                // Add additional random seeds for large polygons to accelerate generation
+                if (area.Area > 0.001)
+                {
+                    var envelope = area.EnvelopeInternal;
+                    for (int i = 0; i < 5; i++)
+                    {
+                        var randX = envelope.MinX + random.NextDouble() * envelope.Width;
+                        var randY = envelope.MinY + random.NextDouble() * envelope.Height;
+                        var randomPoint = new Nts.Coordinate(randX, randY);
+
+                        if (area.Contains(gf.CreatePoint(randomPoint)))
+                        {
+                            queue.Enqueue((randomPoint, random.NextDouble() * 2 * Math.PI));
+                        }
+                    }
+                }
             }
 
 

--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -142,11 +142,17 @@ namespace StrategyGame
             // Seed the L-system from points on the highways
             foreach (var highway in highways)
             {
+                if (highway.NumPoints < 2)
+                    continue;
                 for (double i = 0.2; i < 1.0; i += 0.3)
                 {
-                    var pt = highway.GetCoordinateN((int)(highway.NumPoints * i));
-                    queue.Enqueue((pt, Math.Atan2(highway.EndPoint.Y - highway.StartPoint.Y, highway.EndPoint.X - highway.StartPoint.X) + Math.PI / 2));
-                    queue.Enqueue((pt, Math.Atan2(highway.EndPoint.Y - highway.StartPoint.Y, highway.EndPoint.X - highway.StartPoint.X) - Math.PI / 2));
+                    int idx = (int)Math.Min(highway.NumPoints - 1, Math.Round(highway.NumPoints * i));
+                    var pt = highway.GetCoordinateN(idx);
+                    double baseAngle = Math.Atan2(
+                        highway.EndPoint.Y - highway.StartPoint.Y,
+                        highway.EndPoint.X - highway.StartPoint.X);
+                    queue.Enqueue((pt, baseAngle + Math.PI / 2));
+                    queue.Enqueue((pt, baseAngle - Math.PI / 2));
                 }
             }
             if (queue.Count == 0 && area.EnvelopeInternal.Width > 0)


### PR DESCRIPTION
## Summary
- scale local road generation iterations with polygon area
- add multiple random seed points for large polygons to speed up generation

## Testing
- `dotnet build "economy sim.sln"` *(fails: Could not resolve SDK 'Microsoft.NET.Sdk.WindowsDesktop')*

------
https://chatgpt.com/codex/tasks/task_e_6875c35d91488323b56fc3513560238d