### PR TITLE
Optimize building and parcel generation; binary cache

### DIFF
--- a/Building.cs
+++ b/Building.cs
@@ -5,6 +5,8 @@ namespace StrategyGame
     public class Building
     {
         public Nts.Polygon Footprint { get; set; }
+        // A simplified version of the footprint used for rendering
+        public Nts.Geometry? SimplifiedFootprint { get; set; }
         public LandUseType LandUse { get; set; }
 
         // Fields used by the BuildingRefiner

--- a/Building.cs
+++ b/Building.cs
@@ -1,12 +1,13 @@
 using Nts = NetTopologySuite.Geometries;
+using System.Collections.Concurrent;
 
 namespace StrategyGame
 {
     public class Building
     {
         public Nts.Polygon Footprint { get; set; }
-        // A simplified version of the footprint used for rendering
-        public Nts.Geometry? SimplifiedFootprint { get; set; }
+        // Simplified footprints cached by cell size for rendering
+        public ConcurrentDictionary<int, Nts.Geometry> SimplifiedFootprints { get; } = new();
         public LandUseType LandUse { get; set; }
 
         // Fields used by the BuildingRefiner

--- a/CityDataModel.cs
+++ b/CityDataModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Nts = NetTopologySuite.Geometries;
+using NetTopologySuite.Index.Strtree;
 
 namespace StrategyGame
 {
@@ -12,5 +13,8 @@ namespace StrategyGame
         public List<Nts.Polygon> RawBlocks { get; set; } = new();
         public List<Parcel> Parcels { get; set; } = new();
         public List<Building> Buildings { get; set; } = new();
+
+        // Spatial index of buildings for faster tile queries
+        public STRtree<Building>? BuildingIndex { get; set; }
     }
 }

--- a/CityDataModel.cs
+++ b/CityDataModel.cs
@@ -7,6 +7,7 @@ namespace StrategyGame
     public class CityDataModel
     {
         public Guid Id { get; set; }
+        public Nts.Polygon UrbanArea { get; set; }
         public List<LineSegment> RoadNetwork { get; set; } = new();
         public List<Nts.Polygon> RawBlocks { get; set; } = new();
         public List<Parcel> Parcels { get; set; } = new();

--- a/CityGeneration.cs
+++ b/CityGeneration.cs
@@ -291,7 +291,7 @@ namespace StrategyGame
                         return;
                 }
 
-                if (foot is Nts.Polygon p && !foot.IsEmpty)
+                if (foot is Nts.Polygon p && p.IsValid && !p.IsEmpty)
                     buildingBag.Add(new Building { Footprint = p, LandUse = parcel.LandUse });
             });
 

--- a/CityGeneration.cs
+++ b/CityGeneration.cs
@@ -285,21 +285,19 @@ namespace StrategyGame
     {
         public static List<Building> GenerateBuildings(CityDataModel model)
         {
-            var buildings = new List<Building>();
+            // We need the ConcurrentBag again for thread-safe collection
+            var buildingBag = new ConcurrentBag<Building>();
             var gf = Nts.GeometryFactory.Default;
 
             const double CommercialInset = -0.00002;
             const double ResidentialInset = -0.00004;
             const double IndustrialInset = -0.00003;
 
-            int parcelIndex = 0;
-            foreach (var parcel in model.Parcels)
-            {
-                // --- Start Diagnostic Logging ---
-                Debug.WriteLine($"--- Processing Parcel Index: {parcelIndex} ---");
-                Debug.WriteLine($"Parcel LandUse: {parcel.LandUse}, Area: {parcel.Shape.Area}, IsValid: {parcel.Shape.IsValid}");
-                // --- End Diagnostic Logging ---
+            // Create a partitioner to process parcels in efficient, thread-safe chunks.
+            var partitioner = Partitioner.Create(model.Parcels, true);
 
+            Parallel.ForEach(partitioner, new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount }, parcel =>
+            {
                 try
                 {
                     Nts.Geometry foot = null;
@@ -317,31 +315,28 @@ namespace StrategyGame
                             else foot = temp;
                             break;
                         default:
-                            parcelIndex++;
-                            continue;
+                            // No need for continue, just don't process
+                            return;
                     }
 
                     if (foot is Nts.Polygon p && p.IsValid && !p.IsEmpty)
                     {
-                        Debug.WriteLine($"Buffer successful for parcel {parcelIndex}. Cleaning footprint...");
                         var cleanedFootprint = p.Buffer(0);
 
                         if (cleanedFootprint is Nts.Polygon cleanedP && cleanedP.IsValid && !cleanedP.IsEmpty)
                         {
-                            buildings.Add(new Building { Footprint = cleanedP, LandUse = parcel.LandUse });
-                            Debug.WriteLine($"--> Building added successfully for parcel {parcelIndex}.");
+                            buildingBag.Add(new Building { Footprint = cleanedP, LandUse = parcel.LandUse });
                         }
                     }
                 }
                 catch (Exception ex)
                 {
-                    // This will tell us if the buffer operation throws a C# error
-                    Debug.WriteLine($"[BUILDING GEN ERROR] on Parcel Index {parcelIndex}: {ex.Message}");
+                    // It's still good practice to keep this catch block for diagnostics
+                    Debug.WriteLine($"[BUILDING GEN ERROR] on a parcel. Error: {ex.Message}");
                 }
+            });
 
-                parcelIndex++;
-            }
-
+            var buildings = buildingBag.ToList();
             model.Buildings = buildings;
             return buildings;
         }

--- a/CityGeneration.cs
+++ b/CityGeneration.cs
@@ -270,15 +270,14 @@ namespace StrategyGame
     {
         public static List<Building> GenerateBuildings(CityDataModel model)
         {
-            var buildingBag = new ConcurrentBag<Building>();
+            var buildings = new List<Building>();
             var gf = Nts.GeometryFactory.Default;
 
-            // Fixed insets provide much faster buffering while maintaining visual quality
             const double CommercialInset = -0.00002;
             const double ResidentialInset = -0.00004;
             const double IndustrialInset = -0.00003;
 
-            Parallel.ForEach(model.Parcels, parcel =>
+            foreach (var parcel in model.Parcels)
             {
                 Nts.Geometry foot;
                 switch (parcel.LandUse)
@@ -301,9 +300,9 @@ namespace StrategyGame
                         }
                         break;
                     case LandUseType.Park:
-                        return;
+                        continue;
                     default:
-                        return;
+                        continue;
                 }
 
                 if (foot is Nts.Polygon p && p.IsValid && !p.IsEmpty)
@@ -311,12 +310,11 @@ namespace StrategyGame
                     var cleanedFootprint = p.Buffer(0);
                     if (cleanedFootprint is Nts.Polygon cleanedP && cleanedP.IsValid && !cleanedP.IsEmpty)
                     {
-                        buildingBag.Add(new Building { Footprint = cleanedP, LandUse = parcel.LandUse });
+                        buildings.Add(new Building { Footprint = cleanedP, LandUse = parcel.LandUse });
                     }
                 }
-            });
+            }
 
-            var buildings = buildingBag.ToList();
             model.Buildings = buildings;
             return buildings;
         }

--- a/CityGeneration.cs
+++ b/CityGeneration.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Diagnostics;
 using Nts = NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries;
 using NetTopologySuite.Index.Strtree;
 using NetTopologySuite.Operation.Polygonize;
 using NetTopologySuite.Operation.Union;
@@ -54,6 +55,12 @@ namespace StrategyGame
     // Original ParcelGenerator
     public static class ParcelGenerator
     {
+        private const double Epsilon = 1e-9;
+
+        private static bool IsBad(Coordinate c) =>
+            double.IsNaN(c.X) || double.IsNaN(c.Y) ||
+            double.IsInfinity(c.X) || double.IsInfinity(c.Y);
+
         public static List<Parcel> GenerateParcels(CityDataModel model)
         {
             if (model.RawBlocks != null && model.RawBlocks.Count > 0)
@@ -66,18 +73,22 @@ namespace StrategyGame
                 return parcels;
 
             var gf = Nts.GeometryFactory.Default;
-            var lineStrings = model.RoadNetwork
+            var validLineStrings = model.RoadNetwork
+                .Where(seg =>
+                    !IsBad(new Coordinate(seg.X1, seg.Y1)) &&
+                    !IsBad(new Coordinate(seg.X2, seg.Y2)) &&
+                    Math.Abs(seg.X1 - seg.X2) + Math.Abs(seg.Y1 - seg.Y2) > Epsilon)
                 .Select(seg => gf.CreateLineString(new[]
                 {
-                    new Nts.Coordinate(seg.X1, seg.Y1),
-                    new Nts.Coordinate(seg.X2, seg.Y2)
+                    new Coordinate(seg.X1, seg.Y1),
+                    new Coordinate(seg.X2, seg.Y2)
                 }))
                 .ToArray();
 
-            if (lineStrings.Length == 0)
+            if (validLineStrings.Length == 0)
                 return parcels;
 
-            var nodedLines = UnaryUnionOp.Union(lineStrings);
+            var nodedLines = CascadedPolygonUnion.Union(validLineStrings);
             var polygonizer = new Polygonizer();
             polygonizer.Add(nodedLines);
             var rawPolys = polygonizer.GetPolygons();

--- a/CityGeneration.cs
+++ b/CityGeneration.cs
@@ -108,45 +108,58 @@ namespace StrategyGame
 
         private static void SubdividePolygon(Nts.Polygon poly, List<Parcel> output)
         {
-            const double DesiredParcelArea = 0.0001;
-            if (poly.Area < DesiredParcelArea * 1.5)
+            const double MinParcelArea = 0.00005;
+            RecursiveSplit(poly, output, MinParcelArea);
+        }
+
+        private static void RecursiveSplit(Nts.Polygon poly, List<Parcel> output, double minArea)
+        {
+            if (poly.Area < minArea * 1.5)
             {
-                output.Add(new Parcel { Shape = poly });
+                if (poly.IsValid && !poly.IsEmpty)
+                    output.Add(new Parcel { Shape = poly });
                 return;
             }
 
             var envelope = poly.EnvelopeInternal;
-            int xSplits = (int)Math.Max(1, Math.Round(envelope.Width / Math.Sqrt(DesiredParcelArea)));
-            int ySplits = (int)Math.Max(1, Math.Round(envelope.Height / Math.Sqrt(DesiredParcelArea)));
+            var gf = poly.Factory;
+            bool splitVertical = envelope.Width > envelope.Height;
 
-            double dx = envelope.Width / xSplits;
-            double dy = envelope.Height / ySplits;
-
-            var gf = Nts.GeometryFactory.Default;
-            for (int i = 0; i < xSplits; i++)
+            Nts.Geometry splitLine;
+            if (splitVertical)
             {
-                for (int j = 0; j < ySplits; j++)
+                double midX = envelope.MinX + envelope.Width / 2;
+                splitLine = gf.CreateLineString(new[]
                 {
-                    var subEnvelope = new Nts.Envelope(
-                        envelope.MinX + i * dx,
-                        envelope.MinX + (i + 1) * dx,
-                        envelope.MinY + j * dy,
-                        envelope.MinY + (j + 1) * dy);
+                    new Nts.Coordinate(midX, envelope.MinY),
+                    new Nts.Coordinate(midX, envelope.MaxY)
+                });
+            }
+            else
+            {
+                double midY = envelope.MinY + envelope.Height / 2;
+                splitLine = gf.CreateLineString(new[]
+                {
+                    new Nts.Coordinate(envelope.MinX, midY),
+                    new Nts.Coordinate(envelope.MaxX, midY)
+                });
+            }
 
-                    try
+            try
+            {
+                var splitGeometries = poly.Difference(splitLine);
+                for (int i = 0; i < splitGeometries.NumGeometries; i++)
+                {
+                    if (splitGeometries.GetGeometryN(i) is Nts.Polygon splitPoly && splitPoly.IsValid && !splitPoly.IsEmpty)
                     {
-                        var envPoly = gf.ToGeometry(subEnvelope);
-                        var parcelGeom = poly.Intersection(envPoly);
-                        if (parcelGeom is Nts.Polygon p && !p.IsEmpty)
-                        {
-                            output.Add(new Parcel { Shape = p });
-                        }
-                    }
-                    catch
-                    {
-                        // Intersection can fail, just skip this sub-parcel
+                        RecursiveSplit(splitPoly, output, minArea);
                     }
                 }
+            }
+            catch (Exception)
+            {
+                if (poly.IsValid && !poly.IsEmpty)
+                    output.Add(new Parcel { Shape = poly });
             }
         }
     }
@@ -245,22 +258,36 @@ namespace StrategyGame
             var buildingBag = new ConcurrentBag<Building>();
             var gf = Nts.GeometryFactory.Default;
 
+            // Fixed insets provide much faster buffering while maintaining visual quality
+            const double CommercialInset = -0.00002;
+            const double ResidentialInset = -0.00004;
+            const double IndustrialInset = -0.00003;
+
             Parallel.ForEach(model.Parcels, parcel =>
             {
-                Nts.Geometry foot = parcel.Shape;
+                Nts.Geometry foot;
                 switch (parcel.LandUse)
                 {
                     case LandUseType.Commercial:
-                        foot = parcel.Shape.Buffer(-parcel.Shape.EnvelopeInternal.Width * 0.05);
+                        foot = parcel.Shape.Buffer(CommercialInset);
                         break;
                     case LandUseType.Residential:
-                        foot = parcel.Shape.Buffer(-parcel.Shape.EnvelopeInternal.Width * 0.15);
+                        foot = parcel.Shape.Buffer(ResidentialInset);
                         break;
                     case LandUseType.Industrial:
-                        var temp = parcel.Shape.Buffer(-parcel.Shape.EnvelopeInternal.Width * 0.1);
-                        foot = gf.ToGeometry(temp.EnvelopeInternal);
+                        var temp = parcel.Shape.Buffer(IndustrialInset);
+                        if (!temp.IsEmpty)
+                        {
+                            foot = gf.ToGeometry(temp.EnvelopeInternal);
+                        }
+                        else
+                        {
+                            foot = temp;
+                        }
                         break;
                     case LandUseType.Park:
+                        return;
+                    default:
                         return;
                 }
 

--- a/CityGeneration.cs
+++ b/CityGeneration.cs
@@ -307,7 +307,13 @@ namespace StrategyGame
                 }
 
                 if (foot is Nts.Polygon p && p.IsValid && !p.IsEmpty)
-                    buildingBag.Add(new Building { Footprint = p, LandUse = parcel.LandUse });
+                {
+                    var cleanedFootprint = p.Buffer(0);
+                    if (cleanedFootprint is Nts.Polygon cleanedP && cleanedP.IsValid && !cleanedP.IsEmpty)
+                    {
+                        buildingBag.Add(new Building { Footprint = cleanedP, LandUse = parcel.LandUse });
+                    }
+                }
             });
 
             var buildings = buildingBag.ToList();

--- a/CityGeneration.cs
+++ b/CityGeneration.cs
@@ -63,17 +63,15 @@ namespace StrategyGame
 
         public static List<Parcel> GenerateParcels(CityDataModel model)
         {
-            if (model.RawBlocks != null && model.RawBlocks.Count > 0)
-            {
-                return GenerateParcelsFromBlocks(model.RawBlocks);
-            }
-
             var parcels = new List<Parcel>();
-            if (model.RoadNetwork == null || !model.RoadNetwork.Any())
+            // Ensure there's a road network and an urban area to work with.
+            if (model.RoadNetwork == null || !model.RoadNetwork.Any() || model.UrbanArea == null)
                 return parcels;
 
             var gf = Nts.GeometryFactory.Default;
-            var validLineStrings = model.RoadNetwork
+
+            // 1. Get all valid road line segments as Geometry.
+            var roadLines = model.RoadNetwork
                 .Where(seg =>
                     !IsBad(new Coordinate(seg.X1, seg.Y1)) &&
                     !IsBad(new Coordinate(seg.X2, seg.Y2)) &&
@@ -83,18 +81,20 @@ namespace StrategyGame
                     new Coordinate(seg.X1, seg.Y1),
                     new Coordinate(seg.X2, seg.Y2)
                 }))
-                .ToArray();
+                .ToList<Nts.Geometry>();
 
-            if (validLineStrings.Length == 0)
-                return parcels;
+            // 2. Add the urban area boundary to the same collection.
+            if (model.UrbanArea.IsValid)
+            {
+                roadLines.Add(model.UrbanArea.Boundary);
+            }
 
-            var nodedLines = CascadedPolygonUnion.Union(validLineStrings);
+            // 3. Union ALL lines together at once. This correctly nodes the entire geometry set.
+            var nodedLines = UnaryUnionOp.Union(roadLines);
+
+            // 4. Polygonize the fully noded line network.
             var polygonizer = new Polygonizer();
             polygonizer.Add(nodedLines);
-            if (model.UrbanArea != null && model.UrbanArea.IsValid)
-            {
-                polygonizer.Add(model.UrbanArea.Boundary);
-            }
             var rawPolys = polygonizer.GetPolygons();
             Debug.WriteLine($"[ParcelGenerator] Polygonizer produced {rawPolys.Count} raw polygons");
 
@@ -102,8 +102,8 @@ namespace StrategyGame
                 .Where(p => p.IsValid && p.Area > 1e-9)
                 .ToList();
 
+            // The rest of the process can now proceed.
             model.RawBlocks = blocks;
-
             parcels = GenerateParcelsFromBlocks(blocks);
 
             Debug.WriteLine($"[ParcelGenerator] Final parcel count: {parcels.Count}");

--- a/CityGeneration.cs
+++ b/CityGeneration.cs
@@ -168,6 +168,14 @@ namespace StrategyGame
             {
                 var splitGeometries = poly.Difference(splitLine);
 
+                // If the split did not create two or more pieces, stop recursion to avoid an infinite loop.
+                if (splitGeometries.NumGeometries < 2)
+                {
+                    if (poly.IsValid && !poly.IsEmpty)
+                        output.Add(new Parcel { Shape = poly });
+                    return;
+                }
+
                 for (int i = 0; i < splitGeometries.NumGeometries; i++)
                 {
                     if (splitGeometries.GetGeometryN(i) is Nts.Polygon splitPoly && splitPoly.IsValid && !splitPoly.IsEmpty)

--- a/CityGeneration.cs
+++ b/CityGeneration.cs
@@ -91,6 +91,10 @@ namespace StrategyGame
             var nodedLines = CascadedPolygonUnion.Union(validLineStrings);
             var polygonizer = new Polygonizer();
             polygonizer.Add(nodedLines);
+            if (model.UrbanArea != null && model.UrbanArea.IsValid)
+            {
+                polygonizer.Add(model.UrbanArea.Boundary);
+            }
             var rawPolys = polygonizer.GetPolygons();
             Debug.WriteLine($"[ParcelGenerator] Polygonizer produced {rawPolys.Count} raw polygons");
 

--- a/CityGeneration.cs
+++ b/CityGeneration.cs
@@ -129,6 +129,10 @@ namespace StrategyGame
 
         private static void RecursiveSplit(Nts.Polygon poly, List<Parcel> output, double minArea)
         {
+            // --- Start Diagnostic Logging ---
+            Debug.WriteLine($"Splitting polygon. Area: {poly.Area}, IsValid: {poly.IsValid}, Envelope: {poly.EnvelopeInternal}");
+            // --- End Diagnostic Logging ---
+
             if (poly.Area < minArea * 1.5)
             {
                 if (poly.IsValid && !poly.IsEmpty)
@@ -163,6 +167,7 @@ namespace StrategyGame
             try
             {
                 var splitGeometries = poly.Difference(splitLine);
+
                 for (int i = 0; i < splitGeometries.NumGeometries; i++)
                 {
                     if (splitGeometries.GetGeometryN(i) is Nts.Polygon splitPoly && splitPoly.IsValid && !splitPoly.IsEmpty)
@@ -171,8 +176,10 @@ namespace StrategyGame
                     }
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                // This will tell us if the split itself throws a C# error
+                Debug.WriteLine($"[RECURSIVE SPLIT ERROR] {ex.Message}");
                 if (poly.IsValid && !poly.IsEmpty)
                     output.Add(new Parcel { Shape = poly });
             }
@@ -277,42 +284,54 @@ namespace StrategyGame
             const double ResidentialInset = -0.00004;
             const double IndustrialInset = -0.00003;
 
+            int parcelIndex = 0;
             foreach (var parcel in model.Parcels)
             {
-                Nts.Geometry foot;
-                switch (parcel.LandUse)
-                {
-                    case LandUseType.Commercial:
-                        foot = parcel.Shape.Buffer(CommercialInset);
-                        break;
-                    case LandUseType.Residential:
-                        foot = parcel.Shape.Buffer(ResidentialInset);
-                        break;
-                    case LandUseType.Industrial:
-                        var temp = parcel.Shape.Buffer(IndustrialInset);
-                        if (!temp.IsEmpty)
-                        {
-                            foot = gf.ToGeometry(temp.EnvelopeInternal);
-                        }
-                        else
-                        {
-                            foot = temp;
-                        }
-                        break;
-                    case LandUseType.Park:
-                        continue;
-                    default:
-                        continue;
-                }
+                // --- Start Diagnostic Logging ---
+                Debug.WriteLine($"--- Processing Parcel Index: {parcelIndex} ---");
+                Debug.WriteLine($"Parcel LandUse: {parcel.LandUse}, Area: {parcel.Shape.Area}, IsValid: {parcel.Shape.IsValid}");
+                // --- End Diagnostic Logging ---
 
-                if (foot is Nts.Polygon p && p.IsValid && !p.IsEmpty)
+                try
                 {
-                    var cleanedFootprint = p.Buffer(0);
-                    if (cleanedFootprint is Nts.Polygon cleanedP && cleanedP.IsValid && !cleanedP.IsEmpty)
+                    Nts.Geometry foot = null;
+                    switch (parcel.LandUse)
                     {
-                        buildings.Add(new Building { Footprint = cleanedP, LandUse = parcel.LandUse });
+                        case LandUseType.Commercial:
+                            foot = parcel.Shape.Buffer(CommercialInset);
+                            break;
+                        case LandUseType.Residential:
+                            foot = parcel.Shape.Buffer(ResidentialInset);
+                            break;
+                        case LandUseType.Industrial:
+                            var temp = parcel.Shape.Buffer(IndustrialInset);
+                            if (!temp.IsEmpty) foot = gf.ToGeometry(temp.EnvelopeInternal);
+                            else foot = temp;
+                            break;
+                        default:
+                            parcelIndex++;
+                            continue;
+                    }
+
+                    if (foot is Nts.Polygon p && p.IsValid && !p.IsEmpty)
+                    {
+                        Debug.WriteLine($"Buffer successful for parcel {parcelIndex}. Cleaning footprint...");
+                        var cleanedFootprint = p.Buffer(0);
+
+                        if (cleanedFootprint is Nts.Polygon cleanedP && cleanedP.IsValid && !cleanedP.IsEmpty)
+                        {
+                            buildings.Add(new Building { Footprint = cleanedP, LandUse = parcel.LandUse });
+                            Debug.WriteLine($"--> Building added successfully for parcel {parcelIndex}.");
+                        }
                     }
                 }
+                catch (Exception ex)
+                {
+                    // This will tell us if the buffer operation throws a C# error
+                    Debug.WriteLine($"[BUILDING GEN ERROR] on Parcel Index {parcelIndex}: {ex.Message}");
+                }
+
+                parcelIndex++;
             }
 
             model.Buildings = buildings;

--- a/CityModelCache.cs
+++ b/CityModelCache.cs
@@ -31,12 +31,18 @@ namespace StrategyGame
 
                 var primaryBuilder = new PathBuilder();
                 var secondaryBuilder = new PathBuilder();
+                float sx = MultiResolutionMapManager.TileSizePx / (float)(bounds.MaxLon - bounds.MinLon);
+                float sy = MultiResolutionMapManager.TileSizePx / (float)(bounds.MaxLat - bounds.MinLat);
                 foreach (var seg in simplified)
                 {
                     var pb = seg.Type == RoadType.Primary ? primaryBuilder : secondaryBuilder;
                     pb.AddLine(
-                        ProceduralCityRenderer.ToPointF(seg.X1, seg.Y1, bounds),
-                        ProceduralCityRenderer.ToPointF(seg.X2, seg.Y2, bounds));
+                        new PointF(
+                            (float)((seg.X1 - bounds.MinLon) * sx),
+                            (float)((bounds.MaxLat - seg.Y1) * sy)),
+                        new PointF(
+                            (float)((seg.X2 - bounds.MinLon) * sx),
+                            (float)((bounds.MaxLat - seg.Y2) * sy)));
                 }
 
                 return new CachedRoads
@@ -53,12 +59,17 @@ namespace StrategyGame
             return _buildings.GetOrAdd(key, _ =>
             {
                 var dict = new Dictionary<Rgba32, IPath>();
+                float sx = MultiResolutionMapManager.TileSizePx / (float)(bounds.MaxLon - bounds.MinLon);
+                float sy = MultiResolutionMapManager.TileSizePx / (float)(bounds.MaxLat - bounds.MinLat);
                 foreach (var group in buildings.GroupBy(b => ProceduralCityRenderer.GetBuildingColor(b.Use)))
                 {
                     var pb = new PathBuilder();
                     foreach (var item in group)
                     {
-                        var points = item.Poly.ExteriorRing.Coordinates.Select(c => ProceduralCityRenderer.ToPointF(c.X, c.Y, bounds)).ToArray();
+                        var points = item.Poly.ExteriorRing.Coordinates.Select(c =>
+                            new PointF(
+                                (float)((c.X - bounds.MinLon) * sx),
+                                (float)((bounds.MaxLat - c.Y) * sy))).ToArray();
                         pb.AddLines(points);
                         pb.CloseFigure();
                     }

--- a/CityModelCache.cs
+++ b/CityModelCache.cs
@@ -1,0 +1,53 @@
+using SixLabors.ImageSharp.Drawing;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace StrategyGame
+{
+    internal static class CityModelCache
+    {
+        private static readonly ConcurrentDictionary<(Guid modelId, int cellSize), CachedRoads> _roads = new();
+
+        public static CachedRoads GetOrAddRoads(Guid modelId, int cellSize, IEnumerable<LineSegment> rawRoads, GeoBounds bounds)
+        {
+            return _roads.GetOrAdd((modelId, cellSize), _ =>
+            {
+                var tileBox = new NetTopologySuite.Geometries.Envelope(bounds.MinLon, bounds.MaxLon, bounds.MinLat, bounds.MaxLat);
+                var clipped = rawRoads.Where(r =>
+                {
+                    double minX = Math.Min(r.X1, r.X2);
+                    double maxX = Math.Max(r.X1, r.X2);
+                    double minY = Math.Min(r.Y1, r.Y2);
+                    double maxY = Math.Max(r.Y1, r.Y2);
+                    return !(maxX < tileBox.MinX || minX > tileBox.MaxX || maxY < tileBox.MinY || minY > tileBox.MaxY);
+                });
+
+                var simplified = ProceduralCityRenderer.SimplifyRoads(clipped, bounds).ToList();
+
+                var primaryBuilder = new PathBuilder();
+                var secondaryBuilder = new PathBuilder();
+                foreach (var seg in simplified)
+                {
+                    var pb = seg.Type == RoadType.Primary ? primaryBuilder : secondaryBuilder;
+                    pb.AddLine(
+                        ProceduralCityRenderer.ToPointF(seg.X1, seg.Y1, bounds),
+                        ProceduralCityRenderer.ToPointF(seg.X2, seg.Y2, bounds));
+                }
+
+                return new CachedRoads
+                {
+                    SecondaryPath = secondaryBuilder.Build(),
+                    PrimaryPath = primaryBuilder.Build()
+                };
+            });
+        }
+
+        internal class CachedRoads
+        {
+            public IPath SecondaryPath { get; init; }
+            public IPath PrimaryPath { get; init; }
+        }
+    }
+}

--- a/CityModelCache.cs
+++ b/CityModelCache.cs
@@ -1,3 +1,4 @@
+using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Drawing;
 using System;
 using System.Collections.Concurrent;
@@ -9,6 +10,7 @@ namespace StrategyGame
     internal static class CityModelCache
     {
         private static readonly ConcurrentDictionary<(Guid modelId, int cellSize), CachedRoads> _roads = new();
+        private static readonly ConcurrentDictionary<(Guid modelId, int cellSize, double minLon, double minLat, double maxLon, double maxLat), CachedBuildings> _buildings = new();
 
         public static CachedRoads GetOrAddRoads(Guid modelId, int cellSize, IEnumerable<LineSegment> rawRoads, GeoBounds bounds)
         {
@@ -44,10 +46,35 @@ namespace StrategyGame
             });
         }
 
+        public static CachedBuildings GetOrAddBuildings(Guid modelId, int cellSize, GeoBounds bounds, IEnumerable<(NetTopologySuite.Geometries.Polygon Poly, LandUseType Use)> buildings)
+        {
+            var key = (modelId, cellSize, bounds.MinLon, bounds.MinLat, bounds.MaxLon, bounds.MaxLat);
+            return _buildings.GetOrAdd(key, _ =>
+            {
+                var dict = new Dictionary<Rgba32, IPath>();
+                foreach (var group in buildings.GroupBy(b => ProceduralCityRenderer.GetBuildingColor(b.Use)))
+                {
+                    var pb = new PathBuilder();
+                    foreach (var item in group)
+                    {
+                        pb.AddPolygon(new Polygon(new LinearLineSegment(item.Poly.ExteriorRing.Coordinates.Select(c => ProceduralCityRenderer.ToPointF(c.X, c.Y, bounds)).ToArray())));
+                    }
+                    dict[group.Key] = pb.Build();
+                }
+
+                return new CachedBuildings { PathsByColor = dict };
+            });
+        }
+
         internal class CachedRoads
         {
             public IPath SecondaryPath { get; init; }
             public IPath PrimaryPath { get; init; }
+        }
+
+        internal class CachedBuildings
+        {
+            public Dictionary<Rgba32, IPath> PathsByColor { get; init; } = new();
         }
     }
 }

--- a/CityModelCache.cs
+++ b/CityModelCache.cs
@@ -1,5 +1,6 @@
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Drawing;
+using SixLabors.ImageSharp.PixelFormats;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -57,9 +58,11 @@ namespace StrategyGame
                     var pb = new PathBuilder();
                     foreach (var item in group)
                     {
-                        pb.AddPolygon(new Polygon(new LinearLineSegment(item.Poly.ExteriorRing.Coordinates.Select(c => ProceduralCityRenderer.ToPointF(c.X, c.Y, bounds)).ToArray())));
+                        var points = item.Poly.ExteriorRing.Coordinates.Select(c => ProceduralCityRenderer.ToPointF(c.X, c.Y, bounds)).ToArray();
+                        pb.AddLines(points);
+                        pb.CloseFigure();
                     }
-                    dict[group.Key] = pb.Build();
+                    dict[(Rgba32)group.Key] = pb.Build();
                 }
 
                 return new CachedBuildings { PathsByColor = dict };

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -4,13 +4,14 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using SD = System.Drawing;
-using SDI = System.Drawing.Imaging;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Linq;
 using SkiaSharp;
 using economy_sim;
+using SixLabors.ImageSharp.Advanced;
+using System.Runtime.InteropServices;
 
 namespace StrategyGame
 {
@@ -18,10 +19,8 @@ namespace StrategyGame
     {
         private readonly int _baseWidth;
         private readonly int _baseHeight;
-        // --- START: Added Field ---
         private readonly MultiResolutionMapManager _mapManager;
-        // --- END: Added Field ---
-        private readonly Dictionary<(int cellSize, int x, int y), (SKBitmap sk, SD.Bitmap gdi)> _tileCache = new();
+        private readonly Dictionary<(int cellSize, int x, int y), SKBitmap> _tileCache = new();
         private readonly Dictionary<(int cellSize, int x, int y), Task<SKBitmap>> _inFlight = new();
         private readonly object _cacheLock = new();
         private readonly LinkedList<(int cellSize, int x, int y)> _lruOrder = new();
@@ -51,9 +50,7 @@ namespace StrategyGame
         {
             _baseWidth = baseWidth;
             _baseHeight = baseHeight;
-            // --- START: Added Initialization ---
             _mapManager = mapManager;
-            // --- END: Added Initialization ---
         }
 
         private static SemaphoreSlim GetFileLock(string path)
@@ -69,21 +66,38 @@ namespace StrategyGame
             }
         }
 
-        private static SD.Bitmap ImageSharpToBitmap(Image<Rgba32> img)
+        private static SKBitmap ImageSharpToSkia(Image<Rgba32> img)
         {
-            var sw = Stopwatch.StartNew();
-            using var ms = new MemoryStream();
-            img.SaveAsPng(ms);
-            ms.Position = 0;
-            var bmp = new SD.Bitmap(ms);
-            PerformanceTracker.Record("ImageSharpToBitmap", sw.Elapsed);
-            return bmp;
-        }
+            var info = new SKImageInfo(img.Width, img.Height, SKColorType.Rgba8888, SKAlphaType.Unpremul);
+            var skBitmap = new SKBitmap(info);
 
+            // Use a high-performance method to get a memory span of the whole image
+            if (img.TryGetSinglePixelSpan(out Span<Rgba32> pixelSpan))
+            {
+                // Safely reinterpret the Rgba32 span as a byte span without allocation
+                var byteSpan = MemoryMarshal.AsBytes(pixelSpan);
+
+                // Copy the raw byte data directly to the Skia bitmap's memory
+                byteSpan.CopyTo(new Span<byte>((void*)skBitmap.GetPixels(), byteSpan.Length));
+            }
+            else
+            {
+                // Provide a fallback for rare cases where image memory isn't contiguous
+                img.ProcessPixelRows(accessor =>
+                {
+                    var ptr = skBitmap.GetPixels();
+                    for (int y = 0; y < accessor.Height; y++)
+                    {
+                        var byteSpan = MemoryMarshal.AsBytes(accessor.GetRowSpan(y));
+                        byteSpan.CopyTo(new Span<byte>((void*)(ptr + y * skBitmap.RowBytes), byteSpan.Length));
+                    }
+                });
+            }
+            return skBitmap;
+        }
 
         private void TouchKey((int cellSize, int x, int y) key)
         {
-            var sw = Stopwatch.StartNew();
             lock (_cacheLock)
             {
                 if (_lruNodes.TryGetValue(key, out var node))
@@ -92,15 +106,18 @@ namespace StrategyGame
                     _lruOrder.AddFirst(node);
                 }
             }
-            PerformanceTracker.Record("LRU-TouchKey", sw.Elapsed);
         }
 
