### PR TITLE
Fix debug counter paths for binary city models

### DIFF
--- a/CityGeneration.cs
+++ b/CityGeneration.cs
@@ -108,44 +108,74 @@ namespace StrategyGame
 
         private static void SubdividePolygon(Nts.Polygon poly, List<Parcel> output)
         {
-            const double DesiredParcelArea = 0.0001;
-            if (poly.Area < DesiredParcelArea * 1.5)
+            const double MinParcelArea = 0.00005;
+            RecursiveSplit(poly, output, MinParcelArea);
+        }
+
+        private static void RecursiveSplit(Nts.Polygon poly, List<Parcel> output, double minArea)
+        {
+            var envelope = poly.EnvelopeInternal;
+
+            // stop if polygon is invalid or essentially degenerate
+            if (!poly.IsValid || poly.Area < 1e-9 || envelope.Width < 1e-9 || envelope.Height < 1e-9)
             {
-                output.Add(new Parcel { Shape = poly });
+                if (poly.IsValid && !poly.IsEmpty)
+                    output.Add(new Parcel { Shape = poly });
                 return;
             }
 
-            var envelope = poly.EnvelopeInternal;
-            int xSplits = (int)Math.Max(1, Math.Round(envelope.Width / Math.Sqrt(DesiredParcelArea)));
-            int ySplits = (int)Math.Max(1, Math.Round(envelope.Height / Math.Sqrt(DesiredParcelArea)));
-
-            double dx = envelope.Width / xSplits;
-            double dy = envelope.Height / ySplits;
-
-            var gf = Nts.GeometryFactory.Default;
-            for (int i = 0; i < xSplits; i++)
+            if (poly.Area < minArea * 1.5)
             {
-                for (int j = 0; j < ySplits; j++)
-                {
-                    var subEnvelope = new Nts.Envelope(
-                        envelope.MinX + i * dx,
-                        envelope.MinX + (i + 1) * dx,
-                        envelope.MinY + j * dy,
-                        envelope.MinY + (j + 1) * dy);
+                if (poly.IsValid && !poly.IsEmpty)
+                    output.Add(new Parcel { Shape = poly });
+                return;
+            }
 
-                    try
+            var gf = poly.Factory;
+            bool splitVertical = envelope.Width > envelope.Height;
+
+            Nts.Geometry splitLine;
+            if (splitVertical)
+            {
+                double midX = envelope.MinX + envelope.Width / 2;
+                splitLine = gf.CreateLineString(new[]
+                {
+                    new Nts.Coordinate(midX, envelope.MinY),
+                    new Nts.Coordinate(midX, envelope.MaxY)
+                });
+            }
+            else
+            {
+                double midY = envelope.MinY + envelope.Height / 2;
+                splitLine = gf.CreateLineString(new[]
+                {
+                    new Nts.Coordinate(envelope.MinX, midY),
+                    new Nts.Coordinate(envelope.MaxX, midY)
+                });
+            }
+
+            try
+            {
+                // clean geometry to avoid subtle topology errors
+                var cleanPoly = poly.Buffer(0) as Nts.Polygon;
+                if (cleanPoly == null || !cleanPoly.IsValid || cleanPoly.IsEmpty)
+                    cleanPoly = poly;
+
+                var splitGeometries = cleanPoly.Difference(splitLine);
+                for (int i = 0; i < splitGeometries.NumGeometries; i++)
+                {
+                    if (splitGeometries.GetGeometryN(i) is Nts.Polygon splitPoly &&
+                        splitPoly.IsValid && !splitPoly.IsEmpty)
                     {
-                        var envPoly = gf.ToGeometry(subEnvelope);
-                        var parcelGeom = poly.Intersection(envPoly);
-                        if (parcelGeom is Nts.Polygon p && !p.IsEmpty)
-                        {
-                            output.Add(new Parcel { Shape = p });
-                        }
+                        RecursiveSplit(splitPoly, output, minArea);
                     }
-                    catch
-                    {
-                        // Intersection can fail, just skip this sub-parcel
-                    }
+                }
+            }
+            catch
+            {
+                if (poly.IsValid && !poly.IsEmpty)
+                {
+                    output.Add(new Parcel { Shape = poly });
                 }
             }
         }
@@ -245,22 +275,35 @@ namespace StrategyGame
             var buildingBag = new ConcurrentBag<Building>();
             var gf = Nts.GeometryFactory.Default;
 
+            const double CommercialInset = -0.00002;
+            const double ResidentialInset = -0.00004;
+            const double IndustrialInset = -0.00003;
+
             Parallel.ForEach(model.Parcels, parcel =>
             {
-                Nts.Geometry foot = parcel.Shape;
+                Nts.Geometry foot;
                 switch (parcel.LandUse)
                 {
                     case LandUseType.Commercial:
-                        foot = parcel.Shape.Buffer(-parcel.Shape.EnvelopeInternal.Width * 0.05);
+                        foot = parcel.Shape.Buffer(CommercialInset);
                         break;
                     case LandUseType.Residential:
-                        foot = parcel.Shape.Buffer(-parcel.Shape.EnvelopeInternal.Width * 0.15);
+                        foot = parcel.Shape.Buffer(ResidentialInset);
                         break;
                     case LandUseType.Industrial:
-                        var temp = parcel.Shape.Buffer(-parcel.Shape.EnvelopeInternal.Width * 0.1);
-                        foot = gf.ToGeometry(temp.EnvelopeInternal);
+                        var temp = parcel.Shape.Buffer(IndustrialInset);
+                        if (!temp.IsEmpty)
+                        {
+                            foot = gf.ToGeometry(temp.EnvelopeInternal);
+                        }
+                        else
+                        {
+                            foot = temp;
+                        }
                         break;
                     case LandUseType.Park:
+                        return;
+                    default:
                         return;
                 }
 
@@ -372,10 +415,12 @@ namespace StrategyGame
                     queue.Clear();
                 }
 
-                await Parallel.ForEachAsync(batch, new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount }, async (area, token) =>
+                // Temporarily run synchronously to help identify problematic polygons
+                // Parallel version can be restored once issues are resolved
+                foreach (var area in batch)
                 {
                     await RoadNetworkGenerator.GenerateModelAsync(area, 10).ConfigureAwait(false);
-                }).ConfigureAwait(false);
+                }
             }
         }
     }

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -2222,7 +2222,7 @@ namespace economy_sim
                     try
                     {
                         string id = File.ReadAllText(hashPath);
-                        string modelPath = Path.Combine(dir, $"{id}.json");
+                        string modelPath = Path.Combine(dir, $"{id}.bin");
                         if (!File.Exists(modelPath))
                         {
                             missing.Add(urban);
@@ -2301,7 +2301,7 @@ namespace economy_sim
                     try
                     {
                         string id = File.ReadAllText(hashPath);
-                        string modelPath = Path.Combine(dir, $"{id}.json");
+                        string modelPath = Path.Combine(dir, $"{id}.bin");
                         if (File.Exists(modelPath))
                         {
                             count++;
@@ -2366,7 +2366,7 @@ namespace economy_sim
                         try
                         {
                             string id = File.ReadAllText(hashPath);
-                            string modelPath = Path.Combine(dir, $"{id}.json");
+                            string modelPath = Path.Combine(dir, $"{id}.bin");
                             if (!File.Exists(modelPath))
                             {
                                 missingAreas.Add(urban);
@@ -2699,21 +2699,20 @@ namespace economy_sim
                         continue;
                     }
                     
-                    string modelPath = Path.Combine(dir, $"{guid}.json");
+                    string modelPath = Path.Combine(dir, $"{guid}.bin");
                     if (!File.Exists(modelPath))
                     {
                         invalidCount++;
-                        issues.Add($"Missing model file {guid}.json for hash {hash}");
+                        issues.Add($"Missing model file {guid}.bin for hash {hash}");
                         continue;
                     }
-                    
+
                     // Try to verify the model can be loaded
-                    string jsonContent = File.ReadAllText(modelPath);
-                    var model = System.Text.Json.JsonSerializer.Deserialize<CityDataModel>(jsonContent);
+                    var model = RoadNetworkGenerator.LoadCityDataModel(guid);
                     if (model == null || model.Id != guid)
                     {
                         invalidCount++;
-                        issues.Add($"Model file {guid}.json has invalid or mismatched ID");
+                        issues.Add($"Model file {guid}.bin has invalid or mismatched ID");
                         continue;
                     }
                     
@@ -2759,7 +2758,7 @@ namespace economy_sim
             {
                 details.AppendLine($"City Model ID: {modelId.Value}");
                 
-                string modelPath = Path.Combine(dir, $"{modelId.Value}.json");
+                string modelPath = Path.Combine(dir, $"{modelId.Value}.bin");
                 if (File.Exists(modelPath))
                 {
                     try
@@ -2770,8 +2769,7 @@ namespace economy_sim
                         details.AppendLine($"Model File Modified: {fileInfo.LastWriteTime}");
                         
                         // Try to load and get basic stats
-                        string jsonContent = File.ReadAllText(modelPath);
-                        var model = System.Text.Json.JsonSerializer.Deserialize<CityDataModel>(jsonContent);
+                        var model = RoadNetworkGenerator.LoadCityDataModel(modelId.Value);
                         if (model != null)
                         {
                             details.AppendLine($"Road Segments: {model.RoadNetwork.Count}");
@@ -2814,7 +2812,7 @@ namespace economy_sim
                 try
                 {
                     string oldId = File.ReadAllText(hashPath);
-                    string oldModelPath = Path.Combine(dir, $"{oldId}.json");
+                    string oldModelPath = Path.Combine(dir, $"{oldId}.bin");
                     
                     // Delete old files
                     File.Delete(hashPath);

--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -8,10 +8,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text.Json;
 using System.Threading.Tasks;
 using NetTopologySuite.IO;
-using NetTopologySuite.IO.Converters;
 using NetTopologySuite.Index.Quadtree;
 
 namespace StrategyGame
@@ -23,12 +21,6 @@ namespace StrategyGame
 
         public static CityGenerationData? Data { get; set; }
 
-        private static readonly JsonSerializerOptions jsonOptions = new()
-        {
-            IncludeFields = true,
-            WriteIndented = true,
-            Converters = { new GeoJsonConverterFactory() }
-        };
 
         public static async Task<CityDataModel> GenerateModelAsync(Nts.Polygon urbanArea, int cellSize)
         {
@@ -44,11 +36,10 @@ namespace StrategyGame
                 try
                 {
                     string id = await File.ReadAllTextAsync(hashPath).ConfigureAwait(false);
-                    string modelPath = Path.Combine(cacheDir, $"{id}.json");
+                    string modelPath = Path.Combine(cacheDir, $"{id}.bin");
                     if (File.Exists(modelPath))
                     {
-                        string jsonIn = await File.ReadAllTextAsync(modelPath).ConfigureAwait(false);
-                        var loaded = JsonSerializer.Deserialize<CityDataModel>(jsonIn, jsonOptions);
+                        var loaded = ReadCityDataModelBinary(modelPath);
                         if (loaded != null)
                         {
                             modelCache[hash] = loaded;
@@ -76,13 +67,19 @@ namespace StrategyGame
             result.Buildings = BuildingGenerator.GenerateBuildings(result);
             BuildingRefiner.RefineBuildings(result);
 
+            // Clean geometries to avoid serialization errors
+            result.Parcels = CleanParcels(result.Parcels);
+            result.Buildings = CleanBuildings(result.Buildings);
+
             Debug.WriteLine($">> Generated {result.Parcels.Count} parcels, {result.Buildings.Count} buildings for {hash}");
 
             try
             {
-                string modelPath = Path.Combine(cacheDir, $"{result.Id}.json");
-                string jsonOut = JsonSerializer.Serialize(result, jsonOptions);
-                await File.WriteAllTextAsync(modelPath, jsonOut).ConfigureAwait(false);
+                string modelPath = Path.Combine(cacheDir, $"{result.Id}.bin");
+                using (var fs = File.Create(modelPath))
+                {
+                    WriteCityDataModelBinary(result, fs);
+                }
                 await File.WriteAllTextAsync(hashPath, result.Id.ToString()).ConfigureAwait(false);
             }
             catch (Exception ex)
@@ -285,11 +282,165 @@ namespace StrategyGame
             return $"{e.MinX:F2}_{e.MinY:F2}_{e.MaxX:F2}_{e.MaxY:F2}";
         }
 
+        private static List<Parcel> CleanParcels(List<Parcel> parcels)
+        {
+            var cleanedList = new ConcurrentBag<Parcel>();
+            Parallel.ForEach(parcels, p =>
+            {
+                var cleanShape = p.Shape.Buffer(0);
+                if (cleanShape is Nts.Polygon poly && poly.IsValid && !poly.IsEmpty)
+                {
+                    p.Shape = poly;
+                    cleanedList.Add(p);
+                }
+            });
+            return cleanedList.ToList();
+        }
+
+        private static List<Building> CleanBuildings(List<Building> buildings)
+        {
+            var cleanedList = new ConcurrentBag<Building>();
+            Parallel.ForEach(buildings, b =>
+            {
+                var cleanFootprint = b.Footprint.Buffer(0);
+                if (cleanFootprint is Nts.Polygon poly && poly.IsValid && !poly.IsEmpty)
+                {
+                    b.Footprint = poly;
+                    cleanedList.Add(b);
+                }
+            });
+            return cleanedList.ToList();
+        }
+
         private static string GetCacheDir()
         {
             var dir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "data", "city_models");
             Directory.CreateDirectory(dir);
             return dir;
+        }
+
+        private static void WriteCityDataModelBinary(CityDataModel model, Stream stream)
+        {
+            using var writer = new BinaryWriter(stream, System.Text.Encoding.UTF8, leaveOpen: true);
+            var wkbWriter = new WKBWriter();
+
+            writer.Write(model.Id.ToByteArray());
+
+            writer.Write(model.RoadNetwork.Count);
+            foreach (var seg in model.RoadNetwork)
+            {
+                writer.Write(seg.X1);
+                writer.Write(seg.Y1);
+                writer.Write(seg.X2);
+                writer.Write(seg.Y2);
+                writer.Write((int)seg.Type);
+            }
+
+            writer.Write(model.RawBlocks.Count);
+            foreach (var poly in model.RawBlocks)
+            {
+                var bytes = wkbWriter.Write(poly);
+                writer.Write(bytes.Length);
+                writer.Write(bytes);
+            }
+
+            writer.Write(model.Parcels.Count);
+            foreach (var parcel in model.Parcels)
+            {
+                var bytes = wkbWriter.Write(parcel.Shape);
+                writer.Write(bytes.Length);
+                writer.Write(bytes);
+                writer.Write((int)parcel.LandUse);
+                writer.Write(parcel.LandValue);
+            }
+
+            writer.Write(model.Buildings.Count);
+            foreach (var b in model.Buildings)
+            {
+                var bytes = wkbWriter.Write(b.Footprint);
+                writer.Write(bytes.Length);
+                writer.Write(bytes);
+                writer.Write((int)b.LandUse);
+                writer.Write(b.Level);
+                writer.Write(b.PopulationCapacity);
+                writer.Write(b.EconomicOutput);
+                writer.Write(b.PollutionOutput);
+            }
+        }
+
+        private static CityDataModel? ReadCityDataModelBinary(string path)
+        {
+            using var fs = File.OpenRead(path);
+            using var reader = new BinaryReader(fs, System.Text.Encoding.UTF8, leaveOpen: false);
+            var wkbReader = new WKBReader();
+
+            var model = new CityDataModel();
+            model.Id = new Guid(reader.ReadBytes(16));
+
+            int roadCount = reader.ReadInt32();
+            var roads = new List<LineSegment>(roadCount);
+            for (int i = 0; i < roadCount; i++)
+            {
+                double x1 = reader.ReadDouble();
+                double y1 = reader.ReadDouble();
+                double x2 = reader.ReadDouble();
+                double y2 = reader.ReadDouble();
+                var type = (RoadType)reader.ReadInt32();
+                roads.Add(new LineSegment(x1, y1, x2, y2, type));
+            }
+            model.RoadNetwork = roads;
+
+            int blockCount = reader.ReadInt32();
+            var blocks = new List<Nts.Polygon>(blockCount);
+            for (int i = 0; i < blockCount; i++)
+            {
+                int len = reader.ReadInt32();
+                var bytes = reader.ReadBytes(len);
+                if (wkbReader.Read(bytes) is Nts.Polygon p)
+                    blocks.Add(p);
+            }
+            model.RawBlocks = blocks;
+
+            int parcelCount = reader.ReadInt32();
+            var parcels = new List<Parcel>(parcelCount);
+            for (int i = 0; i < parcelCount; i++)
+            {
+                int len = reader.ReadInt32();
+                var bytes = reader.ReadBytes(len);
+                var shape = wkbReader.Read(bytes) as Nts.Polygon;
+                var use = (LandUseType)reader.ReadInt32();
+                double value = reader.ReadDouble();
+                if (shape != null)
+                    parcels.Add(new Parcel { Shape = shape, LandUse = use, LandValue = value });
+            }
+            model.Parcels = parcels;
+
+            int buildCount = reader.ReadInt32();
+            var buildings = new List<Building>(buildCount);
+            for (int i = 0; i < buildCount; i++)
+            {
+                int len = reader.ReadInt32();
+                var bytes = reader.ReadBytes(len);
+                var foot = wkbReader.Read(bytes) as Nts.Polygon;
+                var use = (LandUseType)reader.ReadInt32();
+                int level = reader.ReadInt32();
+                int capacity = reader.ReadInt32();
+                double output = reader.ReadDouble();
+                double pollution = reader.ReadDouble();
+                if (foot != null)
+                    buildings.Add(new Building
+                    {
+                        Footprint = foot,
+                        LandUse = use,
+                        Level = level,
+                        PopulationCapacity = capacity,
+                        EconomicOutput = output,
+                        PollutionOutput = pollution
+                    });
+            }
+            model.Buildings = buildings;
+
+            return model;
         }
 
         private sealed class CoordComparer : IEqualityComparer<Nts.Coordinate>
@@ -329,7 +480,7 @@ namespace StrategyGame
                 try
                 {
                     string id = File.ReadAllText(hashPath);
-                    string modelPath = Path.Combine(cacheDir, $"{id}.json");
+                    string modelPath = Path.Combine(cacheDir, $"{id}.bin");
                     return File.Exists(modelPath);
                 }
                 catch
@@ -362,7 +513,7 @@ namespace StrategyGame
                     string id = File.ReadAllText(hashPath);
                     if (Guid.TryParse(id, out Guid guid))
                     {
-                        string modelPath = Path.Combine(cacheDir, $"{guid}.json");
+                        string modelPath = Path.Combine(cacheDir, $"{guid}.bin");
                         if (File.Exists(modelPath))
                             return guid;
                     }
@@ -390,17 +541,17 @@ namespace StrategyGame
             if (Directory.Exists(cacheDir))
             {
                 var hashFiles = Directory.GetFiles(cacheDir, "*.txt");
-                var jsonFiles = Directory.GetFiles(cacheDir, "*.json");
-                
-                diskCount = jsonFiles.Length;
-                
-                // Count unique models (hash files that have corresponding JSON files)
+                var binFiles = Directory.GetFiles(cacheDir, "*.bin");
+
+                diskCount = binFiles.Length;
+
+                // Count unique models (hash files that have corresponding binary files)
                 foreach (string hashFile in hashFiles)
                 {
                     try
                     {
                         string id = File.ReadAllText(hashFile);
-                        string modelPath = Path.Combine(cacheDir, $"{id}.json");
+                        string modelPath = Path.Combine(cacheDir, $"{id}.bin");
                         if (File.Exists(modelPath))
                             totalUnique++;
                     }
@@ -417,14 +568,13 @@ namespace StrategyGame
         public static CityDataModel? LoadCityDataModel(Guid id)
         {
             string cacheDir = GetCacheDir();
-            string modelPath = Path.Combine(cacheDir, $"{id}.json");
+            string modelPath = Path.Combine(cacheDir, $"{id}.bin");
             if (!File.Exists(modelPath))
                 return null;
 
             try
             {
-                string json = File.ReadAllText(modelPath);
-                return JsonSerializer.Deserialize<CityDataModel>(json, jsonOptions);
+                return ReadCityDataModelBinary(modelPath);
             }
             catch (Exception ex)
             {

--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -284,32 +284,50 @@ namespace StrategyGame
 
         private static List<Parcel> CleanParcels(List<Parcel> parcels)
         {
-            var cleanedList = new ConcurrentBag<Parcel>();
-            Parallel.ForEach(parcels, p =>
+            var cleanedList = new List<Parcel>();
+
+            foreach (var p in parcels)
             {
-                var cleanShape = p.Shape.Buffer(0);
-                if (cleanShape is Nts.Polygon poly && poly.IsValid && !poly.IsEmpty)
+                try
                 {
-                    p.Shape = poly;
-                    cleanedList.Add(p);
+                    var cleanShape = p.Shape.Buffer(0);
+                    if (cleanShape is Nts.Polygon poly && poly.IsValid && !poly.IsEmpty)
+                    {
+                        p.Shape = poly;
+                        cleanedList.Add(p);
+                    }
                 }
-            });
-            return cleanedList.ToList();
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"[Warning] Could not clean a parcel, skipping it. Error: {ex.Message}");
+                }
+            }
+
+            return cleanedList;
         }
 
         private static List<Building> CleanBuildings(List<Building> buildings)
         {
-            var cleanedList = new ConcurrentBag<Building>();
-            Parallel.ForEach(buildings, b =>
+            var cleanedList = new List<Building>();
+
+            foreach (var b in buildings)
             {
-                var cleanFootprint = b.Footprint.Buffer(0);
-                if (cleanFootprint is Nts.Polygon poly && poly.IsValid && !poly.IsEmpty)
+                try
                 {
-                    b.Footprint = poly;
-                    cleanedList.Add(b);
+                    var cleanFootprint = b.Footprint.Buffer(0);
+                    if (cleanFootprint is Nts.Polygon poly && poly.IsValid && !poly.IsEmpty)
+                    {
+                        b.Footprint = poly;
+                        cleanedList.Add(b);
+                    }
                 }
-            });
-            return cleanedList.ToList();
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"[Warning] Could not clean a building footprint, skipping it. Error: {ex.Message}");
+                }
+            }
+
+            return cleanedList;
         }
 
         private static string GetCacheDir()


### PR DESCRIPTION
## Summary
- update city model counting and validation logic to use `.bin` files instead of `.json`
- display details by loading models via `RoadNetworkGenerator`
- add stronger validity checks in RecursiveSplit before splitting parcels
- temporarily run city generation sequentially to isolate crashing polygons
- clean parcels and buildings before writing city model binaries

## Testing
- `dotnet restore "economy sim.csproj"` *(fails: command not found)*
- `dotnet build "economy sim.sln" -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875d1d6657c832394dfd5c262c9ca24