### PR TITLE
Fix city tile cache lifetime

### DIFF
--- a/CityGeneration.cs
+++ b/CityGeneration.cs
@@ -270,15 +270,14 @@ namespace StrategyGame
     {
         public static List<Building> GenerateBuildings(CityDataModel model)
         {
-            var buildingBag = new ConcurrentBag<Building>();
+            var buildings = new List<Building>();
             var gf = Nts.GeometryFactory.Default;
 
-            // Fixed insets provide much faster buffering while maintaining visual quality
             const double CommercialInset = -0.00002;
             const double ResidentialInset = -0.00004;
             const double IndustrialInset = -0.00003;
 
-            Parallel.ForEach(model.Parcels, parcel =>
+            foreach (var parcel in model.Parcels)
             {
                 Nts.Geometry foot;
                 switch (parcel.LandUse)
@@ -301,9 +300,9 @@ namespace StrategyGame
                         }
                         break;
                     case LandUseType.Park:
-                        return;
+                        continue;
                     default:
-                        return;
+                        continue;
                 }
 
                 if (foot is Nts.Polygon p && p.IsValid && !p.IsEmpty)
@@ -311,12 +310,11 @@ namespace StrategyGame
                     var cleanedFootprint = p.Buffer(0);
                     if (cleanedFootprint is Nts.Polygon cleanedP && cleanedP.IsValid && !cleanedP.IsEmpty)
                     {
-                        buildingBag.Add(new Building { Footprint = cleanedP, LandUse = parcel.LandUse });
+                        buildings.Add(new Building { Footprint = cleanedP, LandUse = parcel.LandUse });
                     }
                 }
-            });
+            }
 
-            var buildings = buildingBag.ToList();
             model.Buildings = buildings;
             return buildings;
         }

--- a/CityGeneration.cs
+++ b/CityGeneration.cs
@@ -307,7 +307,13 @@ namespace StrategyGame
                 }
 
                 if (foot is Nts.Polygon p && p.IsValid && !p.IsEmpty)
-                    buildingBag.Add(new Building { Footprint = p, LandUse = parcel.LandUse });
+                {
+                    var cleanedFootprint = p.Buffer(0);
+                    if (cleanedFootprint is Nts.Polygon cleanedP && cleanedP.IsValid && !cleanedP.IsEmpty)
+                    {
+                        buildingBag.Add(new Building { Footprint = cleanedP, LandUse = parcel.LandUse });
+                    }
+                }
             });
 
             var buildings = buildingBag.ToList();