-        private void AddToCache((int cellSize, int x, int y) key, (SKBitmap sk, SD.Bitmap gdi) bitmaps)
+        private void AddToCache((int cellSize, int x, int y) key, SKBitmap bitmap)
         {
-            var sw = Stopwatch.StartNew();
             lock (_cacheLock)
             {
-                _tileCache[key] = bitmaps;
+                if (_tileCache.ContainsKey(key))
+                {
+                    _tileCache[key]?.Dispose();
+                }
+
+                _tileCache[key] = bitmap;
                 if (_lruNodes.TryGetValue(key, out var existing))
                 {
                     _lruOrder.Remove(existing);
@@ -112,23 +129,21 @@ namespace StrategyGame
                 {
                     var last = _lruOrder.Last;
                     if (last == null) break;
-                    _lruOrder.RemoveLast();
+
                     var remKey = last.Value;
-                    if (_tileCache.TryGetValue(remKey, out var oldBitmaps))
+                    if (_tileCache.TryGetValue(remKey, out var oldBitmap))
                     {
-                        oldBitmaps.sk.Dispose();
-                        oldBitmaps.gdi.Dispose();
+                        oldBitmap?.Dispose();
                     }
                     _tileCache.Remove(remKey);
                     _lruNodes.Remove(remKey);
+                    _lruOrder.RemoveLast();
                 }
             }
-            PerformanceTracker.Record("AddToCache", sw.Elapsed);
         }
 
         private int GetCellSize(float zoom)
         {
-            var sw = Stopwatch.StartNew();
             float[] anchors = new float[MultiResolutionMapManager.PixelsPerCellLevels.Length];
             for (int i = 0; i < anchors.Length; i++)
                 anchors[i] = MultiResolutionMapManager.PixelsPerCellLevels[i];
@@ -145,17 +160,12 @@ namespace StrategyGame
                 size = anchors[lower] + t * (anchors[lower + 1] - anchors[lower]);
             }
 
-            if (size < 1f)
-                size = 1f;
-
-            var result = (int)Math.Round(size);
-            PerformanceTracker.Record("GetCellSize", sw.Elapsed);
-            return result;
+            if (size < 1f) size = 1f;
+            return (int)Math.Round(size);
         }
 
         private GeoBounds ComputeTileBounds(int cellSize, int tileX, int tileY)
         {
-            var sw = Stopwatch.StartNew();
             int fullW = _baseWidth * cellSize;
             int fullH = _baseHeight * cellSize;
             int offsetX = tileX * MultiResolutionMapManager.TileSizePx;
@@ -163,15 +173,13 @@ namespace StrategyGame
             int tileWidth = Math.Min(MultiResolutionMapManager.TileSizePx, fullW - offsetX);
             int tileHeight = Math.Min(MultiResolutionMapManager.TileSizePx, fullH - offsetY);
 
-            var bounds = new GeoBounds
+            return new GeoBounds
             {
                 MinLon = -180 + (double)offsetX / fullW * 360.0,
                 MaxLon = -180 + (double)(offsetX + tileWidth) / fullW * 360.0,
                 MaxLat = 90 - (double)offsetY / fullH * 180.0,
                 MinLat = 90 - (double)(offsetY + tileHeight) / fullH * 180.0
             };
-            PerformanceTracker.Record("ComputeTileBounds", sw.Elapsed);
-            return bounds;
         }
 
         private string GetTilePath(int cellSize, int tileX, int tileY)
@@ -182,7 +190,6 @@ namespace StrategyGame
 
         public Task<SKBitmap> GetTileAsync(float zoom, int tileX, int tileY, CancellationToken token)
         {
-            var sw = Stopwatch.StartNew();
             int cellSize = GetCellSize(zoom);
             var key = (cellSize, tileX, tileY);
             Task<SKBitmap> result;
@@ -206,39 +213,32 @@ namespace StrategyGame
                     result = task;
                 }
             }
-            PerformanceTracker.Record("GetTileAsync", sw.Elapsed);
             return result;
         }
 
         private async Task<SKBitmap> LoadTileInternalAsync(int cellSize, int tileX, int tileY, CancellationToken token)
         {
-            var sw = Stopwatch.StartNew();
             var key = (cellSize, tileX, tileY);
             lock (_cacheLock)
             {
                 if (_tileCache.TryGetValue(key, out var cached))
                 {
                     TouchKey(key);
-                    PerformanceTracker.Record("LoadTileInternal-CacheHit", sw.Elapsed);
-                    return cached.sk;
+                    return cached;
                 }
             }
 
             string path = GetTilePath(cellSize, tileX, tileY);
             if (File.Exists(path))
             {
-                var swFileLoad = Stopwatch.StartNew();
                 var fileLock = GetFileLock(path);
                 await fileLock.WaitAsync(token).ConfigureAwait(false);
                 try
                 {
                     await using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, true);
                     using var img = await SixLabors.ImageSharp.Image.LoadAsync<Rgba32>(fs, token).ConfigureAwait(false);
-                    var bmp = ImageSharpToBitmap(img);
-                    var sk = SkiaBitmapUtil.ToSKBitmap(bmp);
-                    AddToCache(key, (sk, bmp));
-                    PerformanceTracker.Record("LoadTileInternal-FromDisk", swFileLoad.Elapsed);
-                    PerformanceTracker.Record("LoadTileInternal-Total", sw.Elapsed);
+                    var sk = ImageSharpToSkia(img);
+                    AddToCache(key, sk);
                     return sk;
                 }
                 finally
@@ -247,56 +247,39 @@ namespace StrategyGame
                 }
             }
 
-            var swGeneration = Stopwatch.StartNew();
             GeoBounds bounds = ComputeTileBounds(cellSize, tileX, tileY);
-            var swGen = Stopwatch.StartNew();
             using var generated = await ProceduralCityRenderer.RenderCityTileAsync(bounds, cellSize).ConfigureAwait(false);
-            PerformanceTracker.Record("TileGeneration", swGen.Elapsed);
-            
-            var swBitmap = Stopwatch.StartNew();
-            var bitmap = ImageSharpToBitmap(generated);
-            PerformanceTracker.Record("TileGeneration-ToBitmap", swBitmap.Elapsed);
-            
-            var swSave = Stopwatch.StartNew();
-            string dir = Path.Combine(TileCacheDir, cellSize.ToString());
+            var skBmp = ImageSharpToSkia(generated);
+
+            string dir = Path.GetDirectoryName(path);
             Directory.CreateDirectory(dir);
             var lockFile = GetFileLock(path);
             await lockFile.WaitAsync(token).ConfigureAwait(false);
             try
             {
-                using var clone = generated.Clone();
                 await using var fs = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None, 4096, true);
-                await clone.SaveAsPngAsync(fs, token).ConfigureAwait(false);
+                await generated.SaveAsPngAsync(fs, token).ConfigureAwait(false);
             }
             finally
             {
                 lockFile.Release();
             }
-            PerformanceTracker.Record("TileGeneration-SaveToDisk", swSave.Elapsed);
 
-            var skBmp = SkiaBitmapUtil.ToSKBitmap(bitmap);
-            AddToCache(key, (skBmp, bitmap));
-            PerformanceTracker.Record("LoadTileInternal-Generation", swGeneration.Elapsed);
-            PerformanceTracker.Record("LoadTileInternal-Total", sw.Elapsed);
+            AddToCache(key, skBmp);
             return skBmp;
         }
 
         public SKBitmap AssembleView(float zoom, SD.Rectangle viewArea, Action triggerRefresh = null)
         {
-            var swRender = Stopwatch.StartNew();
             int cellSize = GetCellSize(zoom);
             int tileSize = MultiResolutionMapManager.TileSizePx;
-            
-            var swSurface = Stopwatch.StartNew();
+
             var info = new SKImageInfo(viewArea.Width, viewArea.Height);
             var context = GpuAvailable ? MultiResolutionMapManager.SharedContext : null;
             using var surface = context != null ? SKSurface.Create(context, false, info) : SKSurface.Create(info);
             var canvas = surface.Canvas;
             canvas.Clear(SKColors.Transparent);
-            PerformanceTracker.Record("AssembleView-CreateSurface", swSurface.Elapsed);
 
-            // --- START: Layer Compositing Fix ---
-            // Render the base map layer before drawing city tiles.
             using (var baseMap = _mapManager.AssembleView(zoom, viewArea, triggerRefresh))
             {
                 if (baseMap != null)
@@ -304,17 +287,12 @@ namespace StrategyGame
                     canvas.DrawBitmap(baseMap, SKRect.Create(0, 0, viewArea.Width, viewArea.Height));
                 }
             }
-            // --- END: Layer Compositing Fix ---
 
             int tileStartX = Math.Max(0, viewArea.X / tileSize);
             int tileStartY = Math.Max(0, viewArea.Y / tileSize);
             int tileEndX = (viewArea.Right + tileSize - 1) / tileSize;
             int tileEndY = (viewArea.Bottom + tileSize - 1) / tileSize;
 
-            var swDrawing = Stopwatch.StartNew();
-            int tilesDrawn = 0;
-            int tilesMissing = 0;
-            
             for (int ty = tileStartY; ty < tileEndY; ty++)
             {
                 for (int tx = tileStartX; tx < tileEndX; tx++)
@@ -326,15 +304,13 @@ namespace StrategyGame
                         tx * tileSize - viewArea.X + tileSize,
                         ty * tileSize - viewArea.Y + tileSize);
 
-                    // --- START: Replacement Logic ---
                     SKBitmap tileCopy = null;
                     lock (_cacheLock)
                     {
                         if (_tileCache.TryGetValue(key, out var cachedTile))
                         {
                             TouchKey(key);
-                            // Create a private, safe copy of the tile inside the lock
-                            tileCopy = cachedTile.sk.Copy();
+                            tileCopy = cachedTile.Copy();
                         }
                     }
 
@@ -342,50 +318,23 @@ namespace StrategyGame
                     {
                         using (tileCopy)
                         {
-                            try
-                            {
-                                canvas.DrawBitmap(tileCopy, rect);
-                                tilesDrawn++;
-                            }
-                            catch (AccessViolationException ex)
-                            {
-                                // This catch block is now just a fallback
-                                DebugLogger.Log($"Access violation drawing tile copy {key}: {ex.Message}");
-                            }
+                            canvas.DrawBitmap(tileCopy, rect);
                         }
                     }
                     else
                     {
-                        tilesMissing++;
-                        var ttx = tx;
-                        var tty = ty;
-                        var tileKey = key;
-                        _ = Task.Run(async () =>
-                        {
-                            var swAsync = Stopwatch.StartNew();
-                            var t = await GetTileAsync(zoom, ttx, tty, CancellationToken.None).ConfigureAwait(false);
-                            if (t != null) triggerRefresh?.Invoke();
-                            PerformanceTracker.Record("AssembleView-AsyncTileLoad", swAsync.Elapsed);
-                        });
+                        _ = GetTileAsync(zoom, tx, ty, CancellationToken.None);
                     }
-                    // --- END: Replacement Logic ---
                 }
             }
-            PerformanceTracker.Record("AssembleView-DrawingTiles", swDrawing.Elapsed);
-            PerformanceTracker.Record("AssembleView-TilesDrawn", TimeSpan.FromMilliseconds(tilesDrawn));
-            PerformanceTracker.Record("AssembleView-TilesMissing", TimeSpan.FromMilliseconds(tilesMissing));
 
-            var swReadPixels = Stopwatch.StartNew();
             var result = new SKBitmap(info);
             surface.ReadPixels(result.Info, result.GetPixels(), result.RowBytes, 0, 0);
-            PerformanceTracker.Record("AssembleView-ReadPixels", swReadPixels.Elapsed);
-            PerformanceTracker.Record("TileRendering", swRender.Elapsed);
             return result;
         }
 
-        public async Task PreloadVisibleTilesAsync(float zoom, SD.Rectangle viewRect, int radius = 1, CancellationToken token = default)
+        public async Task PreloadVisibleTilesAsync(float zoom, SD.Rectangle viewRect, int radius = 1, Action triggerRefresh = null, CancellationToken token = default)
         {
-            var sw = Stopwatch.StartNew();
             int cellSize = GetCellSize(zoom);
             int tileSize = MultiResolutionMapManager.TileSizePx;
 
@@ -410,6 +359,12 @@ namespace StrategyGame
 
             foreach (var coord in coords)
             {
+                var key = (cellSize, coord.x, coord.y);
+                lock(_cacheLock)
+                {
+                    if(_tileCache.ContainsKey(key)) continue;
+                }
+
                 await throttle.WaitAsync(token).ConfigureAwait(false);
                 tasks.Add(Task.Run(async () =>
                 {
@@ -426,7 +381,7 @@ namespace StrategyGame
 
             await Task.WhenAll(tasks).ConfigureAwait(false);
 
-            PerformanceTracker.Record("PreloadTiles-Total", sw.Elapsed);
+            triggerRefresh?.Invoke();
         }
     }
 }

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -228,21 +228,27 @@ namespace StrategyGame
             var skBmp = ImageSharpToSkia(generated);
             PerformanceTracker.Record("CityTileManager-GenerateTile", genSw.Elapsed);
 
-            string dir = Path.GetDirectoryName(path);
-            Directory.CreateDirectory(dir);
-            var lockFile = GetFileLock(path);
-            await lockFile.WaitAsync(token).ConfigureAwait(false);
-            try
+            // Save the generated tile image in the background. The caller
+            // shouldn't wait for disk IO before receiving the bitmap.
+            _ = Task.Run(async () =>
             {
-                var saveSw = Stopwatch.StartNew();
-                await using var fs = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None, 4096, true);
-                await generated.SaveAsPngAsync(fs, token).ConfigureAwait(false);
-                PerformanceTracker.Record("CityTileManager-SaveTile", saveSw.Elapsed);
-            }
-            finally
-            {
-                lockFile.Release();
-            }
+                string dir = Path.GetDirectoryName(path);
+                Directory.CreateDirectory(dir);
+                var lockFile = GetFileLock(path);
+                await lockFile.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+                try
+                {
+                    var saveSw = Stopwatch.StartNew();
+                    await using var fs = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None, 4096, true);
+                    await generated.SaveAsPngAsync(fs, CancellationToken.None).ConfigureAwait(false);
+                    PerformanceTracker.Record("CityTileManager-SaveTile", saveSw.Elapsed);
+                }
+                finally
+                {
+                    lockFile.Release();
+                    generated.Dispose();
+                }
+            });
 
             _tileCache.TryAdd(key, skBmp); // Add to concurrent cache
             _inFlight.TryRemove(key, out _); // Clean up in-flight task

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -18,7 +18,7 @@ namespace StrategyGame
     {
         private readonly int _baseWidth;
         private readonly int _baseHeight;
-        private readonly Dictionary<(int cellSize, int x, int y), SKBitmap> _tileCache = new();
+        private readonly Dictionary<(int cellSize, int x, int y), (SKBitmap sk, SD.Bitmap gdi)> _tileCache = new();
         private readonly Dictionary<(int cellSize, int x, int y), Task<SKBitmap>> _inFlight = new();
         private readonly object _cacheLock = new();
         private readonly LinkedList<(int cellSize, int x, int y)> _lruOrder = new();
@@ -89,12 +89,12 @@ namespace StrategyGame
             PerformanceTracker.Record("LRU-TouchKey", sw.Elapsed);
         }
 
-        private void AddToCache((int cellSize, int x, int y) key, SKBitmap bmp)
+        private void AddToCache((int cellSize, int x, int y) key, (SKBitmap sk, SD.Bitmap gdi) bitmaps)
         {
             var sw = Stopwatch.StartNew();
             lock (_cacheLock)
             {
-                _tileCache[key] = bmp;
+                _tileCache[key] = bitmaps;
                 if (_lruNodes.TryGetValue(key, out var existing))
                 {
                     _lruOrder.Remove(existing);
@@ -108,8 +108,11 @@ namespace StrategyGame
                     if (last == null) break;
                     _lruOrder.RemoveLast();
                     var remKey = last.Value;
-                    if (_tileCache.TryGetValue(remKey, out var oldBmp))
-                        oldBmp.Dispose();
+                    if (_tileCache.TryGetValue(remKey, out var oldBitmaps))
+                    {
+                        oldBitmaps.sk.Dispose();
+                        oldBitmaps.gdi.Dispose();
+                    }
                     _tileCache.Remove(remKey);
                     _lruNodes.Remove(remKey);
                 }
@@ -211,7 +214,7 @@ namespace StrategyGame
                 {
                     TouchKey(key);
                     PerformanceTracker.Record("LoadTileInternal-CacheHit", sw.Elapsed);
-                    return cached;
+                    return cached.sk;
                 }
             }
 
@@ -227,8 +230,7 @@ namespace StrategyGame
                     using var img = await SixLabors.ImageSharp.Image.LoadAsync<Rgba32>(fs, token).ConfigureAwait(false);
                     var bmp = ImageSharpToBitmap(img);
                     var sk = SkiaBitmapUtil.ToSKBitmap(bmp);
-                    bmp.Dispose();
-                    AddToCache(key, sk);
+                    AddToCache(key, (sk, bmp));
                     PerformanceTracker.Record("LoadTileInternal-FromDisk", swFileLoad.Elapsed);
                     PerformanceTracker.Record("LoadTileInternal-Total", sw.Elapsed);
                     return sk;
@@ -267,8 +269,7 @@ namespace StrategyGame
             PerformanceTracker.Record("TileGeneration-SaveToDisk", swSave.Elapsed);
 
             var skBmp = SkiaBitmapUtil.ToSKBitmap(bitmap);
-            bitmap.Dispose();
-            AddToCache(key, skBmp);
+            AddToCache(key, (skBmp, bitmap));
             PerformanceTracker.Record("LoadTileInternal-Generation", swGeneration.Elapsed);
             PerformanceTracker.Record("LoadTileInternal-Total", sw.Elapsed);
             return skBmp;
@@ -316,7 +317,7 @@ namespace StrategyGame
                         {
                             TouchKey(key);
                             // Create a private, safe copy of the tile inside the lock
-                            tileCopy = cachedTile.Copy();
+                            tileCopy = cachedTile.sk.Copy();
                         }
                     }
 

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -24,6 +24,8 @@ namespace StrategyGame
         private readonly MultiResolutionMapManager _mapManager;
         private readonly ConcurrentDictionary<(int cellSize, int x, int y), SKBitmap> _tileCache = new();
         private readonly ConcurrentDictionary<(int cellSize, int x, int y), Task<SKBitmap>> _inFlight = new();
+        private readonly ConcurrentDictionary<Guid, CityDataModel> _cityModelCache = new();
+        private readonly ConcurrentDictionary<Guid, Task> _cityModelLoadTasks = new();
         public static readonly bool GpuAvailable;
 
         static CityTileManager()
@@ -80,6 +82,31 @@ namespace StrategyGame
                 }
                 return sem;
             }
+        }
+
+        private void RequestModel(Guid modelId, Action triggerRefresh)
+        {
+            if (_cityModelCache.ContainsKey(modelId) || _cityModelLoadTasks.ContainsKey(modelId))
+                return;
+
+            var loadTask = Task.Run(async () =>
+            {
+                try
+                {
+                    var model = await RoadNetworkGenerator.LoadCityDataModelAsync(modelId).ConfigureAwait(false);
+                    if (model != null)
+                    {
+                        _cityModelCache.TryAdd(model.Id, model);
+                        triggerRefresh?.Invoke();
+                    }
+                }
+                finally
+                {
+                    _cityModelLoadTasks.TryRemove(modelId, out _);
+                }
+            });
+
+            _cityModelLoadTasks.TryAdd(modelId, loadTask);
         }
 
         private static unsafe SKBitmap ImageSharpToSkia(Image<Rgba32> img)
@@ -148,16 +175,16 @@ namespace StrategyGame
             return Path.Combine(tileFolder, $"{tileX}_{tileY}.png");
         }
 
-        public Task<SKBitmap> GetTileAsync(float zoom, int tileX, int tileY, CancellationToken token)
+        public Task<SKBitmap> GetTileAsync(float zoom, int tileX, int tileY, CancellationToken token, Action triggerRefresh = null)
         {
             int cellSize = GetCellSize(zoom);
             var key = (cellSize, tileX, tileY);
 
             // This is a thread-safe way to get an existing task or create a new one.
-            return _inFlight.GetOrAdd(key, (k) => LoadTileInternalAsync(k.cellSize, k.x, k.y, token));
+            return _inFlight.GetOrAdd(key, (k) => LoadTileInternalAsync(k.cellSize, k.x, k.y, token, triggerRefresh));
         }
 
-        private async Task<SKBitmap> LoadTileInternalAsync(int cellSize, int tileX, int tileY, CancellationToken token)
+        private async Task<SKBitmap> LoadTileInternalAsync(int cellSize, int tileX, int tileY, CancellationToken token, Action triggerRefresh)
         {
             var totalSw = Stopwatch.StartNew();
             var key = (cellSize, tileX, tileY);
@@ -192,7 +219,12 @@ namespace StrategyGame
 
             GeoBounds bounds = ComputeTileBounds(cellSize, tileX, tileY);
             var genSw = Stopwatch.StartNew();
-            var generated = await ProceduralCityRenderer.RenderCityTileAsync(bounds, cellSize).ConfigureAwait(false);
+            var generated = ProceduralCityRenderer.RenderCityTile(
+                bounds,
+                cellSize,
+                _cityModelCache,
+                id => RequestModel(id, triggerRefresh)
+            );
             var skBmp = ImageSharpToSkia(generated);
             PerformanceTracker.Record("CityTileManager-GenerateTile", genSw.Elapsed);
 
@@ -266,7 +298,7 @@ namespace StrategyGame
                     }
                     else
                     {
-                        _ = GetTileAsync(zoom, tx, ty, CancellationToken.None);
+                        _ = GetTileAsync(zoom, tx, ty, CancellationToken.None, triggerRefresh);
                     }
                 }
             }
@@ -309,7 +341,7 @@ namespace StrategyGame
                 return;
             }
 
-            var tasks = missingTiles.Select(coord => GetTileAsync(zoom, coord.x, coord.y, token));
+            var tasks = missingTiles.Select(coord => GetTileAsync(zoom, coord.x, coord.y, token, triggerRefresh));
             await Task.WhenAll(tasks).ConfigureAwait(false);
             PerformanceTracker.Record("CityTileManager-PreloadTiles", sw.Elapsed);
             triggerRefresh?.Invoke();

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using System.Linq;
 using SkiaSharp;
 using economy_sim;
-using SixLabors.ImageSharp.Advanced;
 using System.Runtime.InteropServices;
 
 namespace StrategyGame
@@ -66,33 +65,26 @@ namespace StrategyGame
             }
         }
 
-        private static SKBitmap ImageSharpToSkia(Image<Rgba32> img)
+        private static unsafe SKBitmap ImageSharpToSkia(Image<Rgba32> img)
         {
             var info = new SKImageInfo(img.Width, img.Height, SKColorType.Rgba8888, SKAlphaType.Unpremul);
             var skBitmap = new SKBitmap(info);
+            var ptr = skBitmap.GetPixels();
 
-            // Use a high-performance method to get a memory span of the whole image
-            if (img.TryGetSinglePixelSpan(out Span<Rgba32> pixelSpan))
+            // Process the image row-by-row for broader ImageSharp version compatibility.
+            img.ProcessPixelRows(accessor =>
             {
-                // Safely reinterpret the Rgba32 span as a byte span without allocation
-                var byteSpan = MemoryMarshal.AsBytes(pixelSpan);
-
-                // Copy the raw byte data directly to the Skia bitmap's memory
-                byteSpan.CopyTo(new Span<byte>((void*)skBitmap.GetPixels(), byteSpan.Length));
-            }
-            else
-            {
-                // Provide a fallback for rare cases where image memory isn't contiguous
-                img.ProcessPixelRows(accessor =>
+                for (int y = 0; y < accessor.Height; y++)
                 {
-                    var ptr = skBitmap.GetPixels();
-                    for (int y = 0; y < accessor.Height; y++)
-                    {
-                        var byteSpan = MemoryMarshal.AsBytes(accessor.GetRowSpan(y));
-                        byteSpan.CopyTo(new Span<byte>((void*)(ptr + y * skBitmap.RowBytes), byteSpan.Length));
-                    }
-                });
-            }
+                    // Safely reinterpret the Rgba32 span for the current row as a byte span.
+                    var byteSpan = MemoryMarshal.AsBytes(accessor.GetRowSpan(y));
+
+                    // Create a span for the destination row in the Skia bitmap and copy the data.
+                    var destSpan = new Span<byte>((void*)(ptr + y * skBitmap.RowBytes), byteSpan.Length);
+                    byteSpan.CopyTo(destSpan);
+                }
+            });
+
             return skBitmap;
         }
 

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -329,7 +329,6 @@ namespace StrategyGame
         {
             int cellSize = GetCellSize(zoom);
             int tileSize = MultiResolutionMapManager.TileSizePx;
-
             var mapSize = new SD.Size(_baseWidth * cellSize, _baseHeight * cellSize);
 
             int startX = Math.Max(0, viewRect.X / tileSize - radius);
@@ -337,31 +336,45 @@ namespace StrategyGame
             int startY = Math.Max(0, viewRect.Y / tileSize - radius);
             int endY = Math.Min((mapSize.Height - 1) / tileSize, (viewRect.Bottom - 1) / tileSize + radius);
 
-            var coords = new List<(int x, int y)>();
-            for (int x = startX; x <= endX; x++)
+            // --- START: Refactored Logic ---
+
+            // 1. Identify all tiles that need loading in a single, quick lock.
+            var missingTiles = new List<(int x, int y)>();
+            lock (_cacheLock)
             {
-                for (int y = startY; y <= endY; y++)
+                for (int x = startX; x <= endX; x++)
                 {
-                    coords.Add((x, y));
+                    for (int y = startY; y <= endY; y++)
+                    {
+                        var key = (cellSize, x, y);
+                        // Check both the tile cache and the in-flight generation list.
+                        if (!_tileCache.ContainsKey(key) && !_inFlight.ContainsKey(key))
+                        {
+                            missingTiles.Add((x, y));
+                        }
+                    }
                 }
             }
 
+            // 2. If all tiles are already cached or in-flight, just refresh and exit.
+            if (!missingTiles.Any())
+            {
+                triggerRefresh?.Invoke();
+                return;
+            }
+
+            // 3. Launch throttled tasks only for the truly missing tiles.
             using var throttle = new SemaphoreSlim(Environment.ProcessorCount);
             var tasks = new List<Task>();
 
-            foreach (var coord in coords)
+            foreach (var coord in missingTiles)
             {
-                var key = (cellSize, coord.x, coord.y);
-                lock(_cacheLock)
-                {
-                    if(_tileCache.ContainsKey(key)) continue;
-                }
-
                 await throttle.WaitAsync(token).ConfigureAwait(false);
                 tasks.Add(Task.Run(async () =>
                 {
                     try
                     {
+                        // GetTileAsync will create an _inFlight entry, preventing duplicates.
                         await GetTileAsync(zoom, coord.x, coord.y, token).ConfigureAwait(false);
                     }
                     finally
@@ -373,7 +386,10 @@ namespace StrategyGame
 
             await Task.WhenAll(tasks).ConfigureAwait(false);
 
+            // 4. Trigger a single refresh after all new tiles are generated.
             triggerRefresh?.Invoke();
+
+            // --- END: Refactored Logic ---
         }
     }
-}
+    }

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -52,7 +52,7 @@ namespace StrategyGame
             public ImagePixelOwner(Image<Rgba32> image)
             {
                 Image = image;
-                Handle = image.GetPixelMemory().Pin();
+                Handle = image.Frames.RootFrame.DangerousTryGetSinglePixelMemory(out var memory) ? memory.Pin() : throw new InvalidOperationException("Unable to pin pixel memory.");
             }
 
             public void Dispose()

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -12,6 +12,8 @@ using System.Linq;
 using SkiaSharp;
 using economy_sim;
 using System.Runtime.InteropServices;
+using System.Runtime.CompilerServices;
+using System.Buffers;
 
 namespace StrategyGame
 {
@@ -42,6 +44,24 @@ namespace StrategyGame
             Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
             "data", "city_tile_cache");
 
+        private sealed class ImagePixelOwner : IDisposable
+        {
+            public Image<Rgba32> Image { get; }
+            public MemoryHandle Handle { get; }
+
+            public ImagePixelOwner(Image<Rgba32> image)
+            {
+                Image = image;
+                Handle = image.GetPixelMemory().Pin();
+            }
+
+            public void Dispose()
+            {
+                Handle.Dispose();
+                Image.Dispose();
+            }
+        }
+
         public CityTileManager(int baseWidth, int baseHeight, MultiResolutionMapManager mapManager)
         {
             _baseWidth = baseWidth;
@@ -65,22 +85,15 @@ namespace StrategyGame
         private static unsafe SKBitmap ImageSharpToSkia(Image<Rgba32> img)
         {
             var info = new SKImageInfo(img.Width, img.Height, SKColorType.Rgba8888, SKAlphaType.Unpremul);
-            var skBitmap = new SKBitmap(info);
-            var ptr = skBitmap.GetPixels();
+            var owner = new ImagePixelOwner(img);
+            var skBitmap = new SKBitmap();
 
-            // Process the image row-by-row for broader ImageSharp version compatibility.
-            img.ProcessPixelRows(accessor =>
-            {
-                for (int y = 0; y < accessor.Height; y++)
-                {
-                    // Safely reinterpret the Rgba32 span for the current row as a byte span.
-                    var byteSpan = MemoryMarshal.AsBytes(accessor.GetRowSpan(y));
-
-                    // Create a span for the destination row in the Skia bitmap and copy the data.
-                    var destSpan = new Span<byte>((void*)(ptr + y * skBitmap.RowBytes), byteSpan.Length);
-                    byteSpan.CopyTo(destSpan);
-                }
-            });
+            skBitmap.InstallPixels(
+                info,
+                (IntPtr)owner.Handle.Pointer,
+                img.Width * Unsafe.SizeOf<Rgba32>(),
+                (addr, ctx) => ((ImagePixelOwner)ctx!).Dispose(),
+                owner);
 
             return skBitmap;
         }
@@ -159,7 +172,7 @@ namespace StrategyGame
                 try
                 {
                     await using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, true);
-                    using var img = await SixLabors.ImageSharp.Image.LoadAsync<Rgba32>(fs, token).ConfigureAwait(false);
+                    var img = await SixLabors.ImageSharp.Image.LoadAsync<Rgba32>(fs, token).ConfigureAwait(false);
                     var sk = ImageSharpToSkia(img);
                     _tileCache.TryAdd(key, sk); // Add to concurrent cache
                     _inFlight.TryRemove(key, out _); // Clean up in-flight task
@@ -172,7 +185,7 @@ namespace StrategyGame
             }
 
             GeoBounds bounds = ComputeTileBounds(cellSize, tileX, tileY);
-            using var generated = await ProceduralCityRenderer.RenderCityTileAsync(bounds, cellSize).ConfigureAwait(false);
+            var generated = await ProceduralCityRenderer.RenderCityTileAsync(bounds, cellSize).ConfigureAwait(false);
             var skBmp = ImageSharpToSkia(generated);
 
             string dir = Path.GetDirectoryName(path);
@@ -229,18 +242,15 @@ namespace StrategyGame
                         tx * tileSize - viewArea.X + tileSize,
                         ty * tileSize - viewArea.Y + tileSize);
 
-                    SKBitmap tileCopy = null;
+                    SKBitmap tileBitmap = null;
                     if (_tileCache.TryGetValue(key, out var cachedTile))
                     {
-                        tileCopy = cachedTile.Copy();
+                        tileBitmap = cachedTile;
                     }
 
-                    if (tileCopy != null)
+                    if (tileBitmap != null)
                     {
-                        using (tileCopy)
-                        {
-                            canvas.DrawBitmap(tileCopy, rect);
-                        }
+                        canvas.DrawBitmap(tileBitmap, rect);
                     }
                     else
                     {

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -24,7 +24,6 @@ namespace StrategyGame
         private readonly MultiResolutionMapManager _mapManager;
         private readonly ConcurrentDictionary<(int cellSize, int x, int y), SKBitmap> _tileCache = new();
         private readonly ConcurrentDictionary<(int cellSize, int x, int y), Task<SKBitmap>> _inFlight = new();
-        private readonly ConcurrentDictionary<Guid, CityDataModel> _cityModelCache = new();
         private readonly ConcurrentDictionary<Guid, Task> _cityModelLoadTasks = new();
         public static readonly bool GpuAvailable;
 
@@ -84,9 +83,9 @@ namespace StrategyGame
             }
         }
 
-        private void RequestModel(Guid modelId, Action triggerRefresh)
+        private void RequestModel(Guid modelId, Action? triggerRefresh)
         {
-            if (_cityModelCache.ContainsKey(modelId) || _cityModelLoadTasks.ContainsKey(modelId))
+            if (RoadNetworkGenerator.ModelCacheById.ContainsKey(modelId) || _cityModelLoadTasks.ContainsKey(modelId))
                 return;
 
             var loadTask = Task.Run(async () =>
@@ -95,10 +94,7 @@ namespace StrategyGame
                 {
                     var model = await RoadNetworkGenerator.LoadCityDataModelAsync(modelId).ConfigureAwait(false);
                     if (model != null)
-                    {
-                        _cityModelCache.TryAdd(model.Id, model);
                         triggerRefresh?.Invoke();
-                    }
                 }
                 finally
                 {
@@ -222,7 +218,7 @@ namespace StrategyGame
             var generated = await ProceduralCityRenderer.RenderCityTileAsync(
                 bounds,
                 cellSize,
-                _cityModelCache,
+                RoadNetworkGenerator.ModelCacheById,
                 id => RequestModel(id, triggerRefresh)
             ).ConfigureAwait(false);
             var skBmp = ImageSharpToSkia(generated);

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -225,9 +225,12 @@ namespace StrategyGame
             PerformanceTracker.Record("CityTileManager-GenerateTile", genSw.Elapsed);
 
             // Save the generated tile image in the background. The caller
-            // shouldn't wait for disk IO before receiving the bitmap.
+            // shouldn't wait for disk IO before receiving the bitmap. Clone
+            // the image so disposing it won't affect the SKBitmap.
             _ = Task.Run(async () =>
             {
+                using var imageToSave = generated.Clone();
+
                 string dir = Path.GetDirectoryName(path);
                 Directory.CreateDirectory(dir);
                 var lockFile = GetFileLock(path);
@@ -236,13 +239,12 @@ namespace StrategyGame
                 {
                     var saveSw = Stopwatch.StartNew();
                     await using var fs = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None, 4096, true);
-                    await generated.SaveAsPngAsync(fs, CancellationToken.None).ConfigureAwait(false);
+                    await imageToSave.SaveAsPngAsync(fs, CancellationToken.None).ConfigureAwait(false);
                     PerformanceTracker.Record("CityTileManager-SaveTile", saveSw.Elapsed);
                 }
                 finally
                 {
                     lockFile.Release();
-                    generated.Dispose();
                 }
             });
 

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -309,16 +309,28 @@ namespace StrategyGame
                         ty * tileSize - viewArea.Y + tileSize);
 
                     SKBitmap tex = null;
+                    bool drew = false;
                     lock (_cacheLock)
-                        _tileCache.TryGetValue(key, out tex);
-
-                    if (tex != null)
                     {
-                        TouchKey(key);
-                        canvas.DrawBitmap(tex, rect);
-                        tilesDrawn++;
+                        if (_tileCache.TryGetValue(key, out tex))
+                        {
+                            TouchKey(key);
+                            try
+                            {
+                                canvas.DrawBitmap(tex, rect);
+                                drew = true;
+                                tilesDrawn++;
+                            }
+                            catch (AccessViolationException ex)
+                            {
+                                DebugLogger.Log($"Access violation drawing tile {key}: {ex.Message}");
+                                tex.Dispose();
+                                _tileCache.Remove(key);
+                            }
+                        }
                     }
-                    else
+
+                    if (!drew)
                     {
                         tilesMissing++;
                         var ttx = tx;

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -308,29 +308,35 @@ namespace StrategyGame
                         tx * tileSize - viewArea.X + tileSize,
                         ty * tileSize - viewArea.Y + tileSize);
 
-                    SKBitmap tex = null;
-                    bool drew = false;
+                    // --- START: Replacement Logic ---
+                    SKBitmap tileCopy = null;
                     lock (_cacheLock)
                     {
-                        if (_tileCache.TryGetValue(key, out tex))
+                        if (_tileCache.TryGetValue(key, out var cachedTile))
                         {
                             TouchKey(key);
+                            // Create a private, safe copy of the tile inside the lock
+                            tileCopy = cachedTile.Copy();
+                        }
+                    }
+
+                    if (tileCopy != null)
+                    {
+                        using (tileCopy)
+                        {
                             try
                             {
-                                canvas.DrawBitmap(tex, rect);
-                                drew = true;
+                                canvas.DrawBitmap(tileCopy, rect);
                                 tilesDrawn++;
                             }
                             catch (AccessViolationException ex)
                             {
-                                DebugLogger.Log($"Access violation drawing tile {key}: {ex.Message}");
-                                tex.Dispose();
-                                _tileCache.Remove(key);
+                                // This catch block is now just a fallback
+                                DebugLogger.Log($"Access violation drawing tile copy {key}: {ex.Message}");
                             }
                         }
                     }
-
-                    if (!drew)
+                    else
                     {
                         tilesMissing++;
                         var ttx = tx;
@@ -344,6 +350,7 @@ namespace StrategyGame
                             PerformanceTracker.Record("AssembleView-AsyncTileLoad", swAsync.Elapsed);
                         });
                     }
+                    // --- END: Replacement Logic ---
                 }
             }
             PerformanceTracker.Record("AssembleView-DrawingTiles", swDrawing.Elapsed);

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -2,6 +2,7 @@ using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using System;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using SD = System.Drawing;
 using System.IO;
@@ -19,12 +20,8 @@ namespace StrategyGame
         private readonly int _baseWidth;
         private readonly int _baseHeight;
         private readonly MultiResolutionMapManager _mapManager;
-        private readonly Dictionary<(int cellSize, int x, int y), SKBitmap> _tileCache = new();
-        private readonly Dictionary<(int cellSize, int x, int y), Task<SKBitmap>> _inFlight = new();
-        private readonly object _cacheLock = new();
-        private readonly LinkedList<(int cellSize, int x, int y)> _lruOrder = new();
-        private readonly Dictionary<(int cellSize, int x, int y), LinkedListNode<(int cellSize, int x, int y)>> _lruNodes = new();
-        private const int MaxCacheSize = 256;
+        private readonly ConcurrentDictionary<(int cellSize, int x, int y), SKBitmap> _tileCache = new();
+        private readonly ConcurrentDictionary<(int cellSize, int x, int y), Task<SKBitmap>> _inFlight = new();
         public static readonly bool GpuAvailable;
 
         static CityTileManager()
@@ -88,51 +85,7 @@ namespace StrategyGame
             return skBitmap;
         }
 
-        private void TouchKey((int cellSize, int x, int y) key)
-        {
-            lock (_cacheLock)
-            {
-                if (_lruNodes.TryGetValue(key, out var node))
-                {
-                    _lruOrder.Remove(node);
-                    _lruOrder.AddFirst(node);
-                }
-            }
-        }
 
-        private void AddToCache((int cellSize, int x, int y) key, SKBitmap bitmap)
-        {
-            lock (_cacheLock)
-            {
-                if (_tileCache.ContainsKey(key))
-                {
-                    _tileCache[key]?.Dispose();
-                }
-
-                _tileCache[key] = bitmap;
-                if (_lruNodes.TryGetValue(key, out var existing))
-                {
-                    _lruOrder.Remove(existing);
-                }
-                var node = _lruOrder.AddFirst(key);
-                _lruNodes[key] = node;
-
-                while (_tileCache.Count > MaxCacheSize)
-                {
-                    var last = _lruOrder.Last;
-                    if (last == null) break;
-
-                    var remKey = last.Value;
-                    if (_tileCache.TryGetValue(remKey, out var oldBitmap))
-                    {
-                        oldBitmap?.Dispose();
-                    }
-                    _tileCache.Remove(remKey);
-                    _lruNodes.Remove(remKey);
-                    _lruOrder.RemoveLast();
-                }
-            }
-        }
 
         private int GetCellSize(float zoom)
         {
@@ -184,40 +137,18 @@ namespace StrategyGame
         {
             int cellSize = GetCellSize(zoom);
             var key = (cellSize, tileX, tileY);
-            Task<SKBitmap> result;
-            lock (_cacheLock)
-            {
-                if (_inFlight.TryGetValue(key, out var existing))
-                {
-                    result = existing;
-                }
-                else
-                {
-                    var task = LoadTileInternalAsync(cellSize, tileX, tileY, token);
-                    _inFlight[key] = task;
-                    task.ContinueWith(_ =>
-                    {
-                        lock (_cacheLock)
-                        {
-                            _inFlight.Remove(key);
-                        }
-                    }, TaskScheduler.Default);
-                    result = task;
-                }
-            }
-            return result;
+
+            // This is a thread-safe way to get an existing task or create a new one.
+            return _inFlight.GetOrAdd(key, (k) => LoadTileInternalAsync(k.cellSize, k.x, k.y, token));
         }
 
         private async Task<SKBitmap> LoadTileInternalAsync(int cellSize, int tileX, int tileY, CancellationToken token)
         {
             var key = (cellSize, tileX, tileY);
-            lock (_cacheLock)
+            if (_tileCache.TryGetValue(key, out var cached))
             {
-                if (_tileCache.TryGetValue(key, out var cached))
-                {
-                    TouchKey(key);
-                    return cached;
-                }
+                _inFlight.TryRemove(key, out _);
+                return cached;
             }
 
             string path = GetTilePath(cellSize, tileX, tileY);
@@ -230,7 +161,8 @@ namespace StrategyGame
                     await using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, true);
                     using var img = await SixLabors.ImageSharp.Image.LoadAsync<Rgba32>(fs, token).ConfigureAwait(false);
                     var sk = ImageSharpToSkia(img);
-                    AddToCache(key, sk);
+                    _tileCache.TryAdd(key, sk); // Add to concurrent cache
+                    _inFlight.TryRemove(key, out _); // Clean up in-flight task
                     return sk;
                 }
                 finally
@@ -257,7 +189,8 @@ namespace StrategyGame
                 lockFile.Release();
             }
 
-            AddToCache(key, skBmp);
+            _tileCache.TryAdd(key, skBmp); // Add to concurrent cache
+            _inFlight.TryRemove(key, out _); // Clean up in-flight task
             return skBmp;
         }
 
@@ -297,13 +230,9 @@ namespace StrategyGame
                         ty * tileSize - viewArea.Y + tileSize);
 
                     SKBitmap tileCopy = null;
-                    lock (_cacheLock)
+                    if (_tileCache.TryGetValue(key, out var cachedTile))
                     {
-                        if (_tileCache.TryGetValue(key, out var cachedTile))
-                        {
-                            TouchKey(key);
-                            tileCopy = cachedTile.Copy();
-                        }
+                        tileCopy = cachedTile.Copy();
                     }
 
                     if (tileCopy != null)
@@ -340,18 +269,14 @@ namespace StrategyGame
 
             // 1. Identify all tiles that need loading in a single, quick lock.
             var missingTiles = new List<(int x, int y)>();
-            lock (_cacheLock)
+            for (int x = startX; x <= endX; x++)
             {
-                for (int x = startX; x <= endX; x++)
+                for (int y = startY; y <= endY; y++)
                 {
-                    for (int y = startY; y <= endY; y++)
+                    var key = (cellSize, x, y);
+                    if (!_tileCache.ContainsKey(key) && !_inFlight.ContainsKey(key))
                     {
-                        var key = (cellSize, x, y);
-                        // Check both the tile cache and the in-flight generation list.
-                        if (!_tileCache.ContainsKey(key) && !_inFlight.ContainsKey(key))
-                        {
-                            missingTiles.Add((x, y));
-                        }
+                        missingTiles.Add((x, y));
                     }
                 }
             }

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -84,6 +84,7 @@ namespace StrategyGame
 
         private static unsafe SKBitmap ImageSharpToSkia(Image<Rgba32> img)
         {
+            var sw = Stopwatch.StartNew();
             var info = new SKImageInfo(img.Width, img.Height, SKColorType.Rgba8888, SKAlphaType.Unpremul);
             var owner = new ImagePixelOwner(img);
             var skBitmap = new SKBitmap();
@@ -95,6 +96,7 @@ namespace StrategyGame
                 (addr, ctx) => ((ImagePixelOwner)ctx!).Dispose(),
                 owner);
 
+            PerformanceTracker.Record("CityTileManager-ImageSharpToSkia", sw.Elapsed);
             return skBitmap;
         }
 
@@ -157,16 +159,19 @@ namespace StrategyGame
 
         private async Task<SKBitmap> LoadTileInternalAsync(int cellSize, int tileX, int tileY, CancellationToken token)
         {
+            var totalSw = Stopwatch.StartNew();
             var key = (cellSize, tileX, tileY);
             if (_tileCache.TryGetValue(key, out var cached))
             {
                 _inFlight.TryRemove(key, out _);
+                PerformanceTracker.Record("CityTileManager-LoadTile-Cached", totalSw.Elapsed);
                 return cached;
             }
 
             string path = GetTilePath(cellSize, tileX, tileY);
             if (File.Exists(path))
             {
+                var loadSw = Stopwatch.StartNew();
                 var fileLock = GetFileLock(path);
                 await fileLock.WaitAsync(token).ConfigureAwait(false);
                 try
@@ -176,6 +181,7 @@ namespace StrategyGame
                     var sk = ImageSharpToSkia(img);
                     _tileCache.TryAdd(key, sk); // Add to concurrent cache
                     _inFlight.TryRemove(key, out _); // Clean up in-flight task
+                    PerformanceTracker.Record("CityTileManager-LoadTile-FromDisk", loadSw.Elapsed);
                     return sk;
                 }
                 finally
@@ -185,8 +191,10 @@ namespace StrategyGame
             }
 
             GeoBounds bounds = ComputeTileBounds(cellSize, tileX, tileY);
+            var genSw = Stopwatch.StartNew();
             var generated = await ProceduralCityRenderer.RenderCityTileAsync(bounds, cellSize).ConfigureAwait(false);
             var skBmp = ImageSharpToSkia(generated);
+            PerformanceTracker.Record("CityTileManager-GenerateTile", genSw.Elapsed);
 
             string dir = Path.GetDirectoryName(path);
             Directory.CreateDirectory(dir);
@@ -194,8 +202,10 @@ namespace StrategyGame
             await lockFile.WaitAsync(token).ConfigureAwait(false);
             try
             {
+                var saveSw = Stopwatch.StartNew();
                 await using var fs = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None, 4096, true);
                 await generated.SaveAsPngAsync(fs, token).ConfigureAwait(false);
+                PerformanceTracker.Record("CityTileManager-SaveTile", saveSw.Elapsed);
             }
             finally
             {
@@ -204,11 +214,13 @@ namespace StrategyGame
 
             _tileCache.TryAdd(key, skBmp); // Add to concurrent cache
             _inFlight.TryRemove(key, out _); // Clean up in-flight task
+            PerformanceTracker.Record("CityTileManager-LoadTile", totalSw.Elapsed);
             return skBmp;
         }
 
         public SKBitmap AssembleView(float zoom, SD.Rectangle viewArea, Action triggerRefresh = null)
         {
+            var sw = Stopwatch.StartNew();
             int cellSize = GetCellSize(zoom);
             int tileSize = MultiResolutionMapManager.TileSizePx;
 
@@ -261,11 +273,13 @@ namespace StrategyGame
 
             var result = new SKBitmap(info);
             surface.ReadPixels(result.Info, result.GetPixels(), result.RowBytes, 0, 0);
+            PerformanceTracker.Record("CityTileManager-AssembleView", sw.Elapsed);
             return result;
         }
 
         public async Task PreloadVisibleTilesAsync(float zoom, SD.Rectangle viewRect, int radius = 1, Action triggerRefresh = null, CancellationToken token = default)
         {
+            var sw = Stopwatch.StartNew();
             int cellSize = GetCellSize(zoom);
             int tileSize = MultiResolutionMapManager.TileSizePx;
             var mapSize = new SD.Size(_baseWidth * cellSize, _baseHeight * cellSize);
@@ -290,12 +304,14 @@ namespace StrategyGame
 
             if (!missingTiles.Any())
             {
+                PerformanceTracker.Record("CityTileManager-PreloadTiles", sw.Elapsed);
                 triggerRefresh?.Invoke();
                 return;
             }
 
             var tasks = missingTiles.Select(coord => GetTileAsync(zoom, coord.x, coord.y, token));
             await Task.WhenAll(tasks).ConfigureAwait(false);
+            PerformanceTracker.Record("CityTileManager-PreloadTiles", sw.Elapsed);
             triggerRefresh?.Invoke();
         }
     }

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -383,21 +383,27 @@ namespace StrategyGame
             return result;
         }
 
-        public async Task PreloadVisibleTilesAsync(float zoom, SD.Rectangle viewRect, CancellationToken token = default)
+        public async Task PreloadVisibleTilesAsync(float zoom, SD.Rectangle viewRect, int radius = 1, CancellationToken token = default)
         {
             var sw = Stopwatch.StartNew();
             int cellSize = GetCellSize(zoom);
             int tileSize = MultiResolutionMapManager.TileSizePx;
-            int startX = Math.Max(0, viewRect.X / tileSize);
-            int endX = (viewRect.Right + tileSize - 1) / tileSize;
-            int startY = Math.Max(0, viewRect.Y / tileSize);
-            int endY = (viewRect.Bottom + tileSize - 1) / tileSize;
 
-            var coords = Enumerable
-                .Range(startX, endX - startX)
-                .SelectMany(x => Enumerable.Range(startY, endY - startY)
-                    .Select(y => (x, y)))
-                .ToList();
+            var mapSize = new SD.Size(_baseWidth * cellSize, _baseHeight * cellSize);
+
+            int startX = Math.Max(0, viewRect.X / tileSize - radius);
+            int endX = Math.Min((mapSize.Width - 1) / tileSize, (viewRect.Right - 1) / tileSize + radius);
+            int startY = Math.Max(0, viewRect.Y / tileSize - radius);
+            int endY = Math.Min((mapSize.Height - 1) / tileSize, (viewRect.Bottom - 1) / tileSize + radius);
+
+            var coords = new List<(int x, int y)>();
+            for (int x = startX; x <= endX; x++)
+            {
+                for (int y = startY; y <= endY; y++)
+                {
+                    coords.Add((x, y));
+                }
+            }
 
             using var throttle = new SemaphoreSlim(Environment.ProcessorCount);
             var tasks = new List<Task>();

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -265,9 +265,6 @@ namespace StrategyGame
             int startY = Math.Max(0, viewRect.Y / tileSize - radius);
             int endY = Math.Min((mapSize.Height - 1) / tileSize, (viewRect.Bottom - 1) / tileSize + radius);
 
-            // --- START: Refactored Logic ---
-
-            // 1. Identify all tiles that need loading in a single, quick lock.
             var missingTiles = new List<(int x, int y)>();
             for (int x = startX; x <= endX; x++)
             {
@@ -281,40 +278,15 @@ namespace StrategyGame
                 }
             }
 
-            // 2. If all tiles are already cached or in-flight, just refresh and exit.
             if (!missingTiles.Any())
             {
                 triggerRefresh?.Invoke();
                 return;
             }
 
-            // 3. Launch throttled tasks only for the truly missing tiles.
-            using var throttle = new SemaphoreSlim(Environment.ProcessorCount);
-            var tasks = new List<Task>();
-
-            foreach (var coord in missingTiles)
-            {
-                await throttle.WaitAsync(token).ConfigureAwait(false);
-                tasks.Add(Task.Run(async () =>
-                {
-                    try
-                    {
-                        // GetTileAsync will create an _inFlight entry, preventing duplicates.
-                        await GetTileAsync(zoom, coord.x, coord.y, token).ConfigureAwait(false);
-                    }
-                    finally
-                    {
-                        throttle.Release();
-                    }
-                }, token));
-            }
-
+            var tasks = missingTiles.Select(coord => GetTileAsync(zoom, coord.x, coord.y, token));
             await Task.WhenAll(tasks).ConfigureAwait(false);
-
-            // 4. Trigger a single refresh after all new tiles are generated.
             triggerRefresh?.Invoke();
-
-            // --- END: Refactored Logic ---
         }
     }
     }

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -219,12 +219,12 @@ namespace StrategyGame
 
             GeoBounds bounds = ComputeTileBounds(cellSize, tileX, tileY);
             var genSw = Stopwatch.StartNew();
-            var generated = ProceduralCityRenderer.RenderCityTile(
+            var generated = await ProceduralCityRenderer.RenderCityTileAsync(
                 bounds,
                 cellSize,
                 _cityModelCache,
                 id => RequestModel(id, triggerRefresh)
-            );
+            ).ConfigureAwait(false);
             var skBmp = ImageSharpToSkia(generated);
             PerformanceTracker.Record("CityTileManager-GenerateTile", genSw.Elapsed);
 

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -18,6 +18,9 @@ namespace StrategyGame
     {
         private readonly int _baseWidth;
         private readonly int _baseHeight;
+        // --- START: Added Field ---
+        private readonly MultiResolutionMapManager _mapManager;
+        // --- END: Added Field ---
         private readonly Dictionary<(int cellSize, int x, int y), (SKBitmap sk, SD.Bitmap gdi)> _tileCache = new();
         private readonly Dictionary<(int cellSize, int x, int y), Task<SKBitmap>> _inFlight = new();
         private readonly object _cacheLock = new();
@@ -44,10 +47,13 @@ namespace StrategyGame
             Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
             "data", "city_tile_cache");
 
-        public CityTileManager(int baseWidth, int baseHeight)
+        public CityTileManager(int baseWidth, int baseHeight, MultiResolutionMapManager mapManager)
         {
             _baseWidth = baseWidth;
             _baseHeight = baseHeight;
+            // --- START: Added Initialization ---
+            _mapManager = mapManager;
+            // --- END: Added Initialization ---
         }
 
         private static SemaphoreSlim GetFileLock(string path)
@@ -288,6 +294,17 @@ namespace StrategyGame
             var canvas = surface.Canvas;
             canvas.Clear(SKColors.Transparent);
             PerformanceTracker.Record("AssembleView-CreateSurface", swSurface.Elapsed);
+
+            // --- START: Layer Compositing Fix ---
+            // Render the base map layer before drawing city tiles.
+            using (var baseMap = _mapManager.AssembleView(zoom, viewArea, triggerRefresh))
+            {
+                if (baseMap != null)
+                {
+                    canvas.DrawBitmap(baseMap, SKRect.Create(0, 0, viewArea.Width, viewArea.Height));
+                }
+            }
+            // --- END: Layer Compositing Fix ---
 
             int tileStartX = Math.Max(0, viewArea.X / tileSize);
             int tileStartY = Math.Max(0, viewArea.Y / tileSize);

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -366,7 +366,7 @@ namespace StrategyGame
             return result;
         }
 
-        public void PreloadVisibleTiles(float zoom, SD.Rectangle viewRect)
+        public async Task PreloadVisibleTilesAsync(float zoom, SD.Rectangle viewRect, CancellationToken token = default)
         {
             var sw = Stopwatch.StartNew();
             int cellSize = GetCellSize(zoom);
@@ -382,29 +382,27 @@ namespace StrategyGame
                     .Select(y => (x, y)))
                 .ToList();
 
-            int tileCount = coords.Count;
             using var throttle = new SemaphoreSlim(Environment.ProcessorCount);
-            int loaded = 0;
+            var tasks = new List<Task>();
 
-            var swParallel = Stopwatch.StartNew();
-            Parallel.ForEach(coords, coord =>
+            foreach (var coord in coords)
             {
-                throttle.Wait();
-                try
+                await throttle.WaitAsync(token).ConfigureAwait(false);
+                tasks.Add(Task.Run(async () =>
                 {
-                    var swTile = Stopwatch.StartNew();
-                    GetTileAsync(zoom, coord.x, coord.y, CancellationToken.None)
-                        .GetAwaiter().GetResult();
-                    PerformanceTracker.Record("PreloadTile-Single", swTile.Elapsed);
-                    Interlocked.Increment(ref loaded);
-                }
-                finally
-                {
-                    throttle.Release();
-                }
-            });
-            PerformanceTracker.Record("PreloadTiles-Parallel", swParallel.Elapsed);
-            PerformanceTracker.Record("PreloadTiles-Count", TimeSpan.FromMilliseconds(loaded));
+                    try
+                    {
+                        await GetTileAsync(zoom, coord.x, coord.y, token).ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        throttle.Release();
+                    }
+                }, token));
+            }
+
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+
             PerformanceTracker.Record("PreloadTiles-Total", sw.Elapsed);
         }
     }

--- a/LoadingForm.Designer.cs
+++ b/LoadingForm.Designer.cs
@@ -1,0 +1,38 @@
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace economy_sim
+{
+    public partial class LoadingForm : Form
+    {
+        private ProgressBar progressBar;
+        private Label labelStatus;
+
+        private void InitializeComponent()
+        {
+            progressBar = new ProgressBar();
+            labelStatus = new Label();
+            SuspendLayout();
+
+            progressBar.Dock = DockStyle.Bottom;
+            progressBar.Minimum = 0;
+            progressBar.Maximum = 100;
+            progressBar.Style = ProgressBarStyle.Continuous;
+
+            labelStatus.Dock = DockStyle.Fill;
+            labelStatus.TextAlign = ContentAlignment.MiddleCenter;
+
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(300, 80);
+            Controls.Add(labelStatus);
+            Controls.Add(progressBar);
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            StartPosition = FormStartPosition.CenterScreen;
+            Text = "Loading";
+            ControlBox = false;
+
+            ResumeLayout(false);
+        }
+    }
+}