--- a/CityGeneration.cs
+++ b/CityGeneration.cs
@@ -168,6 +168,14 @@ namespace StrategyGame
             {
                 var splitGeometries = poly.Difference(splitLine);
 
+                // If the split did not create two or more pieces, stop recursion to avoid an infinite loop.
+                if (splitGeometries.NumGeometries < 2)
+                {
+                    if (poly.IsValid && !poly.IsEmpty)
+                        output.Add(new Parcel { Shape = poly });
+                    return;
+                }
+
                 for (int i = 0; i < splitGeometries.NumGeometries; i++)
                 {
                     if (splitGeometries.GetGeometryN(i) is Nts.Polygon splitPoly && splitPoly.IsValid && !splitPoly.IsEmpty)

--- a/CityGeneration.cs
+++ b/CityGeneration.cs
@@ -129,6 +129,10 @@ namespace StrategyGame
 
         private static void RecursiveSplit(Nts.Polygon poly, List<Parcel> output, double minArea)
         {
+            // --- Start Diagnostic Logging ---
+            Debug.WriteLine($"Splitting polygon. Area: {poly.Area}, IsValid: {poly.IsValid}, Envelope: {poly.EnvelopeInternal}");
+            // --- End Diagnostic Logging ---
+
             if (poly.Area < minArea * 1.5)
             {
                 if (poly.IsValid && !poly.IsEmpty)
@@ -163,6 +167,7 @@ namespace StrategyGame
             try
             {
                 var splitGeometries = poly.Difference(splitLine);
+
                 for (int i = 0; i < splitGeometries.NumGeometries; i++)
                 {
                     if (splitGeometries.GetGeometryN(i) is Nts.Polygon splitPoly && splitPoly.IsValid && !splitPoly.IsEmpty)
@@ -171,8 +176,10 @@ namespace StrategyGame
                     }
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                // This will tell us if the split itself throws a C# error
+                Debug.WriteLine($"[RECURSIVE SPLIT ERROR] {ex.Message}");
                 if (poly.IsValid && !poly.IsEmpty)
                     output.Add(new Parcel { Shape = poly });
             }
@@ -277,42 +284,54 @@ namespace StrategyGame
             const double ResidentialInset = -0.00004;
             const double IndustrialInset = -0.00003;
 
+            int parcelIndex = 0;
             foreach (var parcel in model.Parcels)
             {
-                Nts.Geometry foot;
-                switch (parcel.LandUse)
-                {
-                    case LandUseType.Commercial:
-                        foot = parcel.Shape.Buffer(CommercialInset);
-                        break;
-                    case LandUseType.Residential:
-                        foot = parcel.Shape.Buffer(ResidentialInset);
-                        break;
-                    case LandUseType.Industrial:
-                        var temp = parcel.Shape.Buffer(IndustrialInset);
-                        if (!temp.IsEmpty)
-                        {
-                            foot = gf.ToGeometry(temp.EnvelopeInternal);
-                        }
-                        else
-                        {
-                            foot = temp;
-                        }
-                        break;
-                    case LandUseType.Park:
-                        continue;
-                    default:
-                        continue;
-                }
+                // --- Start Diagnostic Logging ---
+                Debug.WriteLine($"--- Processing Parcel Index: {parcelIndex} ---");
+                Debug.WriteLine($"Parcel LandUse: {parcel.LandUse}, Area: {parcel.Shape.Area}, IsValid: {parcel.Shape.IsValid}");
+                // --- End Diagnostic Logging ---
 
-                if (foot is Nts.Polygon p && p.IsValid && !p.IsEmpty)
+                try
                 {
-                    var cleanedFootprint = p.Buffer(0);
-                    if (cleanedFootprint is Nts.Polygon cleanedP && cleanedP.IsValid && !cleanedP.IsEmpty)
+                    Nts.Geometry foot = null;
+                    switch (parcel.LandUse)
                     {
-                        buildings.Add(new Building { Footprint = cleanedP, LandUse = parcel.LandUse });
+                        case LandUseType.Commercial:
+                            foot = parcel.Shape.Buffer(CommercialInset);
+                            break;
+                        case LandUseType.Residential:
+                            foot = parcel.Shape.Buffer(ResidentialInset);
+                            break;
+                        case LandUseType.Industrial:
+                            var temp = parcel.Shape.Buffer(IndustrialInset);
+                            if (!temp.IsEmpty) foot = gf.ToGeometry(temp.EnvelopeInternal);
+                            else foot = temp;
+                            break;
+                        default:
+                            parcelIndex++;
+                            continue;
+                    }
+
+                    if (foot is Nts.Polygon p && p.IsValid && !p.IsEmpty)
+                    {
+                        Debug.WriteLine($"Buffer successful for parcel {parcelIndex}. Cleaning footprint...");
+                        var cleanedFootprint = p.Buffer(0);
+
+                        if (cleanedFootprint is Nts.Polygon cleanedP && cleanedP.IsValid && !cleanedP.IsEmpty)
+                        {
+                            buildings.Add(new Building { Footprint = cleanedP, LandUse = parcel.LandUse });
+                            Debug.WriteLine($"--> Building added successfully for parcel {parcelIndex}.");
+                        }
                     }
                 }
+                catch (Exception ex)
+                {
+                    // This will tell us if the buffer operation throws a C# error
+                    Debug.WriteLine($"[BUILDING GEN ERROR] on Parcel Index {parcelIndex}: {ex.Message}");
+                }
+
+                parcelIndex++;
             }
 
             model.Buildings = buildings;

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -18,7 +18,7 @@ namespace StrategyGame
     {
         private readonly int _baseWidth;
         private readonly int _baseHeight;
-        private readonly Dictionary<(int cellSize, int x, int y), SKBitmap> _tileCache = new();
+        private readonly Dictionary<(int cellSize, int x, int y), (SKBitmap sk, SD.Bitmap gdi)> _tileCache = new();
         private readonly Dictionary<(int cellSize, int x, int y), Task<SKBitmap>> _inFlight = new();
         private readonly object _cacheLock = new();
         private readonly LinkedList<(int cellSize, int x, int y)> _lruOrder = new();
@@ -89,12 +89,12 @@ namespace StrategyGame
             PerformanceTracker.Record("LRU-TouchKey", sw.Elapsed);
         }
 
-        private void AddToCache((int cellSize, int x, int y) key, SKBitmap bmp)
+        private void AddToCache((int cellSize, int x, int y) key, (SKBitmap sk, SD.Bitmap gdi) bitmaps)
         {
             var sw = Stopwatch.StartNew();
             lock (_cacheLock)
             {
-                _tileCache[key] = bmp;
+                _tileCache[key] = bitmaps;
                 if (_lruNodes.TryGetValue(key, out var existing))
                 {
                     _lruOrder.Remove(existing);
@@ -108,8 +108,11 @@ namespace StrategyGame
                     if (last == null) break;
                     _lruOrder.RemoveLast();
                     var remKey = last.Value;
-                    if (_tileCache.TryGetValue(remKey, out var oldBmp))
-                        oldBmp.Dispose();
+                    if (_tileCache.TryGetValue(remKey, out var oldBitmaps))
+                    {
+                        oldBitmaps.sk.Dispose();
+                        oldBitmaps.gdi.Dispose();
+                    }
                     _tileCache.Remove(remKey);
                     _lruNodes.Remove(remKey);
                 }
@@ -211,7 +214,7 @@ namespace StrategyGame
                 {
                     TouchKey(key);
                     PerformanceTracker.Record("LoadTileInternal-CacheHit", sw.Elapsed);
-                    return cached;
+                    return cached.sk;
                 }
             }
 
@@ -227,8 +230,7 @@ namespace StrategyGame
                     using var img = await SixLabors.ImageSharp.Image.LoadAsync<Rgba32>(fs, token).ConfigureAwait(false);
                     var bmp = ImageSharpToBitmap(img);
                     var sk = SkiaBitmapUtil.ToSKBitmap(bmp);
-                    bmp.Dispose();
-                    AddToCache(key, sk);
+                    AddToCache(key, (sk, bmp));
                     PerformanceTracker.Record("LoadTileInternal-FromDisk", swFileLoad.Elapsed);
                     PerformanceTracker.Record("LoadTileInternal-Total", sw.Elapsed);
                     return sk;
@@ -267,8 +269,7 @@ namespace StrategyGame
             PerformanceTracker.Record("TileGeneration-SaveToDisk", swSave.Elapsed);
 
             var skBmp = SkiaBitmapUtil.ToSKBitmap(bitmap);
-            bitmap.Dispose();
-            AddToCache(key, skBmp);
+            AddToCache(key, (skBmp, bitmap));
             PerformanceTracker.Record("LoadTileInternal-Generation", swGeneration.Elapsed);
             PerformanceTracker.Record("LoadTileInternal-Total", sw.Elapsed);
             return skBmp;
@@ -316,7 +317,7 @@ namespace StrategyGame
                         {
                             TouchKey(key);
                             // Create a private, safe copy of the tile inside the lock
-                            tileCopy = cachedTile.Copy();
+                            tileCopy = cachedTile.sk.Copy();
                         }
                     }
 

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -366,7 +366,7 @@ namespace StrategyGame
             return result;
         }
 
-        public void PreloadVisibleTiles(float zoom, SD.Rectangle viewRect)
+        public async Task PreloadVisibleTilesAsync(float zoom, SD.Rectangle viewRect, CancellationToken token = default)
         {
             var sw = Stopwatch.StartNew();
             int cellSize = GetCellSize(zoom);
@@ -382,29 +382,27 @@ namespace StrategyGame
                     .Select(y => (x, y)))
                 .ToList();
 
-            int tileCount = coords.Count;
             using var throttle = new SemaphoreSlim(Environment.ProcessorCount);
-            int loaded = 0;
+            var tasks = new List<Task>();
 
-            var swParallel = Stopwatch.StartNew();
-            Parallel.ForEach(coords, coord =>
+            foreach (var coord in coords)
             {
-                throttle.Wait();
-                try
+                await throttle.WaitAsync(token).ConfigureAwait(false);
+                tasks.Add(Task.Run(async () =>
                 {
-                    var swTile = Stopwatch.StartNew();
-                    GetTileAsync(zoom, coord.x, coord.y, CancellationToken.None)
-                        .GetAwaiter().GetResult();
-                    PerformanceTracker.Record("PreloadTile-Single", swTile.Elapsed);
-                    Interlocked.Increment(ref loaded);
-                }
-                finally
-                {
-                    throttle.Release();
-                }
-            });
-            PerformanceTracker.Record("PreloadTiles-Parallel", swParallel.Elapsed);
-            PerformanceTracker.Record("PreloadTiles-Count", TimeSpan.FromMilliseconds(loaded));
+                    try
+                    {
+                        await GetTileAsync(zoom, coord.x, coord.y, token).ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        throttle.Release();
+                    }
+                }, token));
+            }
+
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+
             PerformanceTracker.Record("PreloadTiles-Total", sw.Elapsed);
         }
     }

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -272,7 +272,7 @@ namespace economy_sim
                         "data", "tile_cache");
 
                     mapManager.PreloadVisibleTiles(mapZoom, viewRect);