--- a/LoadingForm.cs
+++ b/LoadingForm.cs
@@ -1,0 +1,20 @@
+using System.Windows.Forms;
+
+namespace economy_sim
+{
+    public partial class LoadingForm : Form
+    {
+        public LoadingForm()
+        {
+            InitializeComponent();
+        }
+
+        public void UpdateProgress(int processed, int total)
+        {
+            int percent = total > 0 ? (int)(processed * 100.0 / total) : 0;
+            if (percent > 100) percent = 100;
+            progressBar.Value = percent;
+            labelStatus.Text = $"Generating city models {processed}/{total}";
+        }
+    }
+}

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -2222,7 +2222,7 @@ namespace economy_sim
                     try
                     {
                         string id = File.ReadAllText(hashPath);
-                        string modelPath = Path.Combine(dir, $"{id}.json");
+                        string modelPath = Path.Combine(dir, $"{id}.bin");
                         if (!File.Exists(modelPath))
                         {
                             missing.Add(urban);
@@ -2301,7 +2301,7 @@ namespace economy_sim
                     try
                     {
                         string id = File.ReadAllText(hashPath);
-                        string modelPath = Path.Combine(dir, $"{id}.json");
+                        string modelPath = Path.Combine(dir, $"{id}.bin");
                         if (File.Exists(modelPath))
                         {
                             count++;
@@ -2366,7 +2366,7 @@ namespace economy_sim
                         try
                         {
                             string id = File.ReadAllText(hashPath);
-                            string modelPath = Path.Combine(dir, $"{id}.json");
+                        string modelPath = Path.Combine(dir, $"{id}.bin");
                             if (!File.Exists(modelPath))
                             {
                                 missingAreas.Add(urban);
@@ -2699,21 +2699,20 @@ namespace economy_sim
                         continue;
                     }
                     
-                    string modelPath = Path.Combine(dir, $"{guid}.json");
+                    string modelPath = Path.Combine(dir, $"{guid}.bin");
                     if (!File.Exists(modelPath))
                     {
                         invalidCount++;
-                        issues.Add($"Missing model file {guid}.json for hash {hash}");
+                        issues.Add($"Missing model file {guid}.bin for hash {hash}");
                         continue;
                     }
-                    
+
                     // Try to verify the model can be loaded
-                    string jsonContent = File.ReadAllText(modelPath);
-                    var model = System.Text.Json.JsonSerializer.Deserialize<CityDataModel>(jsonContent);
+                    var model = RoadNetworkGenerator.LoadCityDataModel(guid);
                     if (model == null || model.Id != guid)
                     {
                         invalidCount++;
-                        issues.Add($"Model file {guid}.json has invalid or mismatched ID");
+                        issues.Add($"Model file {guid}.bin has invalid or mismatched ID");
                         continue;
                     }
                     
@@ -2759,7 +2758,7 @@ namespace economy_sim
             {
                 details.AppendLine($"City Model ID: {modelId.Value}");
                 
-                string modelPath = Path.Combine(dir, $"{modelId.Value}.json");
+                string modelPath = Path.Combine(dir, $"{modelId.Value}.bin");
                 if (File.Exists(modelPath))
                 {
                     try
@@ -2770,8 +2769,7 @@ namespace economy_sim
                         details.AppendLine($"Model File Modified: {fileInfo.LastWriteTime}");
                         
                         // Try to load and get basic stats
-                        string jsonContent = File.ReadAllText(modelPath);
-                        var model = System.Text.Json.JsonSerializer.Deserialize<CityDataModel>(jsonContent);
+                        var model = RoadNetworkGenerator.LoadCityDataModel(modelId.Value);
                         if (model != null)
                         {
                             details.AppendLine($"Road Segments: {model.RoadNetwork.Count}");
@@ -2814,7 +2812,7 @@ namespace economy_sim
                 try
                 {
                     string oldId = File.ReadAllText(hashPath);
-                    string oldModelPath = Path.Combine(dir, $"{oldId}.json");
+                    string oldModelPath = Path.Combine(dir, $"{oldId}.bin");
                     
                     // Delete old files
                     File.Delete(hashPath);

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -244,8 +244,10 @@ namespace economy_sim
                 MainGame_Shown(s, e); // Call your new handler
             };
         }
-        private void MainGame_Shown(object sender, EventArgs e)
+        private async void MainGame_Shown(object sender, EventArgs e)
         {
+            await PreGenerateMissingCityDataAsync();
+
             // Start the simulation loop on a background thread
             // now that the form is fully loaded and displayed.
             simCts = new CancellationTokenSource();
@@ -362,7 +364,6 @@ namespace economy_sim
 
             // Load urban area polygons for procedural generation
             UrbanAreaManager.LoadUrbanAreas();
-            CheckAndPromptForMissingCityData();
 
             // 3. Load World Setup from JSON
             string jsonFilePath = "world_setup.json";
@@ -2074,6 +2075,37 @@ namespace economy_sim
             {
                 await Task.Delay(100).ConfigureAwait(false);
             }
+        }
+
+        private async Task PreGenerateMissingCityDataAsync()
+        {
+            var missing = new List<Nts.Polygon>();
+            foreach (var urban in UrbanAreaManager.UrbanPolygons)
+            {
+                if (!RoadNetworkGenerator.HasCityDataModel(urban))
+                    missing.Add(urban);
+            }
+
+            if (missing.Count == 0)
+                return;
+
+            using var loading = new LoadingForm();
+            loading.UpdateProgress(0, missing.Count);
+            loading.Show();
+
+            foreach (var urban in missing)
+                cityGenerationManager.QueueArea(urban);
+
+            while (true)
+            {
+                int completed = missing.Count(a => RoadNetworkGenerator.HasCityDataModel(a));
+                loading.UpdateProgress(completed, missing.Count);
+                if (completed >= missing.Count && !cityGenerationManager.IsProcessing())
+                    break;
+                await Task.Delay(500).ConfigureAwait(true);
+            }
+
+            loading.Close();
         }
 
         /// <summary>

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -272,7 +272,7 @@ namespace economy_sim
                         "data", "tile_cache");
 
                     mapManager.PreloadVisibleTiles(mapZoom, viewRect);
-                    cityTileManager.PreloadVisibleTiles(mapZoom, viewRect);
+                    _ = cityTileManager.PreloadVisibleTilesAsync(mapZoom, viewRect);
 
                     this.Invoke((MethodInvoker)(() =>
                     {
@@ -413,7 +413,7 @@ namespace economy_sim
             }
 
             mapManager.PreloadVisibleTiles(zoom, view);
-            cityTileManager.PreloadVisibleTiles(zoom, view);
+            _ = cityTileManager.PreloadVisibleTilesAsync(zoom, view);
 
             mapRenderInProgress = true;
 
@@ -2384,7 +2384,7 @@ namespace economy_sim
             Debug.WriteLine($"  FINAL_ORIGIN=({mapViewOrigin.X},{mapViewOrigin.Y})");
 
             ApplyZoom();
-            PreloadMapTiles();
+            _ = PreloadMapTilesAsync();
         }
         private void PanelMap_Resize(object sender, EventArgs e)
         {
@@ -2404,7 +2404,7 @@ namespace economy_sim
                     mapZoom = Math.Min(mapZoom + 1, MultiResolutionMapManager.PixelsPerCellLevels.Length);
                 }
                 ApplyZoom();
-                PreloadMapTiles();
+                _ = PreloadMapTilesAsync();
                 e.Handled = true;
                 e.SuppressKeyPress = true;
                 return;
@@ -2417,7 +2417,7 @@ namespace economy_sim
                     mapZoom = Math.Max(1, mapZoom - 1);
                 }
                 ApplyZoom();
-                PreloadMapTiles();
+                _ = PreloadMapTilesAsync();
                 e.Handled = true;
                 e.SuppressKeyPress = true;
                 return;
@@ -2461,7 +2461,7 @@ namespace economy_sim
                     mapViewOrigin.Y = Math.Max(0, Math.Min(mapViewOrigin.Y, mapSize.Height - panelMap.ClientSize.Height));
                 }
                 ApplyZoom();
-                PreloadMapTiles();
+                _ = PreloadMapTilesAsync();
             }
         }
 
@@ -2504,7 +2504,7 @@ namespace economy_sim
             {
                 isPanning = false;
                 Cursor = Cursors.Default;
-                PreloadMapTiles();
+                _ = PreloadMapTilesAsync();
             }
         }
 
@@ -2528,7 +2528,7 @@ namespace economy_sim
                 this.panelMap.Cursor = Cursors.Default; // Reset panelMap cursor
                 this.panelMap.BackColor = SystemColors.Control;
                 this.pictureBox1.BackColor = SD.Color.Transparent; // Reset pictureBox backcolor
-                PreloadMapTiles();
+                _ = PreloadMapTilesAsync();
             }
         }
 
@@ -2544,7 +2544,7 @@ namespace economy_sim
             }
         }
 
-        private void PreloadMapTiles()
+        private async Task PreloadMapTilesAsync()
         {
             if (mapManager == null)
                 return;
@@ -2555,7 +2555,8 @@ namespace economy_sim
                 view = new SD.Rectangle(mapViewOrigin, panelMap.ClientSize);
                 zoom = mapZoom;
             }
-            _ = mapManager.PreloadTilesAsync(zoom, view, 1, CancellationToken.None);
+            await mapManager.PreloadTilesAsync(zoom, view, 1, CancellationToken.None);
+            await cityTileManager.PreloadVisibleTilesAsync(zoom, view);
         }
 
         private void InvalidateMap()

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -261,7 +261,7 @@ namespace economy_sim
                 var baseSize = mapManager.GetMapSize(1);
                 baseCellsWidth = baseSize.Width / MultiResolutionMapManager.PixelsPerCellLevels[0];
                 baseCellsHeight = baseSize.Height / MultiResolutionMapManager.PixelsPerCellLevels[0];
-                cityTileManager = new CityTileManager(baseCellsWidth, baseCellsHeight);
+                cityTileManager = new CityTileManager(baseCellsWidth, baseCellsHeight, mapManager);
 
                 var viewRect = new SD.Rectangle(mapViewOrigin, panelMap.ClientSize);
 

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -2631,7 +2631,7 @@ namespace economy_sim
         /// <summary>
         /// Validates that all urban areas have consistent city model IDs
         /// </summary>
-        public void ValidateUrbanAreaData()
+        public async Task ValidateUrbanAreaData()
         {
             int validCount = 0;
             int invalidCount = 0;
@@ -2670,7 +2670,7 @@ namespace economy_sim
                     }
 
                     // Try to verify the model can be loaded
-                    var model = RoadNetworkGenerator.LoadCityDataModel(guid);
+                    var model = await RoadNetworkGenerator.LoadCityDataModelAsync(guid).ConfigureAwait(false);
                     if (model == null || model.Id != guid)
                     {
                         invalidCount++;
@@ -2705,7 +2705,7 @@ namespace economy_sim
         /// <summary>
         /// Gets detailed information about a specific urban area and its city model
         /// </summary>
-        public string GetUrbanAreaDetails(Nts.Polygon urbanArea)
+        public async Task<string> GetUrbanAreaDetails(Nts.Polygon urbanArea)
         {
             string hash = ComputeUrbanAreaHash(urbanArea);
             string dir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "data", "city_models");
@@ -2715,7 +2715,7 @@ namespace economy_sim
             details.AppendLine($"Envelope: {urbanArea.EnvelopeInternal}");
             
             // Check for city model data
-            Guid? modelId = RoadNetworkGenerator.GetCityDataModelId(urbanArea);
+            Guid? modelId = await RoadNetworkGenerator.GetCityDataModelIdAsync(urbanArea).ConfigureAwait(false);
             if (modelId.HasValue)
             {
                 details.AppendLine($"City Model ID: {modelId.Value}");
@@ -2731,7 +2731,7 @@ namespace economy_sim
                         details.AppendLine($"Model File Modified: {fileInfo.LastWriteTime}");
                         
                         // Try to load and get basic stats
-                        var model = RoadNetworkGenerator.LoadCityDataModel(modelId.Value);
+                        var model = await RoadNetworkGenerator.LoadCityDataModelAsync(modelId.Value).ConfigureAwait(false);
                         if (model != null)
                         {
                             details.AppendLine($"Road Segments: {model.RoadNetwork.Count}");

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -2344,7 +2344,7 @@ namespace economy_sim
             }
         }
 
-        private void PanelMap_MouseWheel(object sender, MouseEventArgs e)
+        private async void PanelMap_MouseWheel(object sender, MouseEventArgs e)
         {
             // 1) figure out the anchor in panel coords
             SD.Point anchor = panelMap.PointToClient(Cursor.Position);
@@ -2384,7 +2384,7 @@ namespace economy_sim
             Debug.WriteLine($"  FINAL_ORIGIN=({mapViewOrigin.X},{mapViewOrigin.Y})");
 
             ApplyZoom();
-            _ = PreloadMapTilesAsync();
+            await PreloadMapTilesAsync();
         }
         private void PanelMap_Resize(object sender, EventArgs e)
         {
@@ -2498,13 +2498,13 @@ namespace economy_sim
             }
         }
 
-        private void PictureBox1_MouseUp(object sender, MouseEventArgs e)
+        private async void PictureBox1_MouseUp(object sender, MouseEventArgs e)
         {
             if (e.Button == MouseButtons.Left)
             {
                 isPanning = false;
                 Cursor = Cursors.Default;
-                _ = PreloadMapTilesAsync();
+                await PreloadMapTilesAsync();
             }
         }
 
@@ -2546,17 +2546,20 @@ namespace economy_sim
 
         private async Task PreloadMapTilesAsync()
         {
-            if (mapManager == null)
-                return;
+            if (mapManager == null) return;
+
             SD.Rectangle view;
-            int zoom;
+            float zoom;
             lock (_zoomLock)
             {
                 view = new SD.Rectangle(mapViewOrigin, panelMap.ClientSize);
-                zoom = mapZoom;
+                zoom = this.mapZoom;
             }
-            await mapManager.PreloadTilesAsync(zoom, view, 1, CancellationToken.None);
-            await cityTileManager.PreloadVisibleTilesAsync(zoom, view);
+
+            var baseMapTask = mapManager.PreloadTilesAsync(zoom, view, 1, CancellationToken.None);
+            var cityTileTask = cityTileManager.PreloadVisibleTilesAsync(zoom, view, 1, InvalidateMap, CancellationToken.None);
+
+            await Task.WhenAll(baseMapTask, cityTileTask);
         }
 
         private void InvalidateMap()

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -73,6 +73,8 @@ namespace economy_sim
         private bool mapRenderInProgress = false;
         private bool mapRenderQueued = false;
         private SKBitmap _currentMapView;
+        private bool _isUpdatingMap = false;
+        private readonly object _mapUpdateLock = new object();
         private readonly object _zoomLock = new();
         private float _zoom = 1f;
         private int lastCityModelCount = 0;
@@ -290,164 +292,6 @@ namespace economy_sim
 
        
 
-        private void Redraw()
-        {
-            if ((DateTime.Now - _lastRedrawTime).TotalMilliseconds < 100)
-                return;
-
-            _lastRedrawTime = DateTime.Now;
-
-            if (mapManager == null || panelMap.ClientSize.Width <= 0 || panelMap.ClientSize.Height <= 0)
-                return;
-
-            SD.Rectangle viewRect = new SD.Rectangle(
-                -panelMap.AutoScrollPosition.X,
-                -panelMap.AutoScrollPosition.Y,
-                panelMap.ClientSize.Width,
-                panelMap.ClientSize.Height
-            );
-
-            if (viewRect.Width <= 0 || viewRect.Height <= 0)
-                return;
-
-            float zoomLevel = mapZoom;
-
-            DateTime lastInnerRedraw = DateTime.MinValue;
-
-            SKBitmap finalSk = null;
-            try
-            {
-                using SKBitmap terrain = mapManager.AssembleView(zoomLevel, viewRect, triggerRefresh: InvalidateMap);
-                using SKBitmap city = cityTileManager.AssembleView(zoomLevel, viewRect, triggerRefresh: InvalidateMap);
-                finalSk = CombineMaps(terrain, city);
-            }
-            catch (ArgumentException ex)
-            {
-                Debug.WriteLine($"Redraw bitmap generation failed: {ex.Message}");
-                return;
-            }
-
-            if (finalSk == null)
-                return;
-
-            _currentMapView?.Dispose();
-            _currentMapView = finalSk.Copy();
-            pictureBox1.Invalidate();
-        }
-        private CancellationTokenSource redrawCts;
-
-        private void RedrawAsync()
-        {
-            if (panelMap.ClientSize.Width <= 0 || panelMap.ClientSize.Height <= 0 || mapManager == null)
-                return;
-
-            redrawCts?.Cancel();
-            redrawCts = new CancellationTokenSource();
-            var token = redrawCts.Token;
-
-            SD.Rectangle viewRect = new SD.Rectangle(
-                -panelMap.AutoScrollPosition.X,
-                -panelMap.AutoScrollPosition.Y,
-                panelMap.ClientSize.Width,
-                panelMap.ClientSize.Height
-            );
-
-            if (viewRect.Width <= 0 || viewRect.Height <= 0)
-                return;
-
-            DateTime lastInnerRedraw = DateTime.MinValue;
-
-            Task.Run(() =>
-            {
-                try
-                {
-                    using var terrain = mapManager.AssembleView(mapZoom, viewRect, triggerRefresh: InvalidateMap);
-
-                    using var city = cityTileManager.AssembleView(mapZoom, viewRect, triggerRefresh: InvalidateMap);
-
-                    using var finalSk = CombineMaps(terrain, city);
-
-                    if (finalSk != null && !token.IsCancellationRequested)
-                    {
-                        this.Invoke(() =>
-                        {
-                            _currentMapView?.Dispose();
-                            _currentMapView = finalSk.Copy();
-                            pictureBox1.Invalidate();
-                        });
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Debug.WriteLine($"RedrawAsync failed: {ex.Message}");
-                }
-            }, token);
-        }
-
-        private void ApplyZoom()
-        {
-            if (mapManager == null)
-                return;
-
-            if (panelMap.ClientSize.Width <= 0 || panelMap.ClientSize.Height <= 0)
-            {
-                Debug.WriteLine("ApplyZoom skipped: panelMap has invalid size.");
-                return;
-            }
-
-            SD.Rectangle view;
-            int zoom;
-            lock (_zoomLock)
-            {
-                SD.Size mapSize = mapManager.GetMapSize(mapZoom);
-                mapViewOrigin.X = Math.Max(0, Math.Min(mapViewOrigin.X, mapSize.Width - panelMap.ClientSize.Width));
-                mapViewOrigin.Y = Math.Max(0, Math.Min(mapViewOrigin.Y, mapSize.Height - panelMap.ClientSize.Height));
-                zoom = mapZoom;
-                view = new SD.Rectangle(mapViewOrigin, panelMap.ClientSize);
-            }
-
-            if (mapRenderInProgress)
-            {
-                mapRenderQueued = true;
-                return;
-            }
-
-            mapManager.PreloadVisibleTiles(zoom, view);
-            _ = cityTileManager.PreloadVisibleTilesAsync(zoom, view);
-
-            mapRenderInProgress = true;
-
-            Task.Run(() =>
-            {
-                using SKBitmap terrain = mapManager.AssembleView(zoom, view, triggerRefresh: InvalidateMap);
-                using SKBitmap city = cityTileManager.AssembleView(zoom, view, triggerRefresh: InvalidateMap);
-                if (terrain == null) return;
-                using SKBitmap mapSk = CombineMaps(terrain, city);
-                if (mapSk == null) return;
-
-                void setImage()
-                {
-                    _currentMapView?.Dispose();
-                    _currentMapView = mapSk.Copy();
-                    pictureBox1.Invalidate();
-                    mapRenderInProgress = false;
-                    if (mapRenderQueued)
-                    {
-                        mapRenderQueued = false;
-                        ApplyZoom();
-                    }
-                }
-
-                if (pictureBox1.InvokeRequired)
-                {
-                    pictureBox1.Invoke((Action)setImage);
-                }
-                else
-                {
-                    setImage();
-                }
-            });
-        }
 
 
         private SD.Bitmap ScaleBitmapNearest(SD.Bitmap src, int width, int height)
@@ -2344,7 +2188,7 @@ namespace economy_sim
             }
         }
 
-        private async void PanelMap_MouseWheel(object sender, MouseEventArgs e)
+        private void PanelMap_MouseWheel(object sender, MouseEventArgs e)
         {
             // 1) figure out the anchor in panel coords
             SD.Point anchor = panelMap.PointToClient(Cursor.Position);
@@ -2383,14 +2227,13 @@ namespace economy_sim
 
             Debug.WriteLine($"  FINAL_ORIGIN=({mapViewOrigin.X},{mapViewOrigin.Y})");
 
-            ApplyZoom();
-            await PreloadMapTilesAsync();
+            _ = UpdateMapDisplayAsync();
         }
         private void PanelMap_Resize(object sender, EventArgs e)
         {
             // This method is called whenever the map panel is resized.
-            // We call ApplyZoom() to generate a new map image that fits the new dimensions.
-            ApplyZoom();
+            // Kick off an update so the view fits the new dimensions.
+            _ = UpdateMapDisplayAsync();
         }
         private void panelMap_KeyDown(object sender, KeyEventArgs e)
         {
@@ -2403,8 +2246,7 @@ namespace economy_sim
                 {
                     mapZoom = Math.Min(mapZoom + 1, MultiResolutionMapManager.PixelsPerCellLevels.Length);
                 }
-                ApplyZoom();
-                _ = PreloadMapTilesAsync();
+                _ = UpdateMapDisplayAsync();
                 e.Handled = true;
                 e.SuppressKeyPress = true;
                 return;
@@ -2416,8 +2258,7 @@ namespace economy_sim
                 {
                     mapZoom = Math.Max(1, mapZoom - 1);
                 }
-                ApplyZoom();
-                _ = PreloadMapTilesAsync();
+                _ = UpdateMapDisplayAsync();
                 e.Handled = true;
                 e.SuppressKeyPress = true;
                 return;
@@ -2460,8 +2301,7 @@ namespace economy_sim
                     mapViewOrigin.X = Math.Max(0, Math.Min(mapViewOrigin.X, mapSize.Width - panelMap.ClientSize.Width));
                     mapViewOrigin.Y = Math.Max(0, Math.Min(mapViewOrigin.Y, mapSize.Height - panelMap.ClientSize.Height));
                 }
-                ApplyZoom();
-                _ = PreloadMapTilesAsync();
+                _ = UpdateMapDisplayAsync();
             }
         }
 
@@ -2498,13 +2338,13 @@ namespace economy_sim
             }
         }
 
-        private async void PictureBox1_MouseUp(object sender, MouseEventArgs e)
+        private void PictureBox1_MouseUp(object sender, MouseEventArgs e)
         {
             if (e.Button == MouseButtons.Left)
             {
                 isPanning = false;
                 Cursor = Cursors.Default;
-                await PreloadMapTilesAsync();
+                _ = UpdateMapDisplayAsync();
             }
         }
 
@@ -2528,7 +2368,7 @@ namespace economy_sim
                 this.panelMap.Cursor = Cursors.Default; // Reset panelMap cursor
                 this.panelMap.BackColor = SystemColors.Control;
                 this.pictureBox1.BackColor = SD.Color.Transparent; // Reset pictureBox backcolor
-                _ = PreloadMapTilesAsync();
+                _ = UpdateMapDisplayAsync();
             }
         }
 
@@ -2536,11 +2376,8 @@ namespace economy_sim
         {
             if (pendingMapUpdate)
             {
-                lock (_zoomLock)
-                {
-                    ApplyZoom();
-                    pendingMapUpdate = false;
-                }
+                _ = UpdateMapDisplayAsync();
+                pendingMapUpdate = false;
             }
         }
 
@@ -2560,6 +2397,53 @@ namespace economy_sim
             var cityTileTask = cityTileManager.PreloadVisibleTilesAsync(zoom, view, 1, InvalidateMap, CancellationToken.None);
 
             await Task.WhenAll(baseMapTask, cityTileTask);
+        }
+
+        private async Task UpdateMapDisplayAsync()
+        {
+            lock (_mapUpdateLock)
+            {
+                if (_isUpdatingMap) return;
+                _isUpdatingMap = true;
+            }
+
+            try
+            {
+                await PreloadMapTilesAsync();
+
+                SD.Rectangle view;
+                float zoom;
+                lock (_zoomLock)
+                {
+                    view = new SD.Rectangle(mapViewOrigin, panelMap.ClientSize);
+                    zoom = this.mapZoom;
+                }
+
+                if (view.Width <= 0 || view.Height <= 0) return;
+
+                using var terrain = mapManager.AssembleView(zoom, view);
+                using var city = cityTileManager.AssembleView(zoom, view);
+                using var finalSk = CombineMaps(terrain, city);
+
+                if (finalSk != null)
+                {
+                    if (this.IsHandleCreated)
+                    {
+                        this.Invoke((Action)(() => {
+                            _currentMapView?.Dispose();
+                            _currentMapView = finalSk.Copy();
+                            pictureBox1.Invalidate();
+                        }));
+                    }
+                }
+            }
+            finally
+            {
+                lock (_mapUpdateLock)
+                {
+                    _isUpdatingMap = false;
+                }
+            }
         }
 
         private void InvalidateMap()

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -276,17 +276,7 @@ namespace economy_sim
 
                     this.Invoke((MethodInvoker)(() =>
                     {
-                        using var sk = mapManager.AssembleView(mapZoom, viewRect, () =>
-                        {
-                            this.Invoke((MethodInvoker)(() =>
-                            {
-                                var updatedViewRect = new SD.Rectangle(mapViewOrigin, panelMap.ClientSize);
-                                using var sk2 = mapManager.AssembleView(mapZoom, updatedViewRect);
-                                _currentMapView?.Dispose();
-                                _currentMapView = sk2.Copy();
-                                pictureBox1.Invalidate();
-                            }));
-                        });
+                        using var sk = mapManager.AssembleView(mapZoom, viewRect, triggerRefresh: InvalidateMap);
                         _currentMapView?.Dispose();
                         _currentMapView = sk.Copy();
                         pictureBox1.Invalidate();
@@ -327,26 +317,8 @@ namespace economy_sim
             SKBitmap finalSk = null;
             try
             {
-                using SKBitmap terrain = mapManager.AssembleView(zoomLevel, viewRect, triggerRefresh: () =>
-                {
-                    if ((DateTime.Now - lastInnerRedraw).TotalMilliseconds < 100)
-                        return;
-                    lastInnerRedraw = DateTime.Now;
-                    if (this.InvokeRequired)
-                        this.BeginInvoke(new Action(Redraw));
-                    else
-                        Redraw();
-                });
-                using SKBitmap city = cityTileManager.AssembleView(zoomLevel, viewRect, triggerRefresh: () =>
-                {
-                    if ((DateTime.Now - lastInnerRedraw).TotalMilliseconds < 100)
-                        return;
-                    lastInnerRedraw = DateTime.Now;
-                    if (this.InvokeRequired)
-                        this.BeginInvoke(new Action(Redraw));
-                    else
-                        Redraw();
-                });
+                using SKBitmap terrain = mapManager.AssembleView(zoomLevel, viewRect, triggerRefresh: InvalidateMap);
+                using SKBitmap city = cityTileManager.AssembleView(zoomLevel, viewRect, triggerRefresh: InvalidateMap);
                 finalSk = CombineMaps(terrain, city);
             }
             catch (ArgumentException ex)
@@ -389,23 +361,9 @@ namespace economy_sim
             {
                 try
                 {
-                    using var terrain = mapManager.AssembleView(mapZoom, viewRect, triggerRefresh: () =>
-                    {
-                        if ((DateTime.Now - lastInnerRedraw).TotalMilliseconds >= 100 && !token.IsCancellationRequested)
-                        {
-                            lastInnerRedraw = DateTime.Now;
-                            this.BeginInvoke(new Action(RedrawAsync));
-                        }
-                    });
+                    using var terrain = mapManager.AssembleView(mapZoom, viewRect, triggerRefresh: InvalidateMap);
 
-                    using var city = cityTileManager.AssembleView(mapZoom, viewRect, triggerRefresh: () =>
-                    {
-                        if ((DateTime.Now - lastInnerRedraw).TotalMilliseconds >= 100 && !token.IsCancellationRequested)
-                        {
-                            lastInnerRedraw = DateTime.Now;
-                            this.BeginInvoke(new Action(RedrawAsync));
-                        }
-                    });
+                    using var city = cityTileManager.AssembleView(mapZoom, viewRect, triggerRefresh: InvalidateMap);
 
                     using var finalSk = CombineMaps(terrain, city);
 
@@ -461,20 +419,8 @@ namespace economy_sim
 
             Task.Run(() =>
             {
-                using SKBitmap terrain = mapManager.AssembleView(zoom, view, triggerRefresh: () =>
-                {
-                    if (this.InvokeRequired)
-                        this.BeginInvoke(new Action(ApplyZoom));
-                    else
-                        ApplyZoom();
-                });
-                using SKBitmap city = cityTileManager.AssembleView(zoom, view, triggerRefresh: () =>
-                {
-                    if (this.InvokeRequired)
-                        this.BeginInvoke(new Action(ApplyZoom));
-                    else
-                        ApplyZoom();
-                });
+                using SKBitmap terrain = mapManager.AssembleView(zoom, view, triggerRefresh: InvalidateMap);
+                using SKBitmap city = cityTileManager.AssembleView(zoom, view, triggerRefresh: InvalidateMap);
                 if (terrain == null) return;
                 using SKBitmap mapSk = CombineMaps(terrain, city);
                 if (mapSk == null) return;
@@ -2610,6 +2556,18 @@ namespace economy_sim
                 zoom = mapZoom;
             }
             _ = mapManager.PreloadTilesAsync(zoom, view, 1, CancellationToken.None);
+        }
+
+        private void InvalidateMap()
+        {
+            if (pictureBox1.InvokeRequired)
+            {
+                pictureBox1.BeginInvoke(new Action(pictureBox1.Invalidate));
+            }
+            else
+            {
+                pictureBox1.Invalidate();
+            }
         }
 
         private int GetCellSizeForZoom(int zoomLevel)

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -153,7 +153,6 @@ namespace economy_sim
             panelMap.MouseWheel += PanelMap_MouseWheel;
             mapUpdateTimer = new System.Windows.Forms.Timer { Interval = 40 };
             mapUpdateTimer.Tick += MapUpdateTimer_Tick;
-            mapUpdateTimer.Start();
             playerRoleManager = new PlayerRoleManager();
             allCitiesInWorld = new List<StrategyGame.City>();
             allCountries = new List<StrategyGame.Country>();
@@ -288,6 +287,11 @@ namespace economy_sim
 
             pictureBox1.Size = panelMap.ClientSize;
             pictureBox1.Location = new SD.Point(0, 0);
+
+            if (!mapUpdateTimer.Enabled)
+            {
+                mapUpdateTimer.Start();
+            }
         }
 
        
@@ -2383,7 +2387,12 @@ namespace economy_sim
 
         private async Task PreloadMapTilesAsync()
         {
-            if (mapManager == null) return;
+            if (mapManager == null || cityTileManager == null)
+            {
+                RefreshMap();
+                if (mapManager == null || cityTileManager == null)
+                    return;
+            }
 
             SD.Rectangle view;
             float zoom;
@@ -2409,6 +2418,14 @@ namespace economy_sim
 
             try
             {
+                if (mapManager == null || cityTileManager == null)
+                {
+                    RefreshMap();
+                    if (mapManager == null || cityTileManager == null)
+                    {
+                        return;
+                    }
+                }
                 await PreloadMapTilesAsync();
 
                 SD.Rectangle view;

--- a/MultiResolutionMapManager.cs
+++ b/MultiResolutionMapManager.cs
@@ -601,12 +601,18 @@ namespace StrategyGame
             return (int)Math.Round(size);
         }
 
-        private static SystemDrawing.Bitmap ImageSharpToBitmap(Image<Rgba32> img)
+        private static unsafe SystemDrawing.Bitmap ImageSharpToBitmap(Image<Rgba32> img)
         {
-            using var ms = new MemoryStream();
-            img.SaveAsBmp(ms);
-            ms.Position = 0;
-            return new SystemDrawing.Bitmap(ms);
+            var bmp = new SystemDrawing.Bitmap(img.Width, img.Height, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+            var bmpData = bmp.LockBits(
+                new SystemDrawing.Rectangle(0, 0, img.Width, img.Height),
+                System.Drawing.Imaging.ImageLockMode.WriteOnly,
+                bmp.PixelFormat);
+
+            img.CopyPixelDataTo(new Span<byte>((byte*)bmpData.Scan0, bmpData.Stride * bmpData.Height));
+
+            bmp.UnlockBits(bmpData);
+            return bmp;
         }
 
         private static SystemDrawing.Bitmap CreateWaterTile(int width, int height)

--- a/MultiResolutionMapManager.cs
+++ b/MultiResolutionMapManager.cs
@@ -50,9 +50,8 @@ namespace StrategyGame
         private readonly Dictionary<(int cellSize, int x, int y), SystemDrawing.Bitmap> _tileCache = new();
         // LRU order for tile cache entries
         private readonly LinkedList<(int cellSize, int x, int y)> _tileLru = new();
-        private readonly object _cacheLock = new();
+        private readonly object _masterCacheLock = new();
         private readonly object _assembleLock = new();
-        private readonly object _textureLock = new();
         private readonly Dictionary<(int cellSize, int x, int y), SKBitmap> _tileTextures = new();
 
         public static readonly bool GpuAvailable;
@@ -189,7 +188,7 @@ namespace StrategyGame
             System.Drawing.Bitmap bmp = null;
 
             // Try cache first
-            lock (_cacheLock)
+            lock (_masterCacheLock)
             {
                 if (_tileCache.TryGetValue(key, out var cached))
                 {
@@ -262,7 +261,7 @@ namespace StrategyGame
             // Cache result
             if (bmp != null)
             {
-                lock (_cacheLock)
+                lock (_masterCacheLock)
                 {
                     _tileCache[key] = bmp;
                     _tileLru.AddLast(key);
@@ -357,7 +356,7 @@ namespace StrategyGame
 
                         // --- START: Replacement Logic ---
                         SKBitmap textureCopy = null;
-                        lock (_textureLock)
+                        lock (_masterCacheLock)
                         {
                             if (_tileTextures.TryGetValue(key, out var texture))
                             {
@@ -625,7 +624,7 @@ namespace StrategyGame
         private void UploadTileTexture((int cellSize, int x, int y) key, SystemDrawing.Bitmap bmp)
         {
             var sk = SkiaBitmapUtil.ToSKBitmap(bmp);
-            lock (_textureLock)
+            lock (_masterCacheLock)
             {
                 if (_tileTextures.TryGetValue(key, out var old))
                     old.Dispose();
@@ -652,7 +651,7 @@ namespace StrategyGame
                     oldBmp.Dispose();
                     _tileCache.Remove(oldest);
                 }
-                lock (_textureLock)
+                lock (_masterCacheLock)
                 {
                     if (_tileTextures.TryGetValue(oldest, out var tex))
                     {

--- a/MultiResolutionMapManager.cs
+++ b/MultiResolutionMapManager.cs
@@ -334,7 +334,7 @@ namespace StrategyGame
             var context = GpuAvailable ? SharedContext : null;
                 using var surface = context != null ? SKSurface.Create(context, false, info) : SKSurface.Create(info);
                 var canvas = surface.Canvas;
-                canvas.Clear(SKColors.DarkGray);
+                canvas.Clear(SKColors.Transparent);
 
                 for (int ty = tileStartY; ty < tileEndY; ty++)
                 {

--- a/MultiResolutionMapManager.cs
+++ b/MultiResolutionMapManager.cs
@@ -356,14 +356,26 @@ namespace StrategyGame
                             continue;
 
                         SKBitmap texture = null;
+                        bool drew = false;
                         lock (_textureLock)
-                            _tileTextures.TryGetValue(key, out texture);
-
-                        if (texture != null)
                         {
-                            canvas.DrawBitmap(texture, rect);
+                            if (_tileTextures.TryGetValue(key, out texture))
+                            {
+                                try
+                                {
+                                    canvas.DrawBitmap(texture, rect);
+                                    drew = true;
+                                }
+                                catch (AccessViolationException ex)
+                                {
+                                    DebugLogger.Log($"Access violation drawing tile {key}: {ex.Message}");
+                                    texture.Dispose();
+                                    _tileTextures.Remove(key);
+                                }
+                            }
                         }
-                        else
+
+                        if (!drew)
                         {
                             // Try to safely create texture from cached bitmap
                             SKBitmap newTexture = null;

--- a/MultiResolutionMapManager.cs
+++ b/MultiResolutionMapManager.cs
@@ -355,92 +355,60 @@ namespace StrategyGame
                         if (rect.Width <= 0 || rect.Height <= 0)
                             continue;
 
-                        SKBitmap texture = null;
-                        bool drew = false;
+                        // --- START: Replacement Logic ---
+                        SKBitmap textureCopy = null;
                         lock (_textureLock)
                         {
-                            if (_tileTextures.TryGetValue(key, out texture))
+                            if (_tileTextures.TryGetValue(key, out var texture))
+                            {
+                                // Create a private, safe copy of the texture inside the lock
+                                textureCopy = texture.Copy();
+                            }
+                        }
+
+                        if (textureCopy != null)
+                        {
+                            using (textureCopy)
                             {
                                 try
                                 {
-                                    canvas.DrawBitmap(texture, rect);
-                                    drew = true;
+                                    canvas.DrawBitmap(textureCopy, rect);
                                 }
                                 catch (AccessViolationException ex)
                                 {
-                                    DebugLogger.Log($"Access violation drawing tile {key}: {ex.Message}");
-                                    texture.Dispose();
-                                    _tileTextures.Remove(key);
+                                    DebugLogger.Log($"Access violation drawing texture copy {key}: {ex.Message}");
                                 }
                             }
                         }
-
-                        if (!drew)
+                        else
                         {
-                            // Try to safely create texture from cached bitmap
-                            SKBitmap newTexture = null;
-                            lock (_cacheLock)
+                            lock (_tileLoadLock)
                             {
-                                if (_tileCache.TryGetValue(key, out var tile))
+                                if (!_tilesBeingLoaded.Contains(key))
                                 {
-                                    try
+                                    _tilesBeingLoaded.Add(key);
+                                    var ttx = tx;
+                                    var tty = ty;
+                                    var tileKey = key;
+                                    _ = Task.Run(async () =>
                                     {
-                                        // Check dimensions inside the lock to avoid concurrent access
-                                        if (tile.Width > 0 && tile.Height > 0)
+                                        try
                                         {
-                                            // Create texture directly from the cached bitmap while holding the lock
-                                            // This reduces the window for concurrent access issues
-                                            newTexture = SkiaBitmapUtil.ToSKBitmap(tile);
+                                            var t = await GetTileAsync(zoom, ttx, tty, CancellationToken.None);
+                                            if (t != null)
+                                                UploadTileTexture(tileKey, t);
+                                            triggerRefresh?.Invoke();
                                         }
-                                    }
-                                    catch (InvalidOperationException)
-                                    {
-                                        // Bitmap was disposed or being used elsewhere, skip this tile
-                                        newTexture = null;
-                                    }
-                                    catch (ArgumentException)
-                                    {
-                                        // Bitmap properties became invalid
-                                        newTexture = null;
-                                    }
-                                }
-                            }
-
-                            if (newTexture != null)
-                            {
-                                lock (_textureLock)
-                                    _tileTextures[key] = newTexture;
-                                canvas.DrawBitmap(newTexture, rect);
-                            }
-                            else
-                            {
-                                lock (_tileLoadLock)
-                                {
-                                    if (!_tilesBeingLoaded.Contains(key))
-                                    {
-                                        _tilesBeingLoaded.Add(key);
-                                        var ttx = tx;
-                                        var tty = ty;
-                                        var tileKey = key;
-                                        _ = Task.Run(async () =>
+                                        finally
                                         {
-                                            try
-                                            {
-                                                var t = await GetTileAsync(zoom, ttx, tty, CancellationToken.None);
-                                                if (t != null)
-                                                    UploadTileTexture(tileKey, t);
-                                                triggerRefresh?.Invoke();
-                                            }
-                                            finally
-                                            {
-                                                lock (_tileLoadLock)
-                                                    _tilesBeingLoaded.Remove(tileKey);
-                                            }
-                                        });
-                                    }
+                                            lock (_tileLoadLock)
+                                                _tilesBeingLoaded.Remove(tileKey);
+                                        }
+                                    });
                                 }
                             }
                         }
+                        // --- END: Replacement Logic ---
                     }
                 }
 

--- a/MultiResolutionMapManager.cs
+++ b/MultiResolutionMapManager.cs
@@ -51,7 +51,6 @@ namespace StrategyGame
         // LRU order for tile cache entries
         private readonly LinkedList<(int cellSize, int x, int y)> _tileLru = new();
         private readonly object _masterCacheLock = new();
-        private readonly object _assembleLock = new();
         private readonly Dictionary<(int cellSize, int x, int y), SKBitmap> _tileTextures = new();
 
         public static readonly bool GpuAvailable;
@@ -320,21 +319,19 @@ namespace StrategyGame
         /// </summary>
         public SKBitmap AssembleView(float zoom, System.Drawing.Rectangle viewArea, Action triggerRefresh = null)
         {
-            lock (_assembleLock)
-            {
-                int cellSize = GetCellSize(zoom);
-                int tileSize = TileSizePx;
+            int cellSize = GetCellSize(zoom);
+            int tileSize = TileSizePx;
 
-                if (viewArea.Width <= 0 || viewArea.Height <= 0 || cellSize <= 0)
-                    return new SKBitmap(1, 1); // Safe fallback
+            if (viewArea.Width <= 0 || viewArea.Height <= 0 || cellSize <= 0)
+                return new SKBitmap(1, 1); // Safe fallback
 
-                int tileStartX = Math.Max(0, viewArea.X / tileSize);
-                int tileStartY = Math.Max(0, viewArea.Y / tileSize);
-                int tileEndX = (viewArea.Right + tileSize - 1) / tileSize;
-                int tileEndY = (viewArea.Bottom + tileSize - 1) / tileSize;
+            int tileStartX = Math.Max(0, viewArea.X / tileSize);
+            int tileStartY = Math.Max(0, viewArea.Y / tileSize);
+            int tileEndX = (viewArea.Right + tileSize - 1) / tileSize;
+            int tileEndY = (viewArea.Bottom + tileSize - 1) / tileSize;
 
-                var info = new SKImageInfo(viewArea.Width, viewArea.Height);
-                var context = GpuAvailable ? SharedContext : null;
+            var info = new SKImageInfo(viewArea.Width, viewArea.Height);
+            var context = GpuAvailable ? SharedContext : null;
                 using var surface = context != null ? SKSurface.Create(context, false, info) : SKSurface.Create(info);
                 var canvas = surface.Canvas;
                 canvas.Clear(SKColors.DarkGray);
@@ -414,7 +411,6 @@ namespace StrategyGame
                 var result = new SKBitmap(info);
                 surface.ReadPixels(result.Info, result.GetPixels(), result.RowBytes, 0, 0);
                 return result;
-            }
         }
 
         private static void OverlayFeatures(SystemDrawing.Bitmap bmp, ZoomLevel level)

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -69,8 +69,6 @@ namespace StrategyGame
 
                 int urbanAreasProcessed = 0;
                 int urbanAreasSkipped = 0;
-                int totalRoads = 0;
-                int totalBuildings = 0;
 
                 var swUrbanProcessing = Stopwatch.StartNew();
                 var relevantUrbanAreas = UrbanAreaManager.Query(tileBounds);
@@ -126,7 +124,6 @@ namespace StrategyGame
                             }
                         }
                     });
-                    totalBuildings += drawList.Count;
                     PerformanceTracker.Record("CityRenderer-BuildingFiltering", swBuildings.Elapsed);
 
                     var swRendering = Stopwatch.StartNew();
@@ -158,18 +155,15 @@ namespace StrategyGame
                     // STEP 2: Process and draw roads on top of buildings
                     var swRoads = Stopwatch.StartNew();
                     int roadCount = model.RoadNetwork.Count();
-                    totalRoads += roadCount;
                     DrawRoads(img, canvas, model.RoadNetwork, tileBounds);
                     PerformanceTracker.Record("CityRenderer-RoadDrawing", swRoads.Elapsed);
-                    PerformanceTracker.Record("CityRenderer-RoadCount", TimeSpan.FromMilliseconds(roadCount));
+                    // Removed incorrect performance tracking of road count
 
                     // --- END OF FIX ---
                 }
                 PerformanceTracker.Record("CityRenderer-UrbanProcessing", swUrbanProcessing.Elapsed);
                 PerformanceTracker.Record("CityRenderer-UrbanAreasProcessed", TimeSpan.FromMilliseconds(urbanAreasProcessed));
                 PerformanceTracker.Record("CityRenderer-UrbanAreasSkipped", TimeSpan.FromMilliseconds(urbanAreasSkipped));
-                PerformanceTracker.Record("CityRenderer-TotalRoads", TimeSpan.FromMilliseconds(totalRoads));
-                PerformanceTracker.Record("CityRenderer-TotalBuildings", TimeSpan.FromMilliseconds(totalBuildings));
 
                 var swFinalize = Stopwatch.StartNew();
                 if (surface != null)

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -34,197 +34,80 @@ namespace StrategyGame
 
         public static Task<Image<Rgba32>> RenderCityTileAsync(GeoBounds tileBounds, int cellSize)
         {
-            var swTotal = Stopwatch.StartNew();
-            try
+            var img = new Image<Rgba32>(MultiResolutionMapManager.TileSizePx, MultiResolutionMapManager.TileSizePx, new Rgba32(0, 0, 0, 0));
+            var tilePoly = ToPolygon(tileBounds);
+
+            var allBuildingsToDraw = new List<(Nts.Polygon Poly, LandUseType Use)>();
+            var allRoadsToDraw = new List<LineSegment>();
+            var processedModelIds = new HashSet<Guid>();
+
+            var relevantUrbanAreas = UrbanAreaManager.Query(tileBounds);
+            foreach (var urban in relevantUrbanAreas)
             {
-                var swInit = Stopwatch.StartNew();
-                var img = new Image<Rgba32>(Configuration.Default,
-                    MultiResolutionMapManager.TileSizePx,
-                    MultiResolutionMapManager.TileSizePx,
-                    new Rgba32(0, 0, 0, 0));
+                if (!urban.EnvelopeInternal.Intersects(tilePoly.EnvelopeInternal) || !urban.Intersects(tilePoly)) continue;
+                var modelId = RoadNetworkGenerator.GetCityDataModelId(urban);
+                if (!modelId.HasValue || !processedModelIds.Add(modelId.Value)) continue;
 
-                SKSurface? surface = null;
-                SKCanvas? canvas = null;
-                if (GpuAvailable)
+                var model = RoadNetworkGenerator.LoadCityDataModel(modelId.Value);
+                if (model == null) continue;
+
+                allRoadsToDraw.AddRange(model.RoadNetwork);
+
+                var buildingGeoms = model.Buildings
+                    .AsParallel()
+                    .Select(b => new { LandUse = b.LandUse, Visible = b.Footprint.Intersection(tilePoly) })
+                    .Where(b => b.Visible != null && !b.Visible.IsEmpty)
+                    .ToList();
+
+                foreach (var b in buildingGeoms)
                 {
-                    var info = new SKImageInfo(MultiResolutionMapManager.TileSizePx, MultiResolutionMapManager.TileSizePx, SKColorType.Rgba8888, SKAlphaType.Unpremul);
-                    try
+                    if (b.Visible is Nts.Polygon p) lock (allBuildingsToDraw) allBuildingsToDraw.Add((p, b.LandUse));
+                    else if (b.Visible is Nts.MultiPolygon mp)
                     {
-                        var context = GRContext.CreateGl();
-                        surface = SKSurface.Create(context, false, info);
-                        canvas = surface.Canvas;
-                        canvas.Clear(SKColors.Transparent);
-                    }
-                    catch { surface = null; canvas = null; }
-                }
-                var tilePoly = ToPolygon(tileBounds);
-                PerformanceTracker.Record("CityRenderer-Initialization", swInit.Elapsed);
-
-                // --- START: Optimization ---
-                // 1. Use centralized lists and caches to avoid redundant processing.
-                var allBuildingsToDraw = new List<(Nts.Polygon Poly, LandUseType Use)>();
-                var allRoadsToDraw = new List<LineSegment>();
-                var processedModelIds = new HashSet<Guid>();
-                var modelCache = new Dictionary<Guid, CityDataModel>();
-                int urbanAreasProcessed = 0;
-                int urbanAreasSkipped = 0;
-
-                var swUrbanProcessing = Stopwatch.StartNew();
-                var relevantUrbanAreas = UrbanAreaManager.Query(tileBounds);
-
-                // 2. Loop through polygons to collect unique models.
-                foreach (var urban in relevantUrbanAreas)
-                {
-                    if (!urban.EnvelopeInternal.Intersects(tilePoly.EnvelopeInternal) || !urban.Intersects(tilePoly))
-                    {
-                        urbanAreasSkipped++;
-                        continue;
-                    }
-
-                    var modelId = RoadNetworkGenerator.GetCityDataModelId(urban);
-
-                    // If we have no ID or have already processed this model, skip.
-                    if (!modelId.HasValue || !processedModelIds.Add(modelId.Value))
-                    {
-                        continue;
-                    }
-
-                    CityDataModel model;
-                    var swModel = Stopwatch.StartNew();
-                    if (!modelCache.TryGetValue(modelId.Value, out model))
-                    {
-                        model = RoadNetworkGenerator.LoadCityDataModel(modelId.Value);
-                        if (model == null)
-                        {
-                            PerformanceTracker.Record("CityRenderer-ModelGeneration-Failed", swModel.Elapsed);
-                            continue;
-                        }
-                        modelCache[modelId.Value] = model;
-                    }
-                    PerformanceTracker.Record("CityRenderer-ModelGeneration", swModel.Elapsed);
-
-                    urbanAreasProcessed++;
-                    allRoadsToDraw.AddRange(model.RoadNetwork);
-
-                    var swBuildings = Stopwatch.StartNew();
-                    Parallel.ForEach(model.Buildings, b =>
-                    {
-                        if (!b.Footprint.EnvelopeInternal.Intersects(tilePoly.EnvelopeInternal)) return;
-                        var visible = b.Footprint.Intersection(tilePoly);
-                        if (visible == null || visible.IsEmpty) return;
-
-                        if (visible is Nts.Polygon p)
-                        {
-                            lock (allBuildingsToDraw) allBuildingsToDraw.Add((p, b.LandUse));
-                        }
-                        else if (visible is Nts.MultiPolygon mp)
-                        {
-                            for (int i = 0; i < mp.NumGeometries; i++)
-                            {
-                                if (mp.GetGeometryN(i) is Nts.Polygon pp)
-                                    lock (allBuildingsToDraw) allBuildingsToDraw.Add((pp, b.LandUse));
-                            }
-                        }
-                    });
-                    PerformanceTracker.Record("CityRenderer-BuildingFiltering", swBuildings.Elapsed);
-                }
-                PerformanceTracker.Record("CityRenderer-UrbanProcessing", swUrbanProcessing.Elapsed);
-
-                // 3. Perform drawing operations ONCE using the collected geometries.
-                var swRendering = Stopwatch.StartNew();
-                if (canvas != null)
-                {
-                    foreach (var grp in allBuildingsToDraw.GroupBy(d => d.Use))
-                    {
-                        using var path = new SKPath();
-                        foreach (var item in grp) AppendPolygon(path, item.Poly, tileBounds);
-                        using var paint = new SKPaint { Color = ToSkColor(GetBuildingColor(grp.Key)), Style = SKPaintStyle.Fill, IsAntialias = true };
-                        canvas.DrawPath(path, paint);
+                        for (int i = 0; i < mp.NumGeometries; i++)
+                            if (mp.GetGeometryN(i) is Nts.Polygon pp) lock (allBuildingsToDraw) allBuildingsToDraw.Add((pp, b.LandUse));
                     }
                 }
-                else
-                {
-                    foreach (var item in allBuildingsToDraw) RenderPolygon(img, null, item.Poly, tileBounds, GetBuildingColor(item.Use));
-                }
-                PerformanceTracker.Record("CityRenderer-BuildingRendering", swRendering.Elapsed);
-
-                var swRoads = Stopwatch.StartNew();
-                DrawRoads(img, canvas, allRoadsToDraw, tileBounds);
-                PerformanceTracker.Record("CityRenderer-RoadDrawing", swRoads.Elapsed);
-
-                // --- END: Optimization ---
-
-                // Fix for performance tracking: log the count directly, not as time.
-                PerformanceTracker.Record("CityRenderer-UrbanAreasProcessed", TimeSpan.Zero);
-                PerformanceTracker.Record("CityRenderer-UrbanAreasSkipped", TimeSpan.Zero);
-
-                var swFinalize = Stopwatch.StartNew();
-                if (surface != null)
-                {
-                    using var snapshot = surface.Snapshot();
-                    using var data = snapshot.Encode(SKEncodedImageFormat.Png, 100);
-                    img.Dispose();
-                    img = SixLabors.ImageSharp.Image.Load<Rgba32>(data.AsStream());
-                }
-                PerformanceTracker.Record("CityRenderer-Finalization", swFinalize.Elapsed);
-                PerformanceTracker.Record("CityRenderer-Total", swTotal.Elapsed);
-
-                return Task.FromResult(img);
             }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"[Error] RenderCityTileAsync Exception: {ex.Message}\n{ex.StackTrace}");
-                PerformanceTracker.Record("CityRenderer-Exception", swTotal.Elapsed);
-                throw;
-            }
+
+            DrawBuildings(img, allBuildingsToDraw, tileBounds);
+            DrawRoads(img, allRoadsToDraw, tileBounds);
+
+            return Task.FromResult(img);
         }
 
-        private static void DrawRoads(Image<Rgba32> img, SKCanvas? canvas, IEnumerable<LineSegment> roads, GeoBounds bounds)
+        private static void DrawBuildings(Image<Rgba32> img, List<(Nts.Polygon Poly, LandUseType Use)> buildings, GeoBounds bounds)
         {
-            var sw = Stopwatch.StartNew();
-            if (canvas != null)
+            var buildingsByColor = buildings.GroupBy(b => GetBuildingColor(b.Use));
+
+            img.Mutate(ctx =>
             {
-                // This is the efficient GPU path
-                // (No changes needed here)
-                foreach (var seg in roads)
+                foreach (var group in buildingsByColor)
                 {
-                    float width = seg.Type == RoadType.Primary ? 2f : 1f;
-                    using var paint = new SKPaint
-                    {
-                        Color = new SKColor(180, 180, 180, 200),
-                        StrokeWidth = width,
-                        Style = SKPaintStyle.Stroke,
-                        IsAntialias = true
-                    };
-                    var p1 = ToSKPoint(seg.X1, seg.Y1, bounds);
-                    var p2 = ToSKPoint(seg.X2, seg.Y2, bounds);
-                    canvas.DrawLine(p1, p2, paint);
+                    var color = group.Key;
+                    var paths = new PathCollection(group.Select(item =>
+                        new Polygon(new LinearLineSegment(item.Poly.ExteriorRing.Coordinates.Select(c => ToPointF(c.X, c.Y, bounds)).ToArray()))));
+                    ctx.Fill(color, paths);
                 }
-                PerformanceTracker.Record("DrawRoads-Skia", sw.Elapsed);
-            }
-            else
+            });
+        }
+
+        private static void DrawRoads(Image<Rgba32> img, IEnumerable<LineSegment> roads, GeoBounds bounds)
+        {
+            var primaryPathBuilder = new PathBuilder();
+            var secondaryPathBuilder = new PathBuilder();
+            foreach (var seg in roads)
             {
-                // --- START: Optimized CPU Fallback ---
-                // Create pens once outside the loop to avoid thousands of allocations.
-                var primaryPen = Pens.Solid(new Rgba32(180, 180, 180, 200), 2f);
-                var secondaryPen = Pens.Solid(new Rgba32(180, 180, 180, 200), 1f);
-
-                img.Mutate(ctx =>
-                {
-                    // Loop and draw each line individually, which is faster for this use case.
-                    foreach (var seg in roads)
-                    {
-                        var p1 = ToPointF(seg.X1, seg.Y1, bounds);
-                        var p2 = ToPointF(seg.X2, seg.Y2, bounds);
-
-                        // Select the appropriate pre-made pen.
-                        var pen = seg.Type == RoadType.Primary ? primaryPen : secondaryPen;
-                        ctx.DrawLine(pen, p1, p2);
-                    }
-                });
-                // --- END: Optimized CPU Fallback ---
-                PerformanceTracker.Record("DrawRoads-ImageSharp", sw.Elapsed);
+                var builder = seg.Type == RoadType.Primary ? primaryPathBuilder : secondaryPathBuilder;
+                builder.AddLine(ToPointF(seg.X1, seg.Y1, bounds), ToPointF(seg.X2, seg.Y2, bounds));
             }
+
+            var primaryPen = Pens.Solid(new Rgba32(180, 180, 180, 200), 2f);
+            var secondaryPen = Pens.Solid(new Rgba32(180, 180, 180, 200), 1f);
+
+            img.Mutate(ctx => ctx
+                .Draw(secondaryPen, secondaryPathBuilder.Build())
+                .Draw(primaryPen, primaryPathBuilder.Build()));
         }
 
         private static SixLabors.ImageSharp.PointF ToPointF(double lon, double lat, GeoBounds b)
@@ -286,28 +169,5 @@ namespace StrategyGame
             return result;
         }
 
-        private static void RenderPolygon(Image<Rgba32> img, SKCanvas? canvas, Nts.Polygon poly, GeoBounds bounds, Rgba32 color)
-        {
-            var sw = Stopwatch.StartNew();
-            if (canvas != null)
-            {
-                using var path = new SKPath();
-                AppendPolygon(path, poly, bounds);
-                using var paint = new SKPaint
-                {
-                    Color = ToSkColor(color),
-                    Style = SKPaintStyle.Fill,
-                    IsAntialias = true
-                };
-                canvas.DrawPath(path, paint);
-                PerformanceTracker.Record("RenderPolygon-Skia", sw.Elapsed);
-            }
-            else
-            {
-                var coords = poly.ExteriorRing.Coordinates.Select(c => ToPointF(c.X, c.Y, bounds)).ToArray();
-                img.Mutate(ctx => ctx.Fill(color, new Polygon(coords)));
-                PerformanceTracker.Record("RenderPolygon-ImageSharp", sw.Elapsed);
-            }
-        }
     }
 }

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -37,8 +37,6 @@ namespace StrategyGame
             var swTotal = Stopwatch.StartNew();
             try
             {
-                Console.WriteLine($"[Debug] RenderCityTileAsync: Bounds={{MinLon={tileBounds.MinLon},MaxLon={tileBounds.MaxLon},MinLat={tileBounds.MinLat},MaxLat={tileBounds.MaxLat}}}, cellSize={cellSize}");
-
                 var swInit = Stopwatch.StartNew();
                 var img = new Image<Rgba32>(Configuration.Default,
                     MultiResolutionMapManager.TileSizePx,
@@ -49,8 +47,7 @@ namespace StrategyGame
                 SKCanvas? canvas = null;
                 if (GpuAvailable)
                 {
-                    var info = new SKImageInfo(MultiResolutionMapManager.TileSizePx,
-                        MultiResolutionMapManager.TileSizePx);
+                    var info = new SKImageInfo(MultiResolutionMapManager.TileSizePx, MultiResolutionMapManager.TileSizePx, SKColorType.Rgba8888, SKAlphaType.Unpremul);
                     try
                     {
                         var context = GRContext.CreateGl();
@@ -58,112 +55,108 @@ namespace StrategyGame
                         canvas = surface.Canvas;
                         canvas.Clear(SKColors.Transparent);
                     }
-                    catch
-                    {
-                        surface = null;
-                        canvas = null;
-                    }
+                    catch { surface = null; canvas = null; }
                 }
                 var tilePoly = ToPolygon(tileBounds);
                 PerformanceTracker.Record("CityRenderer-Initialization", swInit.Elapsed);
 
+                // --- START: Optimization ---
+                // 1. Use centralized lists and caches to avoid redundant processing.
+                var allBuildingsToDraw = new List<(Nts.Polygon Poly, LandUseType Use)>();
+                var allRoadsToDraw = new List<LineSegment>();
+                var processedModelIds = new HashSet<Guid>();
+                var modelCache = new Dictionary<Guid, CityDataModel>();
                 int urbanAreasProcessed = 0;
                 int urbanAreasSkipped = 0;
 
                 var swUrbanProcessing = Stopwatch.StartNew();
                 var relevantUrbanAreas = UrbanAreaManager.Query(tileBounds);
+
+                // 2. Loop through polygons to collect unique models.
                 foreach (var urban in relevantUrbanAreas)
                 {
-                    var swSpatialCheck = Stopwatch.StartNew();
                     if (!urban.EnvelopeInternal.Intersects(tilePoly.EnvelopeInternal) || !urban.Intersects(tilePoly))
                     {
                         urbanAreasSkipped++;
-                        PerformanceTracker.Record("CityRenderer-SpatialCheck-Skipped", swSpatialCheck.Elapsed);
                         continue;
                     }
-                    PerformanceTracker.Record("CityRenderer-SpatialCheck-Passed", swSpatialCheck.Elapsed);
 
-                    var swModel = Stopwatch.StartNew();
                     var modelId = RoadNetworkGenerator.GetCityDataModelId(urban);
-                    if (!modelId.HasValue)
+
+                    // If we have no ID or have already processed this model, skip.
+                    if (!modelId.HasValue || !processedModelIds.Add(modelId.Value))
                     {
-                        PerformanceTracker.Record("CityRenderer-ModelGeneration-Failed", swModel.Elapsed);
                         continue;
                     }
 
-                    var model = RoadNetworkGenerator.LoadCityDataModel(modelId.Value);
-                    if (model == null)
+                    CityDataModel model;
+                    var swModel = Stopwatch.StartNew();
+                    if (!modelCache.TryGetValue(modelId.Value, out model))
                     {
-                        PerformanceTracker.Record("CityRenderer-ModelGeneration-Failed", swModel.Elapsed);
-                        continue;
+                        model = RoadNetworkGenerator.LoadCityDataModel(modelId.Value);
+                        if (model == null)
+                        {
+                            PerformanceTracker.Record("CityRenderer-ModelGeneration-Failed", swModel.Elapsed);
+                            continue;
+                        }
+                        modelCache[modelId.Value] = model;
                     }
                     PerformanceTracker.Record("CityRenderer-ModelGeneration", swModel.Elapsed);
+
                     urbanAreasProcessed++;
+                    allRoadsToDraw.AddRange(model.RoadNetwork);
 
-                    // --- START OF FIX ---
-                    // The drawing order has been swapped. Buildings are now drawn BEFORE roads.
-
-                    // STEP 1: Process and draw buildings
                     var swBuildings = Stopwatch.StartNew();
-                    var drawList = new List<(Nts.Polygon Poly, LandUseType Use)>();
                     Parallel.ForEach(model.Buildings, b =>
                     {
-                        if (!b.Footprint.EnvelopeInternal.Intersects(tilePoly.EnvelopeInternal))
-                            return;
+                        if (!b.Footprint.EnvelopeInternal.Intersects(tilePoly.EnvelopeInternal)) return;
                         var visible = b.Footprint.Intersection(tilePoly);
+                        if (visible == null || visible.IsEmpty) return;
+
                         if (visible is Nts.Polygon p)
                         {
-                            lock (drawList) drawList.Add((p, b.LandUse));
+                            lock (allBuildingsToDraw) allBuildingsToDraw.Add((p, b.LandUse));
                         }
                         else if (visible is Nts.MultiPolygon mp)
                         {
                             for (int i = 0; i < mp.NumGeometries; i++)
                             {
                                 if (mp.GetGeometryN(i) is Nts.Polygon pp)
-                                    lock (drawList) drawList.Add((pp, b.LandUse));
+                                    lock (allBuildingsToDraw) allBuildingsToDraw.Add((pp, b.LandUse));
                             }
                         }
                     });
                     PerformanceTracker.Record("CityRenderer-BuildingFiltering", swBuildings.Elapsed);
-
-                    var swRendering = Stopwatch.StartNew();
-                    if (canvas != null)
-                    {
-                        foreach (var grp in drawList.GroupBy(d => d.Use))
-                        {
-                            using var path = new SKPath();
-                            foreach (var item in grp)
-                            {
-                                AppendPolygon(path, item.Poly, tileBounds);
-                            }
-                            using var paint = new SKPaint
-                            {
-                                Color = ToSkColor(GetBuildingColor(grp.Key)),
-                                Style = SKPaintStyle.Fill,
-                                IsAntialias = true
-                            };
-                            canvas.DrawPath(path, paint);
-                        }
-                    }
-                    else
-                    {
-                        foreach (var item in drawList)
-                            RenderPolygon(img, null, item.Poly, tileBounds, GetBuildingColor(item.Use));
-                    }
-                    PerformanceTracker.Record("CityRenderer-BuildingRendering", swRendering.Elapsed);
-
-                    // STEP 2: Process and draw roads on top of buildings
-                    var swRoads = Stopwatch.StartNew();
-                    int roadCount = model.RoadNetwork.Count();
-                    DrawRoads(img, canvas, model.RoadNetwork, tileBounds);
-                    PerformanceTracker.Record("CityRenderer-RoadDrawing", swRoads.Elapsed);
-                    // Removed incorrect performance tracking of road count
-
-                    // --- END OF FIX ---
                 }
                 PerformanceTracker.Record("CityRenderer-UrbanProcessing", swUrbanProcessing.Elapsed);
-                PerformanceTracker.Record("CityRenderer-UrbanAreasProcessed", TimeSpan.FromMilliseconds(urbanAreasProcessed));
-                PerformanceTracker.Record("CityRenderer-UrbanAreasSkipped", TimeSpan.FromMilliseconds(urbanAreasSkipped));
+
+                // 3. Perform drawing operations ONCE using the collected geometries.
+                var swRendering = Stopwatch.StartNew();
+                if (canvas != null)
+                {
+                    foreach (var grp in allBuildingsToDraw.GroupBy(d => d.Use))
+                    {
+                        using var path = new SKPath();
+                        foreach (var item in grp) AppendPolygon(path, item.Poly, tileBounds);
+                        using var paint = new SKPaint { Color = ToSkColor(GetBuildingColor(grp.Key)), Style = SKPaintStyle.Fill, IsAntialias = true };
+                        canvas.DrawPath(path, paint);
+                    }
+                }
+                else
+                {
+                    foreach (var item in allBuildingsToDraw) RenderPolygon(img, null, item.Poly, tileBounds, GetBuildingColor(item.Use));
+                }
+                PerformanceTracker.Record("CityRenderer-BuildingRendering", swRendering.Elapsed);
+
+                var swRoads = Stopwatch.StartNew();
+                DrawRoads(img, canvas, allRoadsToDraw, tileBounds);
+                PerformanceTracker.Record("CityRenderer-RoadDrawing", swRoads.Elapsed);
+
+                // --- END: Optimization ---
+
+                // Fix for performance tracking: log the count directly, not as time.
+                PerformanceTracker.Record("CityRenderer-UrbanAreasProcessed", TimeSpan.Zero);
+                PerformanceTracker.Record("CityRenderer-UrbanAreasSkipped", TimeSpan.Zero);
 
                 var swFinalize = Stopwatch.StartNew();
                 if (surface != null)
@@ -178,15 +171,9 @@ namespace StrategyGame
 
                 return Task.FromResult(img);
             }
-            catch (ArgumentException ex)
-            {
-                Console.WriteLine($"[Error] RenderCityTileAsync ArgumentException: {ex.Message}");
-                PerformanceTracker.Record("CityRenderer-ArgumentException", swTotal.Elapsed);
-                throw;
-            }
             catch (Exception ex)
             {
-                Console.WriteLine($"[Error] RenderCityTileAsync Exception: {ex.Message}");
+                Console.WriteLine($"[Error] RenderCityTileAsync Exception: {ex.Message}\n{ex.StackTrace}");
                 PerformanceTracker.Record("CityRenderer-Exception", swTotal.Elapsed);
                 throw;
             }
@@ -197,6 +184,7 @@ namespace StrategyGame
             var sw = Stopwatch.StartNew();
             if (canvas != null)
             {
+                // GPU Path (already efficient)
                 foreach (var seg in roads)
                 {
                     float width = seg.Type == RoadType.Primary ? 2f : 1f;
@@ -215,17 +203,41 @@ namespace StrategyGame
             }
             else
             {
-                img.Mutate(ctx =>
+                // --- START: Optimized CPU Path ---
+
+                // 1. Build paths for each road type instead of drawing lines individually.
+                var primaryPathBuilder = new PathBuilder();
+                var secondaryPathBuilder = new PathBuilder();
+
+                foreach (var seg in roads)
                 {
-                    foreach (var seg in roads)
+                    var p1 = ToPointF(seg.X1, seg.Y1, bounds);
+                    var p2 = ToPointF(seg.X2, seg.Y2, bounds);
+
+                    if (seg.Type == RoadType.Primary)
                     {
-                        float width = seg.Type == RoadType.Primary ? 2f : 1f;
-                        var pen = SixLabors.ImageSharp.Drawing.Processing.Pens.Solid(new Rgba32(180, 180, 180, 200), width);
-                        var p1 = ToPointF(seg.X1, seg.Y1, bounds);
-                        var p2 = ToPointF(seg.X2, seg.Y2, bounds);
-                        ctx.DrawLine(pen, p1, p2);
+                        primaryPathBuilder.AddLine(p1, p2);
                     }
-                });
+                    else
+                    {
+                        secondaryPathBuilder.AddLine(p1, p2);
+                    }
+                }
+
+                var primaryPath = primaryPathBuilder.Build();
+                var secondaryPath = secondaryPathBuilder.Build();
+
+                // 2. Create pens only once.
+                var primaryPen = SixLabors.ImageSharp.Drawing.Processing.Pens.Solid(new Rgba32(180, 180, 180, 200), 2f);
+                var secondaryPen = SixLabors.ImageSharp.Drawing.Processing.Pens.Solid(new Rgba32(180, 180, 180, 200), 1f);
+
+                // 3. Draw each path in a single, efficient operation.
+                img.Mutate(ctx => ctx
+                    .Draw(secondaryPen, secondaryPath) // Draw smaller roads first
+                    .Draw(primaryPen, primaryPath)   // Draw main roads on top
+                );
+
+                // --- END: Optimized CPU Path ---
                 PerformanceTracker.Record("DrawRoads-ImageSharp", sw.Elapsed);
             }
         }

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -184,7 +184,8 @@ namespace StrategyGame
             var sw = Stopwatch.StartNew();
             if (canvas != null)
             {
-                // GPU Path (already efficient)
+                // This is the efficient GPU path
+                // (No changes needed here)
                 foreach (var seg in roads)
                 {
                     float width = seg.Type == RoadType.Primary ? 2f : 1f;
@@ -203,41 +204,25 @@ namespace StrategyGame
             }
             else
             {
-                // --- START: Optimized CPU Path ---
+                // --- START: Optimized CPU Fallback ---
+                // Create pens once outside the loop to avoid thousands of allocations.
+                var primaryPen = Pens.Solid(new Rgba32(180, 180, 180, 200), 2f);
+                var secondaryPen = Pens.Solid(new Rgba32(180, 180, 180, 200), 1f);
 
-                // 1. Build paths for each road type instead of drawing lines individually.
-                var primaryPathBuilder = new PathBuilder();
-                var secondaryPathBuilder = new PathBuilder();
-
-                foreach (var seg in roads)
+                img.Mutate(ctx =>
                 {
-                    var p1 = ToPointF(seg.X1, seg.Y1, bounds);
-                    var p2 = ToPointF(seg.X2, seg.Y2, bounds);
-
-                    if (seg.Type == RoadType.Primary)
+                    // Loop and draw each line individually, which is faster for this use case.
+                    foreach (var seg in roads)
                     {
-                        primaryPathBuilder.AddLine(p1, p2);
+                        var p1 = ToPointF(seg.X1, seg.Y1, bounds);
+                        var p2 = ToPointF(seg.X2, seg.Y2, bounds);
+
+                        // Select the appropriate pre-made pen.
+                        var pen = seg.Type == RoadType.Primary ? primaryPen : secondaryPen;
+                        ctx.DrawLine(pen, p1, p2);
                     }
-                    else
-                    {
-                        secondaryPathBuilder.AddLine(p1, p2);
-                    }
-                }
-
-                var primaryPath = primaryPathBuilder.Build();
-                var secondaryPath = secondaryPathBuilder.Build();
-
-                // 2. Create pens only once.
-                var primaryPen = SixLabors.ImageSharp.Drawing.Processing.Pens.Solid(new Rgba32(180, 180, 180, 200), 2f);
-                var secondaryPen = SixLabors.ImageSharp.Drawing.Processing.Pens.Solid(new Rgba32(180, 180, 180, 200), 1f);
-
-                // 3. Draw each path in a single, efficient operation.
-                img.Mutate(ctx => ctx
-                    .Draw(secondaryPen, secondaryPath) // Draw smaller roads first
-                    .Draw(primaryPen, primaryPath)   // Draw main roads on top
-                );
-
-                // --- END: Optimized CPU Path ---
+                });
+                // --- END: Optimized CPU Fallback ---
                 PerformanceTracker.Record("DrawRoads-ImageSharp", sw.Elapsed);
             }
         }

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -76,19 +76,62 @@ namespace StrategyGame
             return img;
         }
 
-        // Batched building drawing with caching
+        // Batched building drawing with caching and dynamic LOD
         private static void DrawBuildings(Image<Rgba32> img, Guid modelId, List<(Nts.Polygon Poly, LandUseType Use)> buildings, GeoBounds bounds, int cellSize)
         {
             var sw = Stopwatch.StartNew();
-            var cached = CityModelCache.GetOrAddBuildings(modelId, cellSize, bounds, buildings);
+
+            // 1) Cull buildings that would be too small on screen
+            if (cellSize <= 40)
+            {
+                buildings = buildings.Where(b =>
+                {
+                    var env = b.Poly.EnvelopeInternal;
+                    var p0 = ToPointF(env.MinX, env.MinY, bounds);
+                    var p1 = ToPointF(env.MaxX, env.MaxY, bounds);
+                    return Math.Abs(p1.X - p0.X) > 4 || Math.Abs(p1.Y - p0.Y) > 4;
+                }).ToList();
+            }
+
+            // 2) Optionally drop residential buildings at very small scales
+            if (cellSize <= 20)
+            {
+                buildings = buildings.Where(b => b.Use != LandUseType.Residential).ToList();
+            }
+
+            // 3) Dynamically simplify footprints based on zoom level
+            double tol = (bounds.MaxLon - bounds.MinLon)
+                         / MultiResolutionMapManager.TileSizePx
+                         * (cellSize <= 80 ? 2.5 : 1.0);
+
+            var reduced = new List<(Nts.Polygon Poly, LandUseType Use)>();
+            foreach (var (poly, use) in buildings)
+            {
+                var simplified = DouglasPeuckerSimplifier.Simplify(poly, tol);
+                if (simplified == null || simplified.IsEmpty) continue;
+
+                if (simplified is Nts.Polygon p)
+                {
+                    reduced.Add((p, use));
+                }
+                else if (simplified is Nts.MultiPolygon mp)
+                {
+                    for (int i = 0; i < mp.NumGeometries; i++)
+                    {
+                        if (mp.GetGeometryN(i) is Nts.Polygon pp && !pp.IsEmpty)
+                            reduced.Add((pp, use));
+                    }
+                }
+            }
+
+            var cached = CityModelCache.GetOrAddBuildings(modelId, cellSize, bounds, reduced);
 
             img.Mutate(ctx =>
             {
                 foreach (var kvp in cached.PathsByColor)
-                {
                     ctx.Fill(kvp.Key, kvp.Value);
-                }
             });
+
             PerformanceTracker.Record("CityRenderer-BuildingRendering", sw.Elapsed);
         }
 

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -100,22 +100,26 @@ namespace StrategyGame
         {
             var sw = Stopwatch.StartNew();
 
-            // 1) Cull buildings that would be too small on screen
-            if (cellSize <= 40)
+            // Consolidated culling loop to reduce allocations
+            var culledBuildings = new List<(Nts.Polygon Poly, LandUseType Use, Building Bld)>();
+            bool cullBySize = cellSize <= 40;
+            bool cullResidential = cellSize <= 20;
+
+            foreach (var bld in buildings)
             {
-                buildings = buildings.Where(b =>
+                if (cullResidential && bld.Use == LandUseType.Residential)
+                    continue;
+
+                if (cullBySize)
                 {
-                    var env = b.Poly.EnvelopeInternal;
+                    var env = bld.Poly.EnvelopeInternal;
                     var p0 = ToPointF(env.MinX, env.MinY, bounds);
                     var p1 = ToPointF(env.MaxX, env.MaxY, bounds);
-                    return Math.Abs(p1.X - p0.X) > 4 || Math.Abs(p1.Y - p0.Y) > 4;
-                }).ToList();
-            }
+                    if (Math.Abs(p1.X - p0.X) < 4 && Math.Abs(p1.Y - p0.Y) < 4)
+                        continue;
+                }
 
-            // 2) Optionally drop residential buildings at very small scales
-            if (cellSize <= 20)
-            {
-                buildings = buildings.Where(b => b.Use != LandUseType.Residential).ToList();
+                culledBuildings.Add(bld);
             }
 
             // 3) Dynamically simplify footprints based on zoom level
@@ -124,7 +128,7 @@ namespace StrategyGame
                          * (cellSize <= 80 ? 2.5 : 1.0);
 
             var reduced = new List<(Nts.Polygon Poly, LandUseType Use)>();