-                    cityTileManager.PreloadVisibleTiles(mapZoom, viewRect);
+                    _ = cityTileManager.PreloadVisibleTilesAsync(mapZoom, viewRect);
 
                     this.Invoke((MethodInvoker)(() =>
                     {
@@ -413,7 +413,7 @@ namespace economy_sim
             }
 
             mapManager.PreloadVisibleTiles(zoom, view);
-            cityTileManager.PreloadVisibleTiles(zoom, view);
+            _ = cityTileManager.PreloadVisibleTilesAsync(zoom, view);
 
             mapRenderInProgress = true;
 
@@ -2384,7 +2384,7 @@ namespace economy_sim
             Debug.WriteLine($"  FINAL_ORIGIN=({mapViewOrigin.X},{mapViewOrigin.Y})");
 
             ApplyZoom();
-            PreloadMapTiles();
+            _ = PreloadMapTilesAsync();
         }
         private void PanelMap_Resize(object sender, EventArgs e)
         {
@@ -2404,7 +2404,7 @@ namespace economy_sim
                     mapZoom = Math.Min(mapZoom + 1, MultiResolutionMapManager.PixelsPerCellLevels.Length);
                 }
                 ApplyZoom();
-                PreloadMapTiles();
+                _ = PreloadMapTilesAsync();
                 e.Handled = true;
                 e.SuppressKeyPress = true;
                 return;
@@ -2417,7 +2417,7 @@ namespace economy_sim
                     mapZoom = Math.Max(1, mapZoom - 1);
                 }
                 ApplyZoom();