-            foreach (var (poly, use, bld) in buildings)
+            foreach (var (poly, use, bld) in culledBuildings)
             {
                 var simplified = bld.SimplifiedFootprints.GetOrAdd(cellSize, _ =>
                 {
@@ -163,31 +167,23 @@ namespace StrategyGame
             double tolerance = (bounds.MaxLon - bounds.MinLon) / MultiResolutionMapManager.TileSizePx * 2.0;
 
             var gf = Nts.GeometryFactory.Default;
-            foreach (var group in roads.GroupBy(r => r.Type))
+            foreach (var road in roads)
             {
-                var lineStrings = group.Select(s =>
-                    gf.CreateLineString(new[]
-                    {
-                        new Nts.Coordinate(s.X1, s.Y1),
-                        new Nts.Coordinate(s.X2, s.Y2)
-                    })).ToArray();
-
-                if (lineStrings.Length == 0) continue;
-
-                var multi = gf.CreateMultiLineString(lineStrings);
-                var simplified = NetTopologySuite.Simplify.DouglasPeuckerSimplifier.Simplify(multi, tolerance) as Nts.MultiLineString;
-                if (simplified == null) continue;
-
-                for (int i = 0; i < simplified.NumGeometries; i++)
+                var line = gf.CreateLineString(new[]
                 {
-                    if (simplified.GetGeometryN(i) is Nts.LineString ln)
+                    new Nts.Coordinate(road.X1, road.Y1),
+                    new Nts.Coordinate(road.X2, road.Y2)
+                });
+
+                var simplified = DouglasPeuckerSimplifier.Simplify(line, tolerance);
+
+                if (simplified is Nts.LineString ln)
+                {
+                    for (int j = 0; j < ln.NumPoints - 1; j++)
                     {
-                        for (int j = 0; j < ln.NumPoints - 1; j++)
-                        {
-                            var c1 = ln.GetCoordinateN(j);
-                            var c2 = ln.GetCoordinateN(j + 1);
-                            yield return new LineSegment(c1.X, c1.Y, c2.X, c2.Y, group.Key);
-                        }
+                        var c1 = ln.GetCoordinateN(j);
+                        var c2 = ln.GetCoordinateN(j + 1);
+                        yield return new LineSegment(c1.X, c1.Y, c2.X, c2.Y, road.Type);
                     }
                 }
             }

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -102,13 +102,10 @@ namespace StrategyGame
                     PerformanceTracker.Record("CityRenderer-ModelGeneration", swModel.Elapsed);
                     urbanAreasProcessed++;
 
-                    var swRoads = Stopwatch.StartNew();
-                    int roadCount = model.RoadNetwork.Count();
-                    totalRoads += roadCount;
-                    DrawRoads(img, canvas, model.RoadNetwork, tileBounds);
-                    PerformanceTracker.Record("CityRenderer-RoadDrawing", swRoads.Elapsed);
-                    PerformanceTracker.Record("CityRenderer-RoadCount", TimeSpan.FromMilliseconds(roadCount));
+                    // --- START OF FIX ---
+                    // The drawing order has been swapped. Buildings are now drawn BEFORE roads.
 
+                    // STEP 1: Process and draw buildings
                     var swBuildings = Stopwatch.StartNew();
                     var drawList = new List<(Nts.Polygon Poly, LandUseType Use)>();
                     Parallel.ForEach(model.Buildings, b =>
@@ -157,6 +154,16 @@ namespace StrategyGame
                             RenderPolygon(img, null, item.Poly, tileBounds, GetBuildingColor(item.Use));
                     }
                     PerformanceTracker.Record("CityRenderer-BuildingRendering", swRendering.Elapsed);
+
+                    // STEP 2: Process and draw roads on top of buildings
+                    var swRoads = Stopwatch.StartNew();
+                    int roadCount = model.RoadNetwork.Count();
+                    totalRoads += roadCount;
+                    DrawRoads(img, canvas, model.RoadNetwork, tileBounds);
+                    PerformanceTracker.Record("CityRenderer-RoadDrawing", swRoads.Elapsed);
+                    PerformanceTracker.Record("CityRenderer-RoadCount", TimeSpan.FromMilliseconds(roadCount));
+
+                    // --- END OF FIX ---
                 }
                 PerformanceTracker.Record("CityRenderer-UrbanProcessing", swUrbanProcessing.Elapsed);
                 PerformanceTracker.Record("CityRenderer-UrbanAreasProcessed", TimeSpan.FromMilliseconds(urbanAreasProcessed));

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -105,6 +105,8 @@ namespace StrategyGame
             bool cullBySize = cellSize <= 40;
             bool cullResidential = cellSize <= 20;
 
+            float sx = MultiResolutionMapManager.TileSizePx / (float)(bounds.MaxLon - bounds.MinLon);
+            float sy = MultiResolutionMapManager.TileSizePx / (float)(bounds.MaxLat - bounds.MinLat);
             foreach (var bld in buildings)
             {
                 if (cullResidential && bld.Use == LandUseType.Residential)
@@ -113,9 +115,11 @@ namespace StrategyGame
                 if (cullBySize)
                 {
                     var env = bld.Poly.EnvelopeInternal;
-                    var p0 = ToPointF(env.MinX, env.MinY, bounds);
-                    var p1 = ToPointF(env.MaxX, env.MaxY, bounds);
-                    if (Math.Abs(p1.X - p0.X) < 4 && Math.Abs(p1.Y - p0.Y) < 4)
+                    float p0x = (float)((env.MinX - bounds.MinLon) * sx);
+                    float p0y = (float)((bounds.MaxLat - env.MinY) * sy);
+                    float p1x = (float)((env.MaxX - bounds.MinLon) * sx);
+                    float p1y = (float)((bounds.MaxLat - env.MaxY) * sy);
+                    if (Math.Abs(p1x - p0x) < 4 && Math.Abs(p1y - p0y) < 4)
                         continue;
                 }
 

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -7,9 +7,7 @@ using NetTopologySuite.Simplify;
 using System.Linq;
 using System;
 using System.Collections.Generic;
-using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.Threading.Tasks;
 using SixLabors.ImageSharp.Drawing;
 using economy_sim;
 
@@ -17,33 +15,34 @@ namespace StrategyGame
 {
     public static class ProceduralCityRenderer
     {
-        private static readonly ConcurrentDictionary<Guid, CityDataModel> _modelCache = new();
-        // This method is now async to support awaiting the data model.
-        public static async Task<Image<Rgba32>> RenderCityTileAsync(GeoBounds tileBounds, int cellSize)
+        // Rendering should never block on disk. Models must be supplied via cache.
+        public static Image<Rgba32> RenderCityTile(
+            GeoBounds tileBounds,
+            int cellSize,
+            IReadOnlyDictionary<Guid, CityDataModel> cityModelCache,
+            Action<Guid> requestModel)
         {
             var sw = Stopwatch.StartNew();
             var img = new Image<Rgba32>(MultiResolutionMapManager.TileSizePx, MultiResolutionMapManager.TileSizePx, new Rgba32(0, 0, 0, 0));
             var tilePoly = ToPolygon(tileBounds);
 
             var processedModelIds = new HashSet<Guid>();
-            
+
             var relevantUrbanAreas = UrbanAreaManager.Query(tileBounds);
 
-            // This loop now awaits the new async methods, preventing deadlocks.
             foreach (var urban in relevantUrbanAreas)
             {
                 if (!urban.EnvelopeInternal.Intersects(tilePoly.EnvelopeInternal) || !urban.Intersects(tilePoly))
                     continue;
 
-                var modelId = await RoadNetworkGenerator.GetCityDataModelIdAsync(urban).ConfigureAwait(false);
+                var modelId = RoadNetworkGenerator.GetCityDataModelIdAsync(urban).Result;
                 if (!modelId.HasValue || !processedModelIds.Add(modelId.Value))
                     continue;
 
-                if (!_modelCache.TryGetValue(modelId.Value, out var model))
+                if (!cityModelCache.TryGetValue(modelId.Value, out var model))
                 {
-                    model = await RoadNetworkGenerator.LoadCityDataModelAsync(modelId.Value).ConfigureAwait(false);
-                    if (model == null) continue;
-                    _modelCache[modelId.Value] = model;
+                    requestModel(modelId.Value);
+                    continue;
                 }
 
                 DrawRoads(img, modelId.Value, model.RoadNetwork, tileBounds, cellSize);

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -20,6 +20,7 @@ namespace StrategyGame
     {
         // Rendering should never block on disk. Models must be supplied via cache.
         private static readonly ConcurrentDictionary<(Guid modelId, int cellSize), List<LineSegment>> _simplifiedRoadCache = new();
+        private static readonly Nts.GeometryFactory _geomFactory = Nts.GeometryFactory.Default;
         public static async Task<Image<Rgba32>> RenderCityTileAsync(
             GeoBounds tileBounds,
             int cellSize,
@@ -166,10 +167,9 @@ namespace StrategyGame
         {
             double tolerance = (bounds.MaxLon - bounds.MinLon) / MultiResolutionMapManager.TileSizePx * 2.0;
 
-            var gf = Nts.GeometryFactory.Default;
             foreach (var road in roads)
             {
-                var line = gf.CreateLineString(new[]
+                var line = _geomFactory.CreateLineString(new[]
                 {
                     new Nts.Coordinate(road.X1, road.Y1),
                     new Nts.Coordinate(road.X2, road.Y2)

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -21,6 +21,7 @@ namespace StrategyGame
         // This method is now async to support awaiting the data model.
         public static async Task<Image<Rgba32>> RenderCityTileAsync(GeoBounds tileBounds, int cellSize)
         {
+            var sw = Stopwatch.StartNew();
             var img = new Image<Rgba32>(MultiResolutionMapManager.TileSizePx, MultiResolutionMapManager.TileSizePx, new Rgba32(0, 0, 0, 0));
             var tilePoly = ToPolygon(tileBounds);
 
@@ -73,6 +74,7 @@ namespace StrategyGame
                 DrawBuildings(img, modelId.Value, toDraw, tileBounds, cellSize);
             }
 
+            PerformanceTracker.Record("CityRenderer-RenderTile", sw.Elapsed);
             return img;
         }
 

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -24,7 +24,6 @@ namespace StrategyGame
             var img = new Image<Rgba32>(MultiResolutionMapManager.TileSizePx, MultiResolutionMapManager.TileSizePx, new Rgba32(0, 0, 0, 0));
             var tilePoly = ToPolygon(tileBounds);
 
-            var allBuildingsToDraw = new List<(Nts.Polygon Poly, LandUseType Use)>();
             var processedModelIds = new HashSet<Guid>();
             
             var relevantUrbanAreas = UrbanAreaManager.Query(tileBounds);
@@ -48,45 +47,46 @@ namespace StrategyGame
 
                 DrawRoads(img, modelId.Value, model.RoadNetwork, tileBounds, cellSize);
                 
-                // Process building geometry in parallel
-                var buildingGeoms = model.Buildings
-                    .AsParallel()
-                    .Select(b => new { b.LandUse, Visible = b.Footprint.Intersection(tilePoly) })
-                    .Where(b => b.Visible != null && !b.Visible.IsEmpty)
-                    .ToList();
-
-                foreach(var b in buildingGeoms)
+                // Query visible buildings using the model's spatial index
+                var tileEnv = tilePoly.EnvelopeInternal;
+                var candidates = (model.BuildingIndex?.Query(tileEnv).Cast<Building>() ?? model.Buildings);
+                var toDraw = new List<(Nts.Polygon, LandUseType)>();
+                foreach (var b in candidates)
                 {
-                    if (b.Visible is Nts.Polygon p) lock (allBuildingsToDraw) allBuildingsToDraw.Add((p, b.LandUse));
-                    else if (b.Visible is Nts.MultiPolygon mp)
+                    var env = b.Footprint.EnvelopeInternal;
+                    if (!env.Intersects(tileEnv)) continue;
+                    var baseGeom = b.SimplifiedFootprint ?? b.Footprint;
+                    Nts.Geometry clipped = tileEnv.Contains(env)
+                        ? baseGeom
+                        : baseGeom.Intersection(tilePoly);
+
+                    if (clipped is Nts.Polygon p && !p.IsEmpty)
+                        toDraw.Add((p, b.LandUse));
+                    else if (clipped is Nts.MultiPolygon mp)
                     {
                         for (int i = 0; i < mp.NumGeometries; i++)
-                            if (mp.GetGeometryN(i) is Nts.Polygon pp) lock (allBuildingsToDraw) allBuildingsToDraw.Add((pp, b.LandUse));
+                            if (mp.GetGeometryN(i) is Nts.Polygon pp && !pp.IsEmpty)
+                                toDraw.Add((pp, b.LandUse));
                     }
                 }
+
+                DrawBuildings(img, modelId.Value, toDraw, tileBounds, cellSize);
             }
 
-            // Call the optimized, batched drawing methods
-            DrawBuildings(img, allBuildingsToDraw, tileBounds);
-            
             return img;
         }
-        
-        // Batched building drawing
-        private static void DrawBuildings(Image<Rgba32> img, List<(Nts.Polygon Poly, LandUseType Use)> buildings, GeoBounds bounds)
+
+        // Batched building drawing with caching
+        private static void DrawBuildings(Image<Rgba32> img, Guid modelId, List<(Nts.Polygon Poly, LandUseType Use)> buildings, GeoBounds bounds, int cellSize)
         {
             var sw = Stopwatch.StartNew();
-            var buildingsByColor = buildings.GroupBy(b => GetBuildingColor(b.Use));
+            var cached = CityModelCache.GetOrAddBuildings(modelId, cellSize, bounds, buildings);
 
             img.Mutate(ctx =>
             {
-                foreach (var group in buildingsByColor)
+                foreach (var kvp in cached.PathsByColor)
                 {
-                    var color = group.Key;
-                    var paths = new PathCollection(group.Select(item =>
-                        new Polygon(new LinearLineSegment(item.Poly.ExteriorRing.Coordinates.Select(c => ToPointF(c.X, c.Y, bounds)).ToArray()))
-                    ));
-                    ctx.Fill(color, paths);
+                    ctx.Fill(kvp.Key, kvp.Value);
                 }
             });
             PerformanceTracker.Record("CityRenderer-BuildingRendering", sw.Elapsed);
@@ -153,6 +153,6 @@ namespace StrategyGame
                 (float)((lon - b.MinLon) / (b.MaxLon - b.MinLon) * MultiResolutionMapManager.TileSizePx),
                 (float)((b.MaxLat - lat) / (b.MaxLat - b.MinLat) * MultiResolutionMapManager.TileSizePx));
         private static Nts.Polygon ToPolygon(GeoBounds b) => new Nts.Polygon(new Nts.LinearRing(new[] { new Nts.Coordinate(b.MinLon, b.MinLat), new Nts.Coordinate(b.MaxLon, b.MinLat), new Nts.Coordinate(b.MaxLon, b.MaxLat), new Nts.Coordinate(b.MinLon, b.MaxLat), new Nts.Coordinate(b.MinLon, b.MinLat) }));
-        private static Rgba32 GetBuildingColor(LandUseType use) => use switch { LandUseType.Commercial => new Rgba32(200, 50, 50, 180), LandUseType.Residential => new Rgba32(50, 50, 200, 180), LandUseType.Industrial => new Rgba32(120, 120, 120, 180), _ => new Rgba32(60, 160, 60, 180) };
+        internal static Rgba32 GetBuildingColor(LandUseType use) => use switch { LandUseType.Commercial => new Rgba32(200, 50, 50, 180), LandUseType.Residential => new Rgba32(50, 50, 200, 180), LandUseType.Industrial => new Rgba32(120, 120, 120, 180), _ => new Rgba32(60, 160, 60, 180) };
     }
 }

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -3,36 +3,18 @@ using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Drawing.Processing;
-using SkiaSharp;
 using System.Linq;
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Threading.Tasks;
 using SixLabors.ImageSharp.Drawing;
-using System.Diagnostics;
-using economy_sim;
 
 namespace StrategyGame
 {
     public static class ProceduralCityRenderer
     {
-        private static readonly bool GpuAvailable;
-
-        static ProceduralCityRenderer()
-        {
-            try
-            {
-                using var context = GRContext.CreateGl();
-                GpuAvailable = context != null;
-            }
-            catch
-            {
-                GpuAvailable = false;
-            }
-        }
-
-        public static Task<Image<Rgba32>> RenderCityTileAsync(GeoBounds tileBounds, int cellSize)
+        // This method is now async to support awaiting the data model.
+        public static async Task<Image<Rgba32>> RenderCityTileAsync(GeoBounds tileBounds, int cellSize)
         {
             var img = new Image<Rgba32>(MultiResolutionMapManager.TileSizePx, MultiResolutionMapManager.TileSizePx, new Rgba32(0, 0, 0, 0));
             var tilePoly = ToPolygon(tileBounds);
@@ -40,26 +22,32 @@ namespace StrategyGame
             var allBuildingsToDraw = new List<(Nts.Polygon Poly, LandUseType Use)>();
             var allRoadsToDraw = new List<LineSegment>();
             var processedModelIds = new HashSet<Guid>();
-
+            
             var relevantUrbanAreas = UrbanAreaManager.Query(tileBounds);
+
+            // This loop now awaits the new async methods, preventing deadlocks.
             foreach (var urban in relevantUrbanAreas)
             {
                 if (!urban.EnvelopeInternal.Intersects(tilePoly.EnvelopeInternal) || !urban.Intersects(tilePoly)) continue;
-                var modelId = RoadNetworkGenerator.GetCityDataModelId(urban);
-                if (!modelId.HasValue || !processedModelIds.Add(modelId.Value)) continue;
 
-                var model = RoadNetworkGenerator.LoadCityDataModel(modelId.Value);
+                // Use the new async GetCityDataModelIdAsync
+                var modelId = await RoadNetworkGenerator.GetCityDataModelIdAsync(urban).ConfigureAwait(false);
+                if (!modelId.HasValue || !processedModelIds.Add(modelId.Value)) continue;
+                
+                // Use the new async LoadCityDataModelAsync
+                var model = await RoadNetworkGenerator.LoadCityDataModelAsync(modelId.Value).ConfigureAwait(false);
                 if (model == null) continue;
 
                 allRoadsToDraw.AddRange(model.RoadNetwork);
-
+                
+                // Process building geometry in parallel
                 var buildingGeoms = model.Buildings
                     .AsParallel()
-                    .Select(b => new { LandUse = b.LandUse, Visible = b.Footprint.Intersection(tilePoly) })
+                    .Select(b => new { b.LandUse, Visible = b.Footprint.Intersection(tilePoly) })
                     .Where(b => b.Visible != null && !b.Visible.IsEmpty)
                     .ToList();
 
-                foreach (var b in buildingGeoms)
+                foreach(var b in buildingGeoms)
                 {
                     if (b.Visible is Nts.Polygon p) lock (allBuildingsToDraw) allBuildingsToDraw.Add((p, b.LandUse));
                     else if (b.Visible is Nts.MultiPolygon mp)
@@ -70,104 +58,53 @@ namespace StrategyGame
                 }
             }
 
+            // Call the optimized, batched drawing methods
             DrawBuildings(img, allBuildingsToDraw, tileBounds);
             DrawRoads(img, allRoadsToDraw, tileBounds);
-
-            return Task.FromResult(img);
+            
+            return img;
         }
-
+        
+        // Batched building drawing
         private static void DrawBuildings(Image<Rgba32> img, List<(Nts.Polygon Poly, LandUseType Use)> buildings, GeoBounds bounds)
         {
             var buildingsByColor = buildings.GroupBy(b => GetBuildingColor(b.Use));
-
+            
             img.Mutate(ctx =>
             {
                 foreach (var group in buildingsByColor)
                 {
                     var color = group.Key;
-                    var paths = new PathCollection(group.Select(item =>
-                        new Polygon(new LinearLineSegment(item.Poly.ExteriorRing.Coordinates.Select(c => ToPointF(c.X, c.Y, bounds)).ToArray()))));
+                    var paths = new PathCollection(group.Select(item => 
+                        new Polygon(new LinearLineSegment(item.Poly.ExteriorRing.Coordinates.Select(c => ToPointF(c.X, c.Y, bounds)).ToArray()))
+                    ));
                     ctx.Fill(color, paths);
                 }
             });
         }
 
+        // Batched road drawing
         private static void DrawRoads(Image<Rgba32> img, IEnumerable<LineSegment> roads, GeoBounds bounds)
         {
             var primaryPathBuilder = new PathBuilder();
             var secondaryPathBuilder = new PathBuilder();
             foreach (var seg in roads)
             {
-                var builder = seg.Type == RoadType.Primary ? primaryPathBuilder : secondaryPathBuilder;
-                builder.AddLine(ToPointF(seg.X1, seg.Y1, bounds), ToPointF(seg.X2, seg.Y2, bounds));
+                var pathBuilder = seg.Type == RoadType.Primary ? primaryPathBuilder : secondaryPathBuilder;
+                pathBuilder.AddLine(ToPointF(seg.X1, seg.Y1, bounds), ToPointF(seg.X2, seg.Y2, bounds));
             }
-
+            
             var primaryPen = Pens.Solid(new Rgba32(180, 180, 180, 200), 2f);
             var secondaryPen = Pens.Solid(new Rgba32(180, 180, 180, 200), 1f);
 
             img.Mutate(ctx => ctx
                 .Draw(secondaryPen, secondaryPathBuilder.Build())
-                .Draw(primaryPen, primaryPathBuilder.Build()));
+                .Draw(primaryPen, primaryPathBuilder.Build())
+            );
         }
 
-        private static SixLabors.ImageSharp.PointF ToPointF(double lon, double lat, GeoBounds b)
-        {
-            float x = (float)((lon - b.MinLon) / (b.MaxLon - b.MinLon) * MultiResolutionMapManager.TileSizePx);
-            float y = (float)((b.MaxLat - lat) / (b.MaxLat - b.MinLat) * MultiResolutionMapManager.TileSizePx);
-            return new SixLabors.ImageSharp.PointF(x, y);
-        }
-
-        private static SKPoint ToSKPoint(double lon, double lat, GeoBounds b)
-        {
-            float x = (float)((lon - b.MinLon) / (b.MaxLon - b.MinLon) * MultiResolutionMapManager.TileSizePx);
-            float y = (float)((b.MaxLat - lat) / (b.MaxLat - b.MinLat) * MultiResolutionMapManager.TileSizePx);
-            return new SKPoint(x, y);
-        }
-
-        private static SKColor ToSkColor(Rgba32 c) => new SKColor(c.R, c.G, c.B, c.A);
-
-        private static void AppendPolygon(SKPath path, Nts.Polygon poly, GeoBounds bounds)
-        {
-            var coords = poly.ExteriorRing.Coordinates;
-            if (coords.Length == 0) return;
-            path.MoveTo(ToSKPoint(coords[0].X, coords[0].Y, bounds));
-            for (int i = 1; i < coords.Length; i++)
-            {
-                path.LineTo(ToSKPoint(coords[i].X, coords[i].Y, bounds));
-            }
-            path.Close();
-        }
-
-        private static Rgba32 GetBuildingColor(LandUseType use)
-        {
-            return use switch
-            {
-                LandUseType.Commercial => new Rgba32(200, 50, 50, 180),
-                LandUseType.Residential => new Rgba32(50, 50, 200, 180),
-                LandUseType.Industrial => new Rgba32(120, 120, 120, 180),
-                LandUseType.Park => new Rgba32(60, 160, 60, 180),
-                _ => new Rgba32(100, 100, 100, 180)
-            };
-        }
-
-        private static Nts.Polygon ToPolygon(GeoBounds b)
-        {
-            var sw = Stopwatch.StartNew();
-            if (b.MinLon >= b.MaxLon || b.MinLat >= b.MaxLat)
-                throw new ArgumentException("Invalid GeoBounds: Min must be less than Max.");
-
-            var gf = Nts.GeometryFactory.Default;
-            var result = gf.CreatePolygon(new[]
-            {
-                new Nts.Coordinate(b.MinLon, b.MinLat),
-                new Nts.Coordinate(b.MaxLon, b.MinLat),
-                new Nts.Coordinate(b.MaxLon, b.MaxLat),
-                new Nts.Coordinate(b.MinLon, b.MaxLat),
-                new Nts.Coordinate(b.MinLon, b.MinLat)
-            });
-            PerformanceTracker.Record("ToPolygon", sw.Elapsed);
-            return result;
-        }
-
+        private static PointF ToPointF(double lon, double lat, GeoBounds b) => new PointF((float)((lon - b.MinLon) / (b.MaxLon - b.MinLon) * MultiResolutionMapManager.TileSizePx), (float)((b.MaxLat - lat) / (b.MaxLat - b.MinLat) * MultiResolutionMapManager.TileSizePx));
+        private static Nts.Polygon ToPolygon(GeoBounds b) => new Nts.Polygon(new Nts.LinearRing(new[] { new Nts.Coordinate(b.MinLon, b.MinLat), new Nts.Coordinate(b.MaxLon, b.MinLat), new Nts.Coordinate(b.MaxLon, b.MaxLat), new Nts.Coordinate(b.MinLon, b.MaxLat), new Nts.Coordinate(b.MinLon, b.MinLat) }));
+        private static Rgba32 GetBuildingColor(LandUseType use) => use switch { LandUseType.Commercial => new Rgba32(200, 50, 50, 180), LandUseType.Residential => new Rgba32(50, 50, 200, 180), LandUseType.Industrial => new Rgba32(120, 120, 120, 180), _ => new Rgba32(60, 160, 60, 180) };
     }
 }

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -3,12 +3,14 @@ using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Drawing.Processing;
+using NetTopologySuite.Simplify;
 using System.Linq;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using SixLabors.ImageSharp.Drawing;
+using economy_sim;
 
 namespace StrategyGame
 {
@@ -61,7 +63,7 @@ namespace StrategyGame
 
             // Call the optimized, batched drawing methods
             DrawBuildings(img, allBuildingsToDraw, tileBounds);
-            DrawRoads(img, allRoadsToDraw, tileBounds);
+            DrawRoads(img, allRoadsToDraw, tileBounds, cellSize);
             
             return img;
         }
@@ -87,9 +89,50 @@ namespace StrategyGame
         }
 
         // Batched road drawing
-        private static void DrawRoads(Image<Rgba32> img, IEnumerable<LineSegment> roads, GeoBounds bounds)
+        private static IEnumerable<LineSegment> SimplifyRoads(IEnumerable<LineSegment> roads, GeoBounds bounds)
+        {
+            double tolerance = (bounds.MaxLon - bounds.MinLon) / MultiResolutionMapManager.TileSizePx * 2.0;
+
+            var gf = Nts.GeometryFactory.Default;
+            foreach (var group in roads.GroupBy(r => r.Type))
+            {
+                var lineStrings = group.Select(s =>
+                    gf.CreateLineString(new[]
+                    {
+                        new Nts.Coordinate(s.X1, s.Y1),
+                        new Nts.Coordinate(s.X2, s.Y2)
+                    })).ToArray();
+
+                if (lineStrings.Length == 0) continue;
+
+                var multi = gf.CreateMultiLineString(lineStrings);
+                var simplified = NetTopologySuite.Simplify.DouglasPeuckerSimplifier.Simplify(multi, tolerance) as Nts.MultiLineString;
+                if (simplified == null) continue;
+
+                for (int i = 0; i < simplified.NumGeometries; i++)
+                {
+                    if (simplified.GetGeometryN(i) is Nts.LineString ln)
+                    {
+                        for (int j = 0; j < ln.NumPoints - 1; j++)
+                        {
+                            var c1 = ln.GetCoordinateN(j);
+                            var c2 = ln.GetCoordinateN(j + 1);
+                            yield return new LineSegment(c1.X, c1.Y, c2.X, c2.Y, group.Key);
+                        }
+                    }
+                }
+            }
+        }
+
+        private static void DrawRoads(Image<Rgba32> img, IEnumerable<LineSegment> roads, GeoBounds bounds, int cellSize)
         {
             var sw = Stopwatch.StartNew();
+            if (cellSize <= 40)
+            {
+                roads = roads.Where(r => r.Type == RoadType.Primary);
+            }
+
+            roads = SimplifyRoads(roads, bounds).ToList();
             var primaryPathBuilder = new PathBuilder();
             var secondaryPathBuilder = new PathBuilder();
             foreach (var seg in roads)
@@ -98,8 +141,8 @@ namespace StrategyGame
                 pathBuilder.AddLine(ToPointF(seg.X1, seg.Y1, bounds), ToPointF(seg.X2, seg.Y2, bounds));
             }
 
-            var primaryPen = Pens.Solid(new Rgba32(180, 180, 180, 200), 2f);
-            var secondaryPen = Pens.Solid(new Rgba32(180, 180, 180, 200), 1f);
+            var primaryPen = SixLabors.ImageSharp.Drawing.Processing.Pens.Solid(new Rgba32(180, 180, 180, 200), 2f);
+            var secondaryPen = SixLabors.ImageSharp.Drawing.Processing.Pens.Solid(new Rgba32(180, 180, 180, 200), 1f);
 
             img.Mutate(ctx => ctx
                 .Draw(secondaryPen, secondaryPathBuilder.Build())
@@ -108,7 +151,10 @@ namespace StrategyGame
             PerformanceTracker.Record("CityRenderer-RoadDrawing", sw.Elapsed);
         }
 
-        private static PointF ToPointF(double lon, double lat, GeoBounds b) => new PointF((float)((lon - b.MinLon) / (b.MaxLon - b.MinLon) * MultiResolutionMapManager.TileSizePx), (float)((b.MaxLat - lat) / (b.MaxLat - b.MinLat) * MultiResolutionMapManager.TileSizePx));
+        private static SixLabors.ImageSharp.PointF ToPointF(double lon, double lat, GeoBounds b) =>
+            new SixLabors.ImageSharp.PointF(
+                (float)((lon - b.MinLon) / (b.MaxLon - b.MinLon) * MultiResolutionMapManager.TileSizePx),
+                (float)((b.MaxLat - lat) / (b.MaxLat - b.MinLat) * MultiResolutionMapManager.TileSizePx));
         private static Nts.Polygon ToPolygon(GeoBounds b) => new Nts.Polygon(new Nts.LinearRing(new[] { new Nts.Coordinate(b.MinLon, b.MinLat), new Nts.Coordinate(b.MaxLon, b.MinLat), new Nts.Coordinate(b.MaxLon, b.MaxLat), new Nts.Coordinate(b.MinLon, b.MaxLat), new Nts.Coordinate(b.MinLon, b.MinLat) }));
         private static Rgba32 GetBuildingColor(LandUseType use) => use switch { LandUseType.Commercial => new Rgba32(200, 50, 50, 180), LandUseType.Residential => new Rgba32(50, 50, 200, 180), LandUseType.Industrial => new Rgba32(120, 120, 120, 180), _ => new Rgba32(60, 160, 60, 180) };
     }

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -4,9 +4,11 @@ using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Drawing.Processing;
 using NetTopologySuite.Simplify;
+using NetTopologySuite.Geometries.Prepared;
 using System.Linq;
 using System;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using SixLabors.ImageSharp.Drawing;
 using economy_sim;
@@ -16,6 +18,7 @@ namespace StrategyGame
     public static class ProceduralCityRenderer
     {
         // Rendering should never block on disk. Models must be supplied via cache.
+        private static readonly ConcurrentDictionary<(Guid modelId, int cellSize), List<LineSegment>> _simplifiedRoadCache = new();
         public static Image<Rgba32> RenderCityTile(
             GeoBounds tileBounds,
             int cellSize,
@@ -26,13 +29,16 @@ namespace StrategyGame
             var img = new Image<Rgba32>(MultiResolutionMapManager.TileSizePx, MultiResolutionMapManager.TileSizePx, new Rgba32(0, 0, 0, 0));
             var tilePoly = ToPolygon(tileBounds);
 
+            var preparedFactory = new PreparedGeometryFactory();
+            var preparedTilePoly = preparedFactory.Create(tilePoly);
+
             var processedModelIds = new HashSet<Guid>();
 
             var relevantUrbanAreas = UrbanAreaManager.Query(tileBounds);
 
             foreach (var urban in relevantUrbanAreas)
             {
-                if (!urban.EnvelopeInternal.Intersects(tilePoly.EnvelopeInternal) || !urban.Intersects(tilePoly))
+                if (!preparedTilePoly.Intersects(urban))
                     continue;
 
                 var modelId = RoadNetworkGenerator.GetCityDataModelIdAsync(urban).Result;
@@ -180,19 +186,30 @@ namespace StrategyGame
         private static void DrawRoads(Image<Rgba32> img, Guid modelId, IEnumerable<LineSegment> roads, GeoBounds bounds, int cellSize)
         {
             var sw = Stopwatch.StartNew();
-            if (cellSize <= 40)
+
+            var simplifiedRoads = _simplifiedRoadCache.GetOrAdd((modelId, cellSize), _ =>
             {
-                roads = roads.Where(r => r.Type == RoadType.Primary);
+                var filteredRoads = cellSize <= 40
+                    ? roads.Where(r => r.Type == RoadType.Primary).ToList()
+                    : roads.ToList();
+
+                return SimplifyRoads(filteredRoads, bounds).ToList();
+            });
+
+            if (!simplifiedRoads.Any())
+            {
+                PerformanceTracker.Record("CityRenderer-RoadDrawing", sw.Elapsed);
+                return;
             }
 
-            var cached = CityModelCache.GetOrAddRoads(modelId, cellSize, roads, bounds);
+            var cachedPaths = CityModelCache.GetOrAddRoads(modelId, cellSize, simplifiedRoads, bounds);
 
             var primaryPen = SixLabors.ImageSharp.Drawing.Processing.Pens.Solid(new Rgba32(180, 180, 180, 200), 2f);
             var secondaryPen = SixLabors.ImageSharp.Drawing.Processing.Pens.Solid(new Rgba32(180, 180, 180, 200), 1f);
 
             img.Mutate(ctx => ctx
-                .Draw(secondaryPen, cached.SecondaryPath)
-                .Draw(primaryPen, cached.PrimaryPath)
+                .Draw(secondaryPen, cachedPaths.SecondaryPath)
+                .Draw(primaryPen, cachedPaths.PrimaryPath)
             );
             PerformanceTracker.Record("CityRenderer-RoadDrawing", sw.Elapsed);
         }

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -12,6 +12,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using SixLabors.ImageSharp.Drawing;
+using SkiaSharp;
 using economy_sim;
 
 namespace StrategyGame
@@ -20,6 +21,30 @@ namespace StrategyGame
     {
         // Rendering should never block on disk. Models must be supplied via cache.
         private static readonly ConcurrentDictionary<(Guid modelId, int cellSize), List<LineSegment>> _simplifiedRoadCache = new();
+
+        // Pre-created brushes and pens for drawing roads. These objects are immutable
+        // which makes them safe for use across threads during tile rendering.
+        private static readonly IBrush PrimaryRoadBrush = new SolidBrush<Rgba32>(new Rgba32(180, 180, 180, 200));
+        private static readonly IBrush SecondaryRoadBrush = new SolidBrush<Rgba32>(new Rgba32(180, 180, 180, 200));
+
+        private static readonly IPen PrimaryRoadPen = Pens.Solid(PrimaryRoadBrush, 2f);
+        private static readonly IPen SecondaryRoadPen = Pens.Solid(SecondaryRoadBrush, 1f);
+
+        private static readonly SKPaint PrimaryRoadPaint = new SKPaint
+        {
+            Color = new SKColor(180, 180, 180, 200),
+            StrokeWidth = 2f,
+            Style = SKPaintStyle.Stroke,
+            IsAntialias = true
+        };
+
+        private static readonly SKPaint SecondaryRoadPaint = new SKPaint
+        {
+            Color = new SKColor(180, 180, 180, 200),
+            StrokeWidth = 1f,
+            Style = SKPaintStyle.Stroke,
+            IsAntialias = true
+        };
         public static async Task<Image<Rgba32>> RenderCityTileAsync(
             GeoBounds tileBounds,
             int cellSize,
@@ -210,12 +235,10 @@ namespace StrategyGame
 
             var cachedPaths = CityModelCache.GetOrAddRoads(modelId, cellSize, simplifiedRoads, bounds);
 
-            var primaryPen = SixLabors.ImageSharp.Drawing.Processing.Pens.Solid(new Rgba32(180, 180, 180, 200), 2f);
-            var secondaryPen = SixLabors.ImageSharp.Drawing.Processing.Pens.Solid(new Rgba32(180, 180, 180, 200), 1f);
-
+            // Use shared pen instances to avoid allocations during rendering
             img.Mutate(ctx => ctx
-                .Draw(secondaryPen, cachedPaths.SecondaryPath)
-                .Draw(primaryPen, cachedPaths.PrimaryPath)
+                .Draw(SecondaryRoadPen, cachedPaths.SecondaryPath)
+                .Draw(PrimaryRoadPen, cachedPaths.PrimaryPath)
             );
             PerformanceTracker.Record("CityRenderer-RoadDrawing", sw.Elapsed);
         }

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Threading.Tasks;
 using SixLabors.ImageSharp.Drawing;
 using economy_sim;
 
@@ -19,7 +20,7 @@ namespace StrategyGame
     {
         // Rendering should never block on disk. Models must be supplied via cache.
         private static readonly ConcurrentDictionary<(Guid modelId, int cellSize), List<LineSegment>> _simplifiedRoadCache = new();
-        public static Image<Rgba32> RenderCityTile(
+        public static async Task<Image<Rgba32>> RenderCityTileAsync(
             GeoBounds tileBounds,
             int cellSize,
             IReadOnlyDictionary<Guid, CityDataModel> cityModelCache,
@@ -36,12 +37,23 @@ namespace StrategyGame
 
             var relevantUrbanAreas = UrbanAreaManager.Query(tileBounds);
 
+            var modelIdTasks = new List<Task<(Guid? Id, Nts.Polygon Urban)>>();
             foreach (var urban in relevantUrbanAreas)
             {
                 if (!preparedTilePoly.Intersects(urban))
                     continue;
 
-                var modelId = RoadNetworkGenerator.GetCityDataModelIdAsync(urban).Result;
+                modelIdTasks.Add(async () =>
+                {
+                    var id = await RoadNetworkGenerator.GetCityDataModelIdAsync(urban).ConfigureAwait(false);
+                    return (id, urban);
+                }());
+            }
+
+            var results = await Task.WhenAll(modelIdTasks).ConfigureAwait(false);
+
+            foreach (var (modelId, urban) in results)
+            {
                 if (!modelId.HasValue || !processedModelIds.Add(modelId.Value))
                     continue;
 
@@ -52,8 +64,7 @@ namespace StrategyGame
                 }
 
                 DrawRoads(img, modelId.Value, model.RoadNetwork, tileBounds, cellSize);
-                
-                // Query visible buildings using the model's spatial index
+
                 var tileEnv = tilePoly.EnvelopeInternal;
                 var candidates = (model.BuildingIndex?.Query(tileEnv).Cast<Building>() ?? model.Buildings);
                 var toDraw = new List<(Nts.Polygon, LandUseType, Building)>();
@@ -63,7 +74,6 @@ namespace StrategyGame
                     if (!env.Intersects(tileEnv)) continue;
                     var baseGeom = b.SimplifiedFootprints.TryGetValue(0, out var g) ? g : b.Footprint;
 
-                    // Skip expensive clipping; ImageSharp will clip while filling
                     if (baseGeom is Nts.Polygon p && !p.IsEmpty)
                     {
                         toDraw.Add((p, b.LandUse, b));

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -57,17 +57,19 @@ namespace StrategyGame
                     var env = b.Footprint.EnvelopeInternal;
                     if (!env.Intersects(tileEnv)) continue;
                     var baseGeom = b.SimplifiedFootprints.TryGetValue(0, out var g) ? g : b.Footprint;
-                    Nts.Geometry clipped = tileEnv.Contains(env)
-                        ? baseGeom
-                        : baseGeom.Intersection(tilePoly);
 
-                    if (clipped is Nts.Polygon p && !p.IsEmpty)
+                    // Skip expensive clipping; ImageSharp will clip while filling
+                    if (baseGeom is Nts.Polygon p && !p.IsEmpty)
+                    {
                         toDraw.Add((p, b.LandUse, b));
-                    else if (clipped is Nts.MultiPolygon mp)
+                    }
+                    else if (baseGeom is Nts.MultiPolygon mp)
                     {
                         for (int i = 0; i < mp.NumGeometries; i++)
+                        {
                             if (mp.GetGeometryN(i) is Nts.Polygon pp && !pp.IsEmpty)
                                 toDraw.Add((pp, b.LandUse, b));
+                        }
                     }
                 }
 

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -7,6 +7,7 @@ using NetTopologySuite.Simplify;
 using System.Linq;
 using System;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using SixLabors.ImageSharp.Drawing;
@@ -16,6 +17,7 @@ namespace StrategyGame
 {
     public static class ProceduralCityRenderer
     {
+        private static readonly ConcurrentDictionary<Guid, CityDataModel> _modelCache = new();
         // This method is now async to support awaiting the data model.
         public static async Task<Image<Rgba32>> RenderCityTileAsync(GeoBounds tileBounds, int cellSize)
         {
@@ -23,7 +25,6 @@ namespace StrategyGame
             var tilePoly = ToPolygon(tileBounds);
 
             var allBuildingsToDraw = new List<(Nts.Polygon Poly, LandUseType Use)>();
-            var allRoadsToDraw = new List<LineSegment>();
             var processedModelIds = new HashSet<Guid>();
             
             var relevantUrbanAreas = UrbanAreaManager.Query(tileBounds);
@@ -31,17 +32,21 @@ namespace StrategyGame
             // This loop now awaits the new async methods, preventing deadlocks.
             foreach (var urban in relevantUrbanAreas)
             {
-                if (!urban.EnvelopeInternal.Intersects(tilePoly.EnvelopeInternal) || !urban.Intersects(tilePoly)) continue;
+                if (!urban.EnvelopeInternal.Intersects(tilePoly.EnvelopeInternal) || !urban.Intersects(tilePoly))
+                    continue;
 
-                // Use the new async GetCityDataModelIdAsync
                 var modelId = await RoadNetworkGenerator.GetCityDataModelIdAsync(urban).ConfigureAwait(false);
-                if (!modelId.HasValue || !processedModelIds.Add(modelId.Value)) continue;
-                
-                // Use the new async LoadCityDataModelAsync
-                var model = await RoadNetworkGenerator.LoadCityDataModelAsync(modelId.Value).ConfigureAwait(false);
-                if (model == null) continue;
+                if (!modelId.HasValue || !processedModelIds.Add(modelId.Value))
+                    continue;
 
-                allRoadsToDraw.AddRange(model.RoadNetwork);
+                if (!_modelCache.TryGetValue(modelId.Value, out var model))
+                {
+                    model = await RoadNetworkGenerator.LoadCityDataModelAsync(modelId.Value).ConfigureAwait(false);
+                    if (model == null) continue;
+                    _modelCache[modelId.Value] = model;
+                }
+
+                DrawRoads(img, modelId.Value, model.RoadNetwork, tileBounds, cellSize);
                 
                 // Process building geometry in parallel
                 var buildingGeoms = model.Buildings
@@ -63,7 +68,6 @@ namespace StrategyGame
 
             // Call the optimized, batched drawing methods
             DrawBuildings(img, allBuildingsToDraw, tileBounds);
-            DrawRoads(img, allRoadsToDraw, tileBounds, cellSize);
             
             return img;
         }
@@ -89,7 +93,7 @@ namespace StrategyGame
         }
 
         // Batched road drawing
-        private static IEnumerable<LineSegment> SimplifyRoads(IEnumerable<LineSegment> roads, GeoBounds bounds)
+        internal static IEnumerable<LineSegment> SimplifyRoads(IEnumerable<LineSegment> roads, GeoBounds bounds)
         {
             double tolerance = (bounds.MaxLon - bounds.MinLon) / MultiResolutionMapManager.TileSizePx * 2.0;
 
@@ -124,7 +128,7 @@ namespace StrategyGame
             }
         }
 
-        private static void DrawRoads(Image<Rgba32> img, IEnumerable<LineSegment> roads, GeoBounds bounds, int cellSize)
+        private static void DrawRoads(Image<Rgba32> img, Guid modelId, IEnumerable<LineSegment> roads, GeoBounds bounds, int cellSize)
         {
             var sw = Stopwatch.StartNew();
             if (cellSize <= 40)
@@ -132,26 +136,19 @@ namespace StrategyGame
                 roads = roads.Where(r => r.Type == RoadType.Primary);
             }
 
-            roads = SimplifyRoads(roads, bounds).ToList();
-            var primaryPathBuilder = new PathBuilder();
-            var secondaryPathBuilder = new PathBuilder();
-            foreach (var seg in roads)
-            {
-                var pathBuilder = seg.Type == RoadType.Primary ? primaryPathBuilder : secondaryPathBuilder;
-                pathBuilder.AddLine(ToPointF(seg.X1, seg.Y1, bounds), ToPointF(seg.X2, seg.Y2, bounds));
-            }
+            var cached = CityModelCache.GetOrAddRoads(modelId, cellSize, roads, bounds);
 
             var primaryPen = SixLabors.ImageSharp.Drawing.Processing.Pens.Solid(new Rgba32(180, 180, 180, 200), 2f);
             var secondaryPen = SixLabors.ImageSharp.Drawing.Processing.Pens.Solid(new Rgba32(180, 180, 180, 200), 1f);
 
             img.Mutate(ctx => ctx
-                .Draw(secondaryPen, secondaryPathBuilder.Build())
-                .Draw(primaryPen, primaryPathBuilder.Build())
+                .Draw(secondaryPen, cached.SecondaryPath)
+                .Draw(primaryPen, cached.PrimaryPath)
             );
             PerformanceTracker.Record("CityRenderer-RoadDrawing", sw.Elapsed);
         }
 
-        private static SixLabors.ImageSharp.PointF ToPointF(double lon, double lat, GeoBounds b) =>
+        internal static SixLabors.ImageSharp.PointF ToPointF(double lon, double lat, GeoBounds b) =>
             new SixLabors.ImageSharp.PointF(
                 (float)((lon - b.MinLon) / (b.MaxLon - b.MinLon) * MultiResolutionMapManager.TileSizePx),
                 (float)((b.MaxLat - lat) / (b.MaxLat - b.MinLat) * MultiResolutionMapManager.TileSizePx));

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -36,24 +36,20 @@ namespace StrategyGame
             var processedModelIds = new HashSet<Guid>();
 
             var relevantUrbanAreas = UrbanAreaManager.Query(tileBounds);
+            var intersectingUrbanAreas = relevantUrbanAreas
+                .Where(preparedTilePoly.Intersects)
+                .ToList();
 
-            var modelIdTasks = new List<Task<(Guid? Id, Nts.Polygon Urban)>>();
-            foreach (var urban in relevantUrbanAreas)
+            var results = await Task
+                .WhenAll(intersectingUrbanAreas
+                    .Select(RoadNetworkGenerator.GetCityDataModelIdAsync))
+                .ConfigureAwait(false);
+
+            for (int i = 0; i < results.Length; i++)
             {
-                if (!preparedTilePoly.Intersects(urban))
-                    continue;
+                var modelId = results[i];
+                var urban = intersectingUrbanAreas[i];
 
-                modelIdTasks.Add(async () =>
-                {
-                    var id = await RoadNetworkGenerator.GetCityDataModelIdAsync(urban).ConfigureAwait(false);
-                    return (id, urban);
-                }());
-            }
-
-            var results = await Task.WhenAll(modelIdTasks).ConfigureAwait(false);
-
-            foreach (var (modelId, urban) in results)
-            {
                 if (!modelId.HasValue || !processedModelIds.Add(modelId.Value))
                     continue;
 

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -51,23 +51,23 @@ namespace StrategyGame
                 // Query visible buildings using the model's spatial index
                 var tileEnv = tilePoly.EnvelopeInternal;
                 var candidates = (model.BuildingIndex?.Query(tileEnv).Cast<Building>() ?? model.Buildings);
-                var toDraw = new List<(Nts.Polygon, LandUseType)>();
+                var toDraw = new List<(Nts.Polygon, LandUseType, Building)>();
                 foreach (var b in candidates)
                 {
                     var env = b.Footprint.EnvelopeInternal;
                     if (!env.Intersects(tileEnv)) continue;
-                    var baseGeom = b.SimplifiedFootprint ?? b.Footprint;
+                    var baseGeom = b.SimplifiedFootprints.TryGetValue(0, out var g) ? g : b.Footprint;
                     Nts.Geometry clipped = tileEnv.Contains(env)
                         ? baseGeom
                         : baseGeom.Intersection(tilePoly);
 
                     if (clipped is Nts.Polygon p && !p.IsEmpty)
-                        toDraw.Add((p, b.LandUse));
+                        toDraw.Add((p, b.LandUse, b));
                     else if (clipped is Nts.MultiPolygon mp)
                     {
                         for (int i = 0; i < mp.NumGeometries; i++)
                             if (mp.GetGeometryN(i) is Nts.Polygon pp && !pp.IsEmpty)
-                                toDraw.Add((pp, b.LandUse));
+                                toDraw.Add((pp, b.LandUse, b));
                     }
                 }
 
@@ -79,7 +79,7 @@ namespace StrategyGame
         }
 
         // Batched building drawing with caching and dynamic LOD
-        private static void DrawBuildings(Image<Rgba32> img, Guid modelId, List<(Nts.Polygon Poly, LandUseType Use)> buildings, GeoBounds bounds, int cellSize)
+        private static void DrawBuildings(Image<Rgba32> img, Guid modelId, List<(Nts.Polygon Poly, LandUseType Use, Building Bld)> buildings, GeoBounds bounds, int cellSize)
         {
             var sw = Stopwatch.StartNew();
 
@@ -107,10 +107,13 @@ namespace StrategyGame
                          * (cellSize <= 80 ? 2.5 : 1.0);
 
             var reduced = new List<(Nts.Polygon Poly, LandUseType Use)>();
-            foreach (var (poly, use) in buildings)
+            foreach (var (poly, use, bld) in buildings)
             {
-                var simplified = DouglasPeuckerSimplifier.Simplify(poly, tol);
-                if (simplified == null || simplified.IsEmpty) continue;
+                var simplified = bld.SimplifiedFootprints.GetOrAdd(cellSize, _ =>
+                {
+                    var simplifiedGeom = DouglasPeuckerSimplifier.Simplify(poly, tol);
+                    return (simplifiedGeom == null || simplifiedGeom.IsEmpty) ? poly : simplifiedGeom;
+                });
 
                 if (simplified is Nts.Polygon p)
                 {

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -6,6 +6,7 @@ using SixLabors.ImageSharp.Drawing.Processing;
 using System.Linq;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using SixLabors.ImageSharp.Drawing;
 
@@ -68,24 +69,27 @@ namespace StrategyGame
         // Batched building drawing
         private static void DrawBuildings(Image<Rgba32> img, List<(Nts.Polygon Poly, LandUseType Use)> buildings, GeoBounds bounds)
         {
+            var sw = Stopwatch.StartNew();
             var buildingsByColor = buildings.GroupBy(b => GetBuildingColor(b.Use));
-            
+
             img.Mutate(ctx =>
             {
                 foreach (var group in buildingsByColor)
                 {
                     var color = group.Key;
-                    var paths = new PathCollection(group.Select(item => 
+                    var paths = new PathCollection(group.Select(item =>
                         new Polygon(new LinearLineSegment(item.Poly.ExteriorRing.Coordinates.Select(c => ToPointF(c.X, c.Y, bounds)).ToArray()))
                     ));
                     ctx.Fill(color, paths);
                 }
             });
+            PerformanceTracker.Record("CityRenderer-BuildingRendering", sw.Elapsed);
         }
 
         // Batched road drawing
         private static void DrawRoads(Image<Rgba32> img, IEnumerable<LineSegment> roads, GeoBounds bounds)
         {
+            var sw = Stopwatch.StartNew();
             var primaryPathBuilder = new PathBuilder();
             var secondaryPathBuilder = new PathBuilder();
             foreach (var seg in roads)
@@ -93,7 +97,7 @@ namespace StrategyGame
                 var pathBuilder = seg.Type == RoadType.Primary ? primaryPathBuilder : secondaryPathBuilder;
                 pathBuilder.AddLine(ToPointF(seg.X1, seg.Y1, bounds), ToPointF(seg.X2, seg.Y2, bounds));
             }
-            
+
             var primaryPen = Pens.Solid(new Rgba32(180, 180, 180, 200), 2f);
             var secondaryPen = Pens.Solid(new Rgba32(180, 180, 180, 200), 1f);
 
@@ -101,6 +105,7 @@ namespace StrategyGame
                 .Draw(secondaryPen, secondaryPathBuilder.Build())
                 .Draw(primaryPen, primaryPathBuilder.Build())
             );
+            PerformanceTracker.Record("CityRenderer-RoadDrawing", sw.Elapsed);
         }
 
         private static PointF ToPointF(double lon, double lat, GeoBounds b) => new PointF((float)((lon - b.MinLon) / (b.MaxLon - b.MinLon) * MultiResolutionMapManager.TileSizePx), (float)((b.MaxLat - lat) / (b.MaxLat - b.MinLat) * MultiResolutionMapManager.TileSizePx));

--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using System.Threading;
 using NetTopologySuite.IO;
 using NetTopologySuite.Index.Quadtree;
+using System.Windows.Forms;
 
 namespace StrategyGame
 {
@@ -259,7 +260,12 @@ namespace StrategyGame
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[Error] Failed to serialize CityDataModel: {ex.Message}");
+                string errorMessage = $"Failed to save city model file for hash {hash}.\n\n" +
+                                      $"Error: {ex.GetType().Name}\n\n" +
+                                      $"Message: {ex.Message}\n\n" +
+                                      $"Stack Trace:\n{ex.StackTrace}";
+                MessageBox.Show(errorMessage, "Critical Save Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                Console.WriteLine($"[CRITICAL ERROR] Failed to serialize CityDataModel: {errorMessage}");
             }
 
             modelCache[hash] = result;

--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -190,10 +190,13 @@ namespace StrategyGame
                 }
             }
 
+            // --- Start of Corrected Logic ---
+
+            // 1. Assign urbanArea immediately upon creation.
             var result = new CityDataModel
             {
                 Id = Guid.NewGuid(),
-                UrbanArea = urbanArea // Immediately assign the urbanArea to the model
+                UrbanArea = urbanArea
             };
             var roadGeometries = GetOrGenerateFor(urbanArea, cellSize);
 
@@ -202,8 +205,11 @@ namespace StrategyGame
                     new LineSegment(s.X, s.Y, e.X, e.Y, tuple.Type)))
                 .ToList();
 
-            // This single call handles block and parcel generation using the urban area boundary.
+            // 2. Delegate ALL block and parcel generation to the robust ParcelGenerator.
+            //    This single line replaces the previous faulty logic.
             result.Parcels = ParcelGenerator.GenerateParcels(result);
+            
+            // --- End of Corrected Logic ---
             LandUseSimulator.Run(result);
             result.Buildings = BuildingGenerator.GenerateBuildings(result);
             BuildingRefiner.RefineBuildings(result);

--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -1,4 +1,5 @@
-﻿using Nts = NetTopologySuite.Geometries;
+using Nts = NetTopologySuite.Geometries;
+using NetTopologySuite.Geometries;
 using NetTopologySuite.Geometries.Prepared;
 using NetTopologySuite.Operation.Union;
 using NetTopologySuite.Operation.Polygonize;
@@ -20,6 +21,12 @@ namespace StrategyGame
         private static readonly ConcurrentDictionary<string, CityDataModel> modelCache = new();
 
         public static CityGenerationData? Data { get; set; }
+
+        private const double Epsilon = 1e-9;
+
+        private static bool IsBad(Coordinate c) =>
+            double.IsNaN(c.X) || double.IsNaN(c.Y) ||
+            double.IsInfinity(c.X) || double.IsInfinity(c.Y);
 
 
         private static void SaveModelBinary(string path, CityDataModel model)
@@ -286,10 +293,12 @@ namespace StrategyGame
                 iterations++;
                 var (origin, angle) = queue.Dequeue();
 
-                var endPoint = new Nts.Coordinate(
+                var endPoint = new Coordinate(
                     origin.X + Math.Cos(angle) * roadSegmentLength,
                     origin.Y + Math.Sin(angle) * roadSegmentLength
                 );
+                if (IsBad(endPoint) || origin.Distance(endPoint) < Epsilon)
+                    continue;
                 // Envelope for quadtree lookup
                 var proposedEnv = new Nts.Envelope(origin, endPoint);
                 // Global Constraint: Must be within the urban area polygon
@@ -361,17 +370,22 @@ namespace StrategyGame
         private static List<Nts.Polygon> PolygonizeRoadNetwork(List<LineSegment> roads)
         {
             var gf = Nts.GeometryFactory.Default;
-            var lineStrings = roads.Select(seg =>
-                gf.CreateLineString(new[]
+            var validLineStrings = roads
+                .Where(s =>
+                    !IsBad(new Coordinate(s.X1, s.Y1)) &&
+                    !IsBad(new Coordinate(s.X2, s.Y2)) &&
+                    Math.Abs(s.X1 - s.X2) + Math.Abs(s.Y1 - s.Y2) > Epsilon)
+                .Select(s => gf.CreateLineString(new[]
                 {
-                    new Nts.Coordinate(seg.X1, seg.Y1),
-                    new Nts.Coordinate(seg.X2, seg.Y2)
-                })).ToArray();
+                    new Coordinate(s.X1, s.Y1),
+                    new Coordinate(s.X2, s.Y2)
+                }))
+                .ToArray();
 
-            if (lineStrings.Length == 0)
+            if (validLineStrings.Length == 0)
                 return new List<Nts.Polygon>();
 
-            var nodedLines = UnaryUnionOp.Union(lineStrings);
+            var nodedLines = CascadedPolygonUnion.Union(validLineStrings);
             var polygonizer = new Polygonizer();
             polygonizer.Add(nodedLines);
             var rawPolys = polygonizer.GetPolygons();

--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -21,8 +21,7 @@ namespace StrategyGame
     {
         private static readonly ConcurrentDictionary<string, List<(Nts.LineString Line, RoadType Type)>> networkCache = new();
         private static readonly ConcurrentDictionary<string, CityDataModel> modelCache = new();
-        private static readonly object _fileLockDictLock = new();
-        private static readonly Dictionary<string, SemaphoreSlim> _fileLocks = new();
+        private static readonly ConcurrentDictionary<string, SemaphoreSlim> _fileLocks = new();
 
         public static CityGenerationData? Data { get; set; }
 
@@ -34,22 +33,14 @@ namespace StrategyGame
 
         private static SemaphoreSlim GetFileLock(string path)
         {
-            lock (_fileLockDictLock)
-            {
-                if (!_fileLocks.TryGetValue(path, out var sem))
-                {
-                    sem = new SemaphoreSlim(1, 1);
-                    _fileLocks[path] = sem;
-                }
-                return sem;
-            }
+            return _fileLocks.GetOrAdd(path, p => new SemaphoreSlim(1, 1));
         }
 
 
         private static async Task SaveModelBinaryAsync(string path, CityDataModel model)
         {
             var fileLock = GetFileLock(path);
-            await fileLock.WaitAsync();
+            await fileLock.WaitAsync().ConfigureAwait(false);
             try
             {
                 var wkbWriter = new WKBWriter();
@@ -120,11 +111,11 @@ namespace StrategyGame
         private static async Task<CityDataModel> LoadModelBinaryAsync(string path)
         {
             var fileLock = GetFileLock(path);
-            await fileLock.WaitAsync();
+            await fileLock.WaitAsync().ConfigureAwait(false);
             try
             {
                 var wkbReader = new WKBReader();
-                byte[] fileBytes = await File.ReadAllBytesAsync(path);
+                byte[] fileBytes = await File.ReadAllBytesAsync(path).ConfigureAwait(false);
                 using var ms = new MemoryStream(fileBytes);
                 using var br = new BinaryReader(ms);
 
@@ -529,7 +520,7 @@ namespace StrategyGame
         /// <summary>
         /// Gets the ID of the city data model for a given urban area, if it exists
         /// </summary>
-        public static Guid? GetCityDataModelId(Nts.Polygon urbanArea)
+        public static async Task<Guid?> GetCityDataModelIdAsync(Nts.Polygon urbanArea)
         {
             string hash = ComputeHash(urbanArea);
             string cacheDir = GetCacheDir();
@@ -544,8 +535,8 @@ namespace StrategyGame
             {
                 try
                 {
-                    string id = File.ReadAllText(hashPath);
-                    if (Guid.TryParse(id, out Guid guid))
+                    string idStr = await File.ReadAllTextAsync(hashPath).ConfigureAwait(false);
+                    if (Guid.TryParse(idStr, out Guid guid))
                     {
                         string modelPath = Path.Combine(cacheDir, $"{guid}.bin");
                         if (File.Exists(modelPath))
@@ -599,16 +590,15 @@ namespace StrategyGame
             return (inMemoryCount, diskCount, totalUnique);
         }
 
-        public static CityDataModel? LoadCityDataModel(Guid id)
+        public static async Task<CityDataModel?> LoadCityDataModelAsync(Guid id)
         {
             string cacheDir = GetCacheDir();
             string modelPath = Path.Combine(cacheDir, $"{id}.bin");
-            if (!File.Exists(modelPath))
-                return null;
+            if (!File.Exists(modelPath)) return null;
 
             try
             {
-                return LoadModelBinaryAsync(modelPath).GetAwaiter().GetResult();
+                return await LoadModelBinaryAsync(modelPath).ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -45,14 +45,14 @@ namespace StrategyGame
         }
 
 
-        private static void SaveModelBinary(string path, CityDataModel model)
+        private static async Task SaveModelBinaryAsync(string path, CityDataModel model)
         {
             var fileLock = GetFileLock(path);
-            fileLock.Wait();
+            await fileLock.WaitAsync();
             try
             {
                 var wkbWriter = new WKBWriter();
-                using var fs = File.Open(path, FileMode.Create);
+                using var fs = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None, 4096, true);
                 using var bw = new BinaryWriter(fs);
 
                 bw.Write(model.Id.ToByteArray());
@@ -116,15 +116,16 @@ namespace StrategyGame
             }
         }
 
-        private static CityDataModel LoadModelBinary(string path)
+        private static async Task<CityDataModel> LoadModelBinaryAsync(string path)
         {
             var fileLock = GetFileLock(path);
-            fileLock.Wait();
+            await fileLock.WaitAsync();
             try
             {
                 var wkbReader = new WKBReader();
-                using var fs = File.OpenRead(path);
-                using var br = new BinaryReader(fs);
+                byte[] fileBytes = await File.ReadAllBytesAsync(path);
+                using var ms = new MemoryStream(fileBytes);
+                using var br = new BinaryReader(ms);
 
             var model = new CityDataModel();
             model.Id = new Guid(br.ReadBytes(16));
@@ -213,7 +214,7 @@ namespace StrategyGame
                     string modelPath = Path.Combine(cacheDir, $"{id}.bin");
                     if (File.Exists(modelPath))
                     {
-                        var loaded = LoadModelBinary(modelPath);
+                        var loaded = await LoadModelBinaryAsync(modelPath);
                         modelCache[hash] = loaded;
                         return loaded;
                     }
@@ -253,7 +254,7 @@ namespace StrategyGame
             try
             {
                 string modelPath = Path.Combine(cacheDir, $"{result.Id}.bin");
-                SaveModelBinary(modelPath, result);
+                await SaveModelBinaryAsync(modelPath, result);
                 await File.WriteAllTextAsync(hashPath, result.Id.ToString()).ConfigureAwait(false);
             }
             catch (Exception ex)
@@ -601,7 +602,7 @@ namespace StrategyGame
 
             try
             {
-                return LoadModelBinary(modelPath);
+                return LoadModelBinaryAsync(modelPath).GetAwaiter().GetResult();
             }
             catch (Exception ex)
             {

--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -31,7 +31,10 @@ namespace StrategyGame
             var index = new STRtree<Building>();
             foreach (var b in model.Buildings)
             {
-                b.SimplifiedFootprint = DouglasPeuckerSimplifier.Simplify(b.Footprint, tol);
+                var simplified = DouglasPeuckerSimplifier.Simplify(b.Footprint, tol);
+                if (simplified == null || simplified.IsEmpty)
+                    simplified = b.Footprint;
+                b.SimplifiedFootprints[0] = simplified;
                 index.Insert(b.Footprint.EnvelopeInternal, b);
             }
             index.Build();

--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Threading;
 using NetTopologySuite.IO;
 using NetTopologySuite.Index.Quadtree;
 
@@ -19,6 +20,8 @@ namespace StrategyGame
     {
         private static readonly ConcurrentDictionary<string, List<(Nts.LineString Line, RoadType Type)>> networkCache = new();
         private static readonly ConcurrentDictionary<string, CityDataModel> modelCache = new();
+        private static readonly object _fileLockDictLock = new();
+        private static readonly Dictionary<string, SemaphoreSlim> _fileLocks = new();
 
         public static CityGenerationData? Data { get; set; }
 
@@ -28,14 +31,31 @@ namespace StrategyGame
             double.IsNaN(c.X) || double.IsNaN(c.Y) ||
             double.IsInfinity(c.X) || double.IsInfinity(c.Y);
 
+        private static SemaphoreSlim GetFileLock(string path)
+        {
+            lock (_fileLockDictLock)
+            {
+                if (!_fileLocks.TryGetValue(path, out var sem))
+                {
+                    sem = new SemaphoreSlim(1, 1);
+                    _fileLocks[path] = sem;
+                }
+                return sem;
+            }
+        }
+
 
         private static void SaveModelBinary(string path, CityDataModel model)
         {
-            var wkbWriter = new WKBWriter();
-            using var fs = File.Open(path, FileMode.Create);
-            using var bw = new BinaryWriter(fs);
+            var fileLock = GetFileLock(path);
+            fileLock.Wait();
+            try
+            {
+                var wkbWriter = new WKBWriter();
+                using var fs = File.Open(path, FileMode.Create);
+                using var bw = new BinaryWriter(fs);
 
-            bw.Write(model.Id.ToByteArray());
+                bw.Write(model.Id.ToByteArray());
 
             if (model.UrbanArea != null)
             {
@@ -77,25 +97,34 @@ namespace StrategyGame
                 bw.Write(parcel.LandValue);
             }
 
-            bw.Write(model.Buildings.Count);
-            foreach (var building in model.Buildings)
+                bw.Write(model.Buildings.Count);
+                foreach (var building in model.Buildings)
+                {
+                    byte[] data = wkbWriter.Write(building.Footprint);
+                    bw.Write(data.Length);
+                    bw.Write(data);
+                    bw.Write((int)building.LandUse);
+                    bw.Write(building.Level);
+                    bw.Write(building.PopulationCapacity);
+                    bw.Write(building.EconomicOutput);
+                    bw.Write(building.PollutionOutput);
+                }
+            }
+            finally
             {
-                byte[] data = wkbWriter.Write(building.Footprint);
-                bw.Write(data.Length);
-                bw.Write(data);
-                bw.Write((int)building.LandUse);
-                bw.Write(building.Level);
-                bw.Write(building.PopulationCapacity);
-                bw.Write(building.EconomicOutput);
-                bw.Write(building.PollutionOutput);
+                fileLock.Release();
             }
         }
 
         private static CityDataModel LoadModelBinary(string path)
         {
-            var wkbReader = new WKBReader();
-            using var fs = File.OpenRead(path);
-            using var br = new BinaryReader(fs);
+            var fileLock = GetFileLock(path);
+            fileLock.Wait();
+            try
+            {
+                var wkbReader = new WKBReader();
+                using var fs = File.OpenRead(path);
+                using var br = new BinaryReader(fs);
 
             var model = new CityDataModel();
             model.Id = new Guid(br.ReadBytes(16));
@@ -159,7 +188,12 @@ namespace StrategyGame
                 });
             }
 
-            return model;
+                return model;
+            }
+            finally
+            {
+                fileLock.Release();
+            }
         }
 
         public static async Task<CityDataModel> GenerateModelAsync(Nts.Polygon urbanArea, int cellSize)

--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -23,6 +23,9 @@ namespace StrategyGame
     {
         private static readonly ConcurrentDictionary<string, List<(Nts.LineString Line, RoadType Type)>> networkCache = new();
         private static readonly ConcurrentDictionary<string, CityDataModel> modelCache = new();
+        private static readonly ConcurrentDictionary<Guid, CityDataModel> modelCacheById = new();
+
+        public static IReadOnlyDictionary<Guid, CityDataModel> ModelCacheById => modelCacheById;
         private static readonly ConcurrentDictionary<string, SemaphoreSlim> _fileLocks = new();
 
         private static void BuildBuildingStructures(CityDataModel model)
@@ -52,6 +55,12 @@ namespace StrategyGame
         private static SemaphoreSlim GetFileLock(string path)
         {
             return _fileLocks.GetOrAdd(path, p => new SemaphoreSlim(1, 1));
+        }
+
+        private static void AddToCache(string hash, CityDataModel model)
+        {
+            modelCache[hash] = model;
+            modelCacheById[model.Id] = model;
         }
 
 
@@ -215,7 +224,10 @@ namespace StrategyGame
             string cacheDir = GetCacheDir();
 
             if (modelCache.TryGetValue(hash, out var cachedModel))
+            {
+                modelCacheById[cachedModel.Id] = cachedModel;
                 return cachedModel;
+            }
 
             string hashPath = Path.Combine(cacheDir, $"{hash}.txt");
             if (File.Exists(hashPath))
@@ -227,7 +239,7 @@ namespace StrategyGame
                     if (File.Exists(modelPath))
                     {
                         var loaded = await LoadModelBinaryAsync(modelPath);
-                        modelCache[hash] = loaded;
+                        AddToCache(hash, loaded);
                         return loaded;
                     }
                 }
@@ -280,7 +292,7 @@ namespace StrategyGame
                 Console.WriteLine($"[CRITICAL ERROR] Failed to serialize CityDataModel: {errorMessage}");
             }
 
-            modelCache[hash] = result;
+            AddToCache(hash, result);
             return result;
         }
 
@@ -548,7 +560,10 @@ namespace StrategyGame
             
             // Check in-memory cache first
             if (modelCache.TryGetValue(hash, out var cachedModel))
+            {
+                modelCacheById[cachedModel.Id] = cachedModel;
                 return cachedModel.Id;
+            }
                 
             // Check disk cache
             string hashPath = Path.Combine(cacheDir, $"{hash}.txt");
@@ -613,13 +628,22 @@ namespace StrategyGame
 
         public static async Task<CityDataModel?> LoadCityDataModelAsync(Guid id)
         {
+            if (modelCacheById.TryGetValue(id, out var cached))
+                return cached;
+
             string cacheDir = GetCacheDir();
             string modelPath = Path.Combine(cacheDir, $"{id}.bin");
             if (!File.Exists(modelPath)) return null;
 
             try
             {
-                return await LoadModelBinaryAsync(modelPath).ConfigureAwait(false);
+                var model = await LoadModelBinaryAsync(modelPath).ConfigureAwait(false);
+                if (model.UrbanArea != null)
+                {
+                    string hash = ComputeHash(model.UrbanArea);
+                    AddToCache(hash, model);
+                }
+                return model;
             }
             catch (Exception ex)
             {

--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -8,10 +8,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
-using System.Text.Json;
 using System.Threading.Tasks;
 using NetTopologySuite.IO;
-using NetTopologySuite.IO.Converters;
 using NetTopologySuite.Index.Quadtree;
 
 namespace StrategyGame
@@ -23,12 +21,120 @@ namespace StrategyGame
 
         public static CityGenerationData? Data { get; set; }
 
-        private static readonly JsonSerializerOptions jsonOptions = new()
+
+        private static void SaveModelBinary(string path, CityDataModel model)
         {
-            IncludeFields = true,
-            WriteIndented = true,
-            Converters = { new GeoJsonConverterFactory() }
-        };
+            var wkbWriter = new WKBWriter();
+            using var fs = File.Open(path, FileMode.Create);
+            using var bw = new BinaryWriter(fs);
+
+            bw.Write(model.Id.ToByteArray());
+
+            bw.Write(model.RoadNetwork.Count);
+            foreach (var seg in model.RoadNetwork)
+            {
+                bw.Write(seg.X1);
+                bw.Write(seg.Y1);
+                bw.Write(seg.X2);
+                bw.Write(seg.Y2);
+                bw.Write((int)seg.Type);
+            }
+
+            bw.Write(model.RawBlocks.Count);
+            foreach (var poly in model.RawBlocks)
+            {
+                byte[] data = wkbWriter.Write(poly);
+                bw.Write(data.Length);
+                bw.Write(data);
+            }
+
+            bw.Write(model.Parcels.Count);
+            foreach (var parcel in model.Parcels)
+            {
+                byte[] data = wkbWriter.Write(parcel.Shape);
+                bw.Write(data.Length);
+                bw.Write(data);
+                bw.Write((int)parcel.LandUse);
+                bw.Write(parcel.LandValue);
+            }
+
+            bw.Write(model.Buildings.Count);
+            foreach (var building in model.Buildings)
+            {
+                byte[] data = wkbWriter.Write(building.Footprint);
+                bw.Write(data.Length);
+                bw.Write(data);
+                bw.Write((int)building.LandUse);
+                bw.Write(building.Level);
+                bw.Write(building.PopulationCapacity);
+                bw.Write(building.EconomicOutput);
+                bw.Write(building.PollutionOutput);
+            }
+        }
+
+        private static CityDataModel LoadModelBinary(string path)
+        {
+            var wkbReader = new WKBReader();
+            using var fs = File.OpenRead(path);
+            using var br = new BinaryReader(fs);
+
+            var model = new CityDataModel();
+            model.Id = new Guid(br.ReadBytes(16));
+
+            int roadCount = br.ReadInt32();
+            for (int i = 0; i < roadCount; i++)
+            {
+                double x1 = br.ReadDouble();
+                double y1 = br.ReadDouble();
+                double x2 = br.ReadDouble();
+                double y2 = br.ReadDouble();
+                var type = (RoadType)br.ReadInt32();
+                model.RoadNetwork.Add(new LineSegment(x1, y1, x2, y2, type));
+            }
+
+            int blockCount = br.ReadInt32();
+            for (int i = 0; i < blockCount; i++)
+            {
+                int len = br.ReadInt32();
+                byte[] data = br.ReadBytes(len);
+                model.RawBlocks.Add((Nts.Polygon)wkbReader.Read(data));
+            }
+
+            int parcelCount = br.ReadInt32();
+            for (int i = 0; i < parcelCount; i++)
+            {
+                int len = br.ReadInt32();
+                byte[] data = br.ReadBytes(len);
+                var shape = (Nts.Polygon)wkbReader.Read(data);
+                var landUse = (LandUseType)br.ReadInt32();
+                double value = br.ReadDouble();
+                model.Parcels.Add(new Parcel { Shape = shape, LandUse = landUse, LandValue = value });
+            }
+
+            int buildingCount = br.ReadInt32();
+            for (int i = 0; i < buildingCount; i++)
+            {
+                int len = br.ReadInt32();
+                byte[] data = br.ReadBytes(len);
+                var footprint = (Nts.Polygon)wkbReader.Read(data);
+                var landUse = (LandUseType)br.ReadInt32();
+                int level = br.ReadInt32();
+                int popCap = br.ReadInt32();
+                double econ = br.ReadDouble();
+                double poll = br.ReadDouble();
+                model.Buildings.Add(new Building
+                {
+                    Footprint = footprint,
+                    LandUse = landUse,
+                    Level = level,
+                    PopulationCapacity = popCap,
+                    EconomicOutput = econ,
+                    PollutionOutput = poll
+                });
+            }
+
+            return model;
+        }
 
         public static async Task<CityDataModel> GenerateModelAsync(Nts.Polygon urbanArea, int cellSize)
         {
@@ -44,16 +150,12 @@ namespace StrategyGame
                 try
                 {
                     string id = await File.ReadAllTextAsync(hashPath).ConfigureAwait(false);
-                    string modelPath = Path.Combine(cacheDir, $"{id}.json");
+                    string modelPath = Path.Combine(cacheDir, $"{id}.bin");
                     if (File.Exists(modelPath))
                     {
-                        string jsonIn = await File.ReadAllTextAsync(modelPath).ConfigureAwait(false);
-                        var loaded = JsonSerializer.Deserialize<CityDataModel>(jsonIn, jsonOptions);
-                        if (loaded != null)
-                        {
-                            modelCache[hash] = loaded;
-                            return loaded;
-                        }
+                        var loaded = LoadModelBinary(modelPath);
+                        modelCache[hash] = loaded;
+                        return loaded;
                     }
                 }
                 catch (Exception ex)
@@ -80,9 +182,8 @@ namespace StrategyGame
 
             try
             {
-                string modelPath = Path.Combine(cacheDir, $"{result.Id}.json");
-                string jsonOut = JsonSerializer.Serialize(result, jsonOptions);
-                await File.WriteAllTextAsync(modelPath, jsonOut).ConfigureAwait(false);
+                string modelPath = Path.Combine(cacheDir, $"{result.Id}.bin");
+                SaveModelBinary(modelPath, result);
                 await File.WriteAllTextAsync(hashPath, result.Id.ToString()).ConfigureAwait(false);
             }
             catch (Exception ex)
@@ -329,7 +430,7 @@ namespace StrategyGame
                 try
                 {
                     string id = File.ReadAllText(hashPath);
-                    string modelPath = Path.Combine(cacheDir, $"{id}.json");
+                    string modelPath = Path.Combine(cacheDir, $"{id}.bin");
                     return File.Exists(modelPath);
                 }
                 catch
@@ -362,7 +463,7 @@ namespace StrategyGame
                     string id = File.ReadAllText(hashPath);
                     if (Guid.TryParse(id, out Guid guid))
                     {
-                        string modelPath = Path.Combine(cacheDir, $"{guid}.json");
+                        string modelPath = Path.Combine(cacheDir, $"{guid}.bin");
                         if (File.Exists(modelPath))
                             return guid;
                     }
@@ -390,17 +491,17 @@ namespace StrategyGame
             if (Directory.Exists(cacheDir))
             {
                 var hashFiles = Directory.GetFiles(cacheDir, "*.txt");
-                var jsonFiles = Directory.GetFiles(cacheDir, "*.json");
-                
-                diskCount = jsonFiles.Length;
-                
-                // Count unique models (hash files that have corresponding JSON files)
+                var binFiles = Directory.GetFiles(cacheDir, "*.bin");
+
+                diskCount = binFiles.Length;
+
+                // Count unique models (hash files that have corresponding binary files)
                 foreach (string hashFile in hashFiles)
                 {
                     try
                     {
                         string id = File.ReadAllText(hashFile);
-                        string modelPath = Path.Combine(cacheDir, $"{id}.json");
+                        string modelPath = Path.Combine(cacheDir, $"{id}.bin");
                         if (File.Exists(modelPath))
                             totalUnique++;
                     }
@@ -417,14 +518,13 @@ namespace StrategyGame
         public static CityDataModel? LoadCityDataModel(Guid id)
         {
             string cacheDir = GetCacheDir();
-            string modelPath = Path.Combine(cacheDir, $"{id}.json");
+            string modelPath = Path.Combine(cacheDir, $"{id}.bin");
             if (!File.Exists(modelPath))
                 return null;
 
             try
             {
-                string json = File.ReadAllText(modelPath);
-                return JsonSerializer.Deserialize<CityDataModel>(json, jsonOptions);
+                return LoadModelBinary(modelPath);
             }
             catch (Exception ex)
             {

--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -37,6 +37,18 @@ namespace StrategyGame
 
             bw.Write(model.Id.ToByteArray());
 
+            if (model.UrbanArea != null)
+            {
+                bw.Write(true);
+                byte[] ua = wkbWriter.Write(model.UrbanArea);
+                bw.Write(ua.Length);
+                bw.Write(ua);
+            }
+            else
+            {
+                bw.Write(false);
+            }
+
             bw.Write(model.RoadNetwork.Count);
             foreach (var seg in model.RoadNetwork)
             {
@@ -87,6 +99,13 @@ namespace StrategyGame
 
             var model = new CityDataModel();
             model.Id = new Guid(br.ReadBytes(16));
+
+            if (br.ReadBoolean())
+            {
+                int len = br.ReadInt32();
+                byte[] ua = br.ReadBytes(len);
+                model.UrbanArea = (Nts.Polygon)wkbReader.Read(ua);
+            }
 
             int roadCount = br.ReadInt32();
             for (int i = 0; i < roadCount; i++)
@@ -171,7 +190,7 @@ namespace StrategyGame
                 }
             }
 
-            var result = new CityDataModel { Id = Guid.NewGuid() };
+            var result = new CityDataModel { Id = Guid.NewGuid(), UrbanArea = urbanArea };
             var roadGeometries = GetOrGenerateFor(urbanArea, cellSize);
 
             result.RoadNetwork = roadGeometries

--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -190,7 +190,11 @@ namespace StrategyGame
                 }
             }
 
-            var result = new CityDataModel { Id = Guid.NewGuid(), UrbanArea = urbanArea };
+            var result = new CityDataModel
+            {
+                Id = Guid.NewGuid(),
+                UrbanArea = urbanArea // Immediately assign the urbanArea to the model
+            };
             var roadGeometries = GetOrGenerateFor(urbanArea, cellSize);
 
             result.RoadNetwork = roadGeometries
@@ -198,8 +202,8 @@ namespace StrategyGame
                     new LineSegment(s.X, s.Y, e.X, e.Y, tuple.Type)))
                 .ToList();
 
-            result.RawBlocks = PolygonizeRoadNetwork(result.RoadNetwork);
-            result.Parcels = ParcelGenerator.GenerateParcelsFromBlocks(result.RawBlocks);
+            // This single call handles block and parcel generation using the urban area boundary.
+            result.Parcels = ParcelGenerator.GenerateParcels(result);
             LandUseSimulator.Run(result);
             result.Buildings = BuildingGenerator.GenerateBuildings(result);
             BuildingRefiner.RefineBuildings(result);

--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -13,6 +13,8 @@ using System.Threading.Tasks;
 using System.Threading;
 using NetTopologySuite.IO;
 using NetTopologySuite.Index.Quadtree;
+using NetTopologySuite.Index.Strtree;
+using NetTopologySuite.Simplify;
 using System.Windows.Forms;
 
 namespace StrategyGame
@@ -22,6 +24,19 @@ namespace StrategyGame
         private static readonly ConcurrentDictionary<string, List<(Nts.LineString Line, RoadType Type)>> networkCache = new();
         private static readonly ConcurrentDictionary<string, CityDataModel> modelCache = new();
         private static readonly ConcurrentDictionary<string, SemaphoreSlim> _fileLocks = new();
+
+        private static void BuildBuildingStructures(CityDataModel model)
+        {
+            const double tol = 0.0001; // degrees ~10m
+            var index = new STRtree<Building>();
+            foreach (var b in model.Buildings)
+            {
+                b.SimplifiedFootprint = DouglasPeuckerSimplifier.Simplify(b.Footprint, tol);
+                index.Insert(b.Footprint.EnvelopeInternal, b);
+            }
+            index.Build();
+            model.BuildingIndex = index;
+        }
 
         public static CityGenerationData? Data { get; set; }
 
@@ -181,7 +196,9 @@ namespace StrategyGame
                 });
             }
 
-                return model;
+            BuildBuildingStructures(model);
+
+            return model;
             }
             finally
             {
@@ -240,6 +257,7 @@ namespace StrategyGame
             LandUseSimulator.Run(result);
             result.Buildings = BuildingGenerator.GenerateBuildings(result);
             BuildingRefiner.RefineBuildings(result);
+            BuildBuildingStructures(result);
 
             Debug.WriteLine($">> Generated {result.Parcels.Count} parcels, {result.Buildings.Count} buildings for {hash}");
 


### PR DESCRIPTION
## Summary
- improve building generation speed with fixed insets
- simplify parcel subdivision using recursive splitting
- change city model cache to a compact binary format

## Testing
- `dotnet build "economy sim.sln" -v minimal` *(fails: SDK Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875ef9e47088323a56102b2b029d065