-                PreloadMapTiles();
+                _ = PreloadMapTilesAsync();
                 e.Handled = true;
                 e.SuppressKeyPress = true;
                 return;
@@ -2461,7 +2461,7 @@ namespace economy_sim
                     mapViewOrigin.Y = Math.Max(0, Math.Min(mapViewOrigin.Y, mapSize.Height - panelMap.ClientSize.Height));
                 }
                 ApplyZoom();
-                PreloadMapTiles();
+                _ = PreloadMapTilesAsync();
             }
         }
 
@@ -2504,7 +2504,7 @@ namespace economy_sim
             {
                 isPanning = false;
                 Cursor = Cursors.Default;
-                PreloadMapTiles();
+                _ = PreloadMapTilesAsync();
             }
         }
 
@@ -2528,7 +2528,7 @@ namespace economy_sim
                 this.panelMap.Cursor = Cursors.Default; // Reset panelMap cursor
                 this.panelMap.BackColor = SystemColors.Control;
                 this.pictureBox1.BackColor = SD.Color.Transparent; // Reset pictureBox backcolor
-                PreloadMapTiles();
+                _ = PreloadMapTilesAsync();
             }
         }
 
@@ -2544,7 +2544,7 @@ namespace economy_sim
             }
         }
 
-        private void PreloadMapTiles()
+        private async Task PreloadMapTilesAsync()
         {
             if (mapManager == null)
                 return;
@@ -2555,7 +2555,8 @@ namespace economy_sim
                 view = new SD.Rectangle(mapViewOrigin, panelMap.ClientSize);
                 zoom = mapZoom;
             }
-            _ = mapManager.PreloadTilesAsync(zoom, view, 1, CancellationToken.None);
+            await mapManager.PreloadTilesAsync(zoom, view, 1, CancellationToken.None);
+            await cityTileManager.PreloadVisibleTilesAsync(zoom, view);
         }
 
         private void InvalidateMap()

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -276,17 +276,7 @@ namespace economy_sim
 
                     this.Invoke((MethodInvoker)(() =>
                     {
-                        using var sk = mapManager.AssembleView(mapZoom, viewRect, () =>
-                        {
-                            this.Invoke((MethodInvoker)(() =>
-                            {
-                                var updatedViewRect = new SD.Rectangle(mapViewOrigin, panelMap.ClientSize);
-                                using var sk2 = mapManager.AssembleView(mapZoom, updatedViewRect);
-                                _currentMapView?.Dispose();
-                                _currentMapView = sk2.Copy();
-                                pictureBox1.Invalidate();
-                            }));
-                        });
+                        using var sk = mapManager.AssembleView(mapZoom, viewRect, triggerRefresh: InvalidateMap);
                         _currentMapView?.Dispose();
                         _currentMapView = sk.Copy();
                         pictureBox1.Invalidate();
@@ -327,26 +317,8 @@ namespace economy_sim
             SKBitmap finalSk = null;
             try
             {
-                using SKBitmap terrain = mapManager.AssembleView(zoomLevel, viewRect, triggerRefresh: () =>
-                {
-                    if ((DateTime.Now - lastInnerRedraw).TotalMilliseconds < 100)
-                        return;
-                    lastInnerRedraw = DateTime.Now;
-                    if (this.InvokeRequired)
-                        this.BeginInvoke(new Action(Redraw));
-                    else
-                        Redraw();
-                });
-                using SKBitmap city = cityTileManager.AssembleView(zoomLevel, viewRect, triggerRefresh: () =>
-                {
-                    if ((DateTime.Now - lastInnerRedraw).TotalMilliseconds < 100)
-                        return;
-                    lastInnerRedraw = DateTime.Now;
-                    if (this.InvokeRequired)
-                        this.BeginInvoke(new Action(Redraw));
-                    else
-                        Redraw();
-                });
+                using SKBitmap terrain = mapManager.AssembleView(zoomLevel, viewRect, triggerRefresh: InvalidateMap);
+                using SKBitmap city = cityTileManager.AssembleView(zoomLevel, viewRect, triggerRefresh: InvalidateMap);
                 finalSk = CombineMaps(terrain, city);
             }
             catch (ArgumentException ex)
@@ -389,23 +361,9 @@ namespace economy_sim
             {
                 try
                 {
-                    using var terrain = mapManager.AssembleView(mapZoom, viewRect, triggerRefresh: () =>
-                    {
-                        if ((DateTime.Now - lastInnerRedraw).TotalMilliseconds >= 100 && !token.IsCancellationRequested)
-                        {
-                            lastInnerRedraw = DateTime.Now;
-                            this.BeginInvoke(new Action(RedrawAsync));
-                        }
-                    });
+                    using var terrain = mapManager.AssembleView(mapZoom, viewRect, triggerRefresh: InvalidateMap);
 
-                    using var city = cityTileManager.AssembleView(mapZoom, viewRect, triggerRefresh: () =>
-                    {
-                        if ((DateTime.Now - lastInnerRedraw).TotalMilliseconds >= 100 && !token.IsCancellationRequested)
-                        {
-                            lastInnerRedraw = DateTime.Now;
-                            this.BeginInvoke(new Action(RedrawAsync));
-                        }
-                    });
+                    using var city = cityTileManager.AssembleView(mapZoom, viewRect, triggerRefresh: InvalidateMap);
 
                     using var finalSk = CombineMaps(terrain, city);
 
@@ -461,20 +419,8 @@ namespace economy_sim
 
             Task.Run(() =>
             {
-                using SKBitmap terrain = mapManager.AssembleView(zoom, view, triggerRefresh: () =>
-                {
-                    if (this.InvokeRequired)
-                        this.BeginInvoke(new Action(ApplyZoom));
-                    else
-                        ApplyZoom();
-                });
-                using SKBitmap city = cityTileManager.AssembleView(zoom, view, triggerRefresh: () =>
-                {
-                    if (this.InvokeRequired)
-                        this.BeginInvoke(new Action(ApplyZoom));
-                    else
-                        ApplyZoom();
-                });
+                using SKBitmap terrain = mapManager.AssembleView(zoom, view, triggerRefresh: InvalidateMap);
+                using SKBitmap city = cityTileManager.AssembleView(zoom, view, triggerRefresh: InvalidateMap);
                 if (terrain == null) return;
                 using SKBitmap mapSk = CombineMaps(terrain, city);
                 if (mapSk == null) return;
@@ -2610,6 +2556,18 @@ namespace economy_sim
                 zoom = mapZoom;
             }
             _ = mapManager.PreloadTilesAsync(zoom, view, 1, CancellationToken.None);
+        }
+
+        private void InvalidateMap()
+        {
+            if (pictureBox1.InvokeRequired)
+            {
+                pictureBox1.BeginInvoke(new Action(pictureBox1.Invalidate));
+            }
+            else
+            {
+                pictureBox1.Invalidate();
+            }
         }
 
         private int GetCellSizeForZoom(int zoomLevel)

--- a/MultiResolutionMapManager.cs
+++ b/MultiResolutionMapManager.cs
@@ -50,9 +50,8 @@ namespace StrategyGame
         private readonly Dictionary<(int cellSize, int x, int y), SystemDrawing.Bitmap> _tileCache = new();
         // LRU order for tile cache entries
         private readonly LinkedList<(int cellSize, int x, int y)> _tileLru = new();
-        private readonly object _cacheLock = new();
+        private readonly object _masterCacheLock = new();
         private readonly object _assembleLock = new();
-        private readonly object _textureLock = new();
         private readonly Dictionary<(int cellSize, int x, int y), SKBitmap> _tileTextures = new();
 
         public static readonly bool GpuAvailable;
@@ -189,7 +188,7 @@ namespace StrategyGame
             System.Drawing.Bitmap bmp = null;
 
             // Try cache first
-            lock (_cacheLock)
+            lock (_masterCacheLock)
             {
                 if (_tileCache.TryGetValue(key, out var cached))
                 {
@@ -262,7 +261,7 @@ namespace StrategyGame
             // Cache result
             if (bmp != null)
             {
-                lock (_cacheLock)
+                lock (_masterCacheLock)
                 {
                     _tileCache[key] = bmp;
                     _tileLru.AddLast(key);
@@ -357,7 +356,7 @@ namespace StrategyGame
 
                         // --- START: Replacement Logic ---
                         SKBitmap textureCopy = null;
-                        lock (_textureLock)
+                        lock (_masterCacheLock)
                         {
                             if (_tileTextures.TryGetValue(key, out var texture))
                             {
@@ -625,7 +624,7 @@ namespace StrategyGame
         private void UploadTileTexture((int cellSize, int x, int y) key, SystemDrawing.Bitmap bmp)
         {
             var sk = SkiaBitmapUtil.ToSKBitmap(bmp);
-            lock (_textureLock)
+            lock (_masterCacheLock)
             {
                 if (_tileTextures.TryGetValue(key, out var old))
                     old.Dispose();
@@ -652,7 +651,7 @@ namespace StrategyGame
                     oldBmp.Dispose();
                     _tileCache.Remove(oldest);
                 }
-                lock (_textureLock)
+                lock (_masterCacheLock)
                 {
                     if (_tileTextures.TryGetValue(oldest, out var tex))
                     {

--- a/MultiResolutionMapManager.cs
+++ b/MultiResolutionMapManager.cs
@@ -51,7 +51,6 @@ namespace StrategyGame
         // LRU order for tile cache entries
         private readonly LinkedList<(int cellSize, int x, int y)> _tileLru = new();
         private readonly object _masterCacheLock = new();
-        private readonly object _assembleLock = new();
         private readonly Dictionary<(int cellSize, int x, int y), SKBitmap> _tileTextures = new();
 
         public static readonly bool GpuAvailable;
@@ -320,21 +319,19 @@ namespace StrategyGame
         /// </summary>
         public SKBitmap AssembleView(float zoom, System.Drawing.Rectangle viewArea, Action triggerRefresh = null)
         {
-            lock (_assembleLock)
-            {
-                int cellSize = GetCellSize(zoom);
-                int tileSize = TileSizePx;
+            int cellSize = GetCellSize(zoom);
+            int tileSize = TileSizePx;
 
-                if (viewArea.Width <= 0 || viewArea.Height <= 0 || cellSize <= 0)
-                    return new SKBitmap(1, 1); // Safe fallback
+            if (viewArea.Width <= 0 || viewArea.Height <= 0 || cellSize <= 0)
+                return new SKBitmap(1, 1); // Safe fallback
 
-                int tileStartX = Math.Max(0, viewArea.X / tileSize);
-                int tileStartY = Math.Max(0, viewArea.Y / tileSize);
-                int tileEndX = (viewArea.Right + tileSize - 1) / tileSize;
-                int tileEndY = (viewArea.Bottom + tileSize - 1) / tileSize;
+            int tileStartX = Math.Max(0, viewArea.X / tileSize);
+            int tileStartY = Math.Max(0, viewArea.Y / tileSize);
+            int tileEndX = (viewArea.Right + tileSize - 1) / tileSize;
+            int tileEndY = (viewArea.Bottom + tileSize - 1) / tileSize;
 
-                var info = new SKImageInfo(viewArea.Width, viewArea.Height);
-                var context = GpuAvailable ? SharedContext : null;
+            var info = new SKImageInfo(viewArea.Width, viewArea.Height);
+            var context = GpuAvailable ? SharedContext : null;
                 using var surface = context != null ? SKSurface.Create(context, false, info) : SKSurface.Create(info);
                 var canvas = surface.Canvas;
                 canvas.Clear(SKColors.DarkGray);
@@ -414,7 +411,6 @@ namespace StrategyGame
                 var result = new SKBitmap(info);
                 surface.ReadPixels(result.Info, result.GetPixels(), result.RowBytes, 0, 0);
                 return result;
-            }
         }
 
         private static void OverlayFeatures(SystemDrawing.Bitmap bmp, ZoomLevel level)

--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using System.Threading;
 using NetTopologySuite.IO;
 using NetTopologySuite.Index.Quadtree;
+using System.Windows.Forms;
 
 namespace StrategyGame
 {
@@ -259,7 +260,12 @@ namespace StrategyGame
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[Error] Failed to serialize CityDataModel: {ex.Message}");
+                string errorMessage = $"Failed to save city model file for hash {hash}.\n\n" +
+                                      $"Error: {ex.GetType().Name}\n\n" +
+                                      $"Message: {ex.Message}\n\n" +
+                                      $"Stack Trace:\n{ex.StackTrace}";
+                MessageBox.Show(errorMessage, "Critical Save Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                Console.WriteLine($"[CRITICAL ERROR] Failed to serialize CityDataModel: {errorMessage}");
             }
 
             modelCache[hash] = result;

--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -45,14 +45,14 @@ namespace StrategyGame
         }
 
 
-        private static void SaveModelBinary(string path, CityDataModel model)
+        private static async Task SaveModelBinaryAsync(string path, CityDataModel model)
         {
             var fileLock = GetFileLock(path);
-            fileLock.Wait();
+            await fileLock.WaitAsync();
             try
             {
                 var wkbWriter = new WKBWriter();
-                using var fs = File.Open(path, FileMode.Create);
+                using var fs = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None, 4096, true);
                 using var bw = new BinaryWriter(fs);
 
                 bw.Write(model.Id.ToByteArray());
@@ -116,15 +116,16 @@ namespace StrategyGame
             }
         }
 
-        private static CityDataModel LoadModelBinary(string path)
+        private static async Task<CityDataModel> LoadModelBinaryAsync(string path)
         {
             var fileLock = GetFileLock(path);
-            fileLock.Wait();
+            await fileLock.WaitAsync();
             try
             {
                 var wkbReader = new WKBReader();
-                using var fs = File.OpenRead(path);
-                using var br = new BinaryReader(fs);
+                byte[] fileBytes = await File.ReadAllBytesAsync(path);
+                using var ms = new MemoryStream(fileBytes);
+                using var br = new BinaryReader(ms);
 
             var model = new CityDataModel();
             model.Id = new Guid(br.ReadBytes(16));
@@ -213,7 +214,7 @@ namespace StrategyGame
                     string modelPath = Path.Combine(cacheDir, $"{id}.bin");
                     if (File.Exists(modelPath))
                     {
-                        var loaded = LoadModelBinary(modelPath);
+                        var loaded = await LoadModelBinaryAsync(modelPath);
                         modelCache[hash] = loaded;
                         return loaded;
                     }
@@ -253,7 +254,7 @@ namespace StrategyGame
             try
             {
                 string modelPath = Path.Combine(cacheDir, $"{result.Id}.bin");
-                SaveModelBinary(modelPath, result);
+                await SaveModelBinaryAsync(modelPath, result);
                 await File.WriteAllTextAsync(hashPath, result.Id.ToString()).ConfigureAwait(false);
             }
             catch (Exception ex)
@@ -601,7 +602,7 @@ namespace StrategyGame
 
             try
             {
-                return LoadModelBinary(modelPath);
+                return LoadModelBinaryAsync(modelPath).GetAwaiter().GetResult();
             }
             catch (Exception ex)
             {

--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Threading;
 using NetTopologySuite.IO;
 using NetTopologySuite.Index.Quadtree;
 
@@ -19,6 +20,8 @@ namespace StrategyGame
     {
         private static readonly ConcurrentDictionary<string, List<(Nts.LineString Line, RoadType Type)>> networkCache = new();
         private static readonly ConcurrentDictionary<string, CityDataModel> modelCache = new();
+        private static readonly object _fileLockDictLock = new();
+        private static readonly Dictionary<string, SemaphoreSlim> _fileLocks = new();
 
         public static CityGenerationData? Data { get; set; }
 
@@ -28,14 +31,31 @@ namespace StrategyGame
             double.IsNaN(c.X) || double.IsNaN(c.Y) ||
             double.IsInfinity(c.X) || double.IsInfinity(c.Y);
 
+        private static SemaphoreSlim GetFileLock(string path)
+        {
+            lock (_fileLockDictLock)
+            {
+                if (!_fileLocks.TryGetValue(path, out var sem))
+                {
+                    sem = new SemaphoreSlim(1, 1);
+                    _fileLocks[path] = sem;
+                }
+                return sem;
+            }
+        }
+
 
         private static void SaveModelBinary(string path, CityDataModel model)
         {
-            var wkbWriter = new WKBWriter();
-            using var fs = File.Open(path, FileMode.Create);
-            using var bw = new BinaryWriter(fs);
+            var fileLock = GetFileLock(path);
+            fileLock.Wait();
+            try
+            {
+                var wkbWriter = new WKBWriter();
+                using var fs = File.Open(path, FileMode.Create);
+                using var bw = new BinaryWriter(fs);
 
-            bw.Write(model.Id.ToByteArray());
+                bw.Write(model.Id.ToByteArray());
 
             if (model.UrbanArea != null)
             {
@@ -77,25 +97,34 @@ namespace StrategyGame
                 bw.Write(parcel.LandValue);
             }
 
-            bw.Write(model.Buildings.Count);
-            foreach (var building in model.Buildings)
+                bw.Write(model.Buildings.Count);
+                foreach (var building in model.Buildings)
+                {
+                    byte[] data = wkbWriter.Write(building.Footprint);
+                    bw.Write(data.Length);
+                    bw.Write(data);
+                    bw.Write((int)building.LandUse);
+                    bw.Write(building.Level);
+                    bw.Write(building.PopulationCapacity);
+                    bw.Write(building.EconomicOutput);
+                    bw.Write(building.PollutionOutput);
+                }
+            }
+            finally
             {
-                byte[] data = wkbWriter.Write(building.Footprint);
-                bw.Write(data.Length);
-                bw.Write(data);
-                bw.Write((int)building.LandUse);
-                bw.Write(building.Level);
-                bw.Write(building.PopulationCapacity);
-                bw.Write(building.EconomicOutput);
-                bw.Write(building.PollutionOutput);
+                fileLock.Release();
             }
         }
 
         private static CityDataModel LoadModelBinary(string path)
         {
-            var wkbReader = new WKBReader();
-            using var fs = File.OpenRead(path);
-            using var br = new BinaryReader(fs);
+            var fileLock = GetFileLock(path);
+            fileLock.Wait();
+            try
+            {
+                var wkbReader = new WKBReader();
+                using var fs = File.OpenRead(path);
+                using var br = new BinaryReader(fs);
 
             var model = new CityDataModel();
             model.Id = new Guid(br.ReadBytes(16));
@@ -159,7 +188,12 @@ namespace StrategyGame
                 });
             }
 
-            return model;
+                return model;
+            }
+            finally
+            {
+                fileLock.Release();
+            }
         }
 
         public static async Task<CityDataModel> GenerateModelAsync(Nts.Polygon urbanArea, int cellSize)


### PR DESCRIPTION
## Summary
- store both SKBitmap and the underlying GDI+ Bitmap in `CityTileManager`'s cache
- update `AddToCache` and tile loading logic to manage tuples
- avoid disposing the source `Bitmap` while its `SKBitmap` is in use

## Testing
- `dotnet restore "economy sim.csproj"` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet build "economy sim.sln" -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_687637b4a194832396acb87277d423e7