### PR TITLE
Improve road rendering performance

### DIFF
--- a/Building.cs
+++ b/Building.cs
@@ -5,6 +5,8 @@ namespace StrategyGame
     public class Building
     {
         public Nts.Polygon Footprint { get; set; }
+        // A simplified version of the footprint used for rendering
+        public Nts.Geometry? SimplifiedFootprint { get; set; }
         public LandUseType LandUse { get; set; }
 
         // Fields used by the BuildingRefiner

--- a/CityDataModel.cs
+++ b/CityDataModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Nts = NetTopologySuite.Geometries;
+using NetTopologySuite.Index.Strtree;
 
 namespace StrategyGame
 {
@@ -12,5 +13,8 @@ namespace StrategyGame
         public List<Nts.Polygon> RawBlocks { get; set; } = new();
         public List<Parcel> Parcels { get; set; } = new();
         public List<Building> Buildings { get; set; } = new();
+
+        // Spatial index of buildings for faster tile queries
+        public STRtree<Building>? BuildingIndex { get; set; }
     }
 }

--- a/CityModelCache.cs
+++ b/CityModelCache.cs
@@ -1,0 +1,53 @@
+using SixLabors.ImageSharp.Drawing;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace StrategyGame
+{
+    internal static class CityModelCache
+    {
+        private static readonly ConcurrentDictionary<(Guid modelId, int cellSize), CachedRoads> _roads = new();
+
+        public static CachedRoads GetOrAddRoads(Guid modelId, int cellSize, IEnumerable<LineSegment> rawRoads, GeoBounds bounds)
+        {
+            return _roads.GetOrAdd((modelId, cellSize), _ =>
+            {
+                var tileBox = new NetTopologySuite.Geometries.Envelope(bounds.MinLon, bounds.MaxLon, bounds.MinLat, bounds.MaxLat);
+                var clipped = rawRoads.Where(r =>
+                {
+                    double minX = Math.Min(r.X1, r.X2);
+                    double maxX = Math.Max(r.X1, r.X2);
+                    double minY = Math.Min(r.Y1, r.Y2);
+                    double maxY = Math.Max(r.Y1, r.Y2);
+                    return !(maxX < tileBox.MinX || minX > tileBox.MaxX || maxY < tileBox.MinY || minY > tileBox.MaxY);
+                });
+
+                var simplified = ProceduralCityRenderer.SimplifyRoads(clipped, bounds).ToList();
+
+                var primaryBuilder = new PathBuilder();
+                var secondaryBuilder = new PathBuilder();
+                foreach (var seg in simplified)
+                {
+                    var pb = seg.Type == RoadType.Primary ? primaryBuilder : secondaryBuilder;
+                    pb.AddLine(
+                        ProceduralCityRenderer.ToPointF(seg.X1, seg.Y1, bounds),
+                        ProceduralCityRenderer.ToPointF(seg.X2, seg.Y2, bounds));
+                }
+
+                return new CachedRoads
+                {
+                    SecondaryPath = secondaryBuilder.Build(),
+                    PrimaryPath = primaryBuilder.Build()
+                };
+            });
+        }
+
+        internal class CachedRoads
+        {
+            public IPath SecondaryPath { get; init; }
+            public IPath PrimaryPath { get; init; }
+        }
+    }
+}

--- a/CityModelCache.cs
+++ b/CityModelCache.cs
@@ -1,3 +1,4 @@
+using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Drawing;
 using System;
 using System.Collections.Concurrent;
@@ -9,6 +10,7 @@ namespace StrategyGame
     internal static class CityModelCache
     {
         private static readonly ConcurrentDictionary<(Guid modelId, int cellSize), CachedRoads> _roads = new();
+        private static readonly ConcurrentDictionary<(Guid modelId, int cellSize, double minLon, double minLat, double maxLon, double maxLat), CachedBuildings> _buildings = new();
 
         public static CachedRoads GetOrAddRoads(Guid modelId, int cellSize, IEnumerable<LineSegment> rawRoads, GeoBounds bounds)
         {
@@ -44,10 +46,35 @@ namespace StrategyGame
             });
         }
 
+        public static CachedBuildings GetOrAddBuildings(Guid modelId, int cellSize, GeoBounds bounds, IEnumerable<(NetTopologySuite.Geometries.Polygon Poly, LandUseType Use)> buildings)
+        {
+            var key = (modelId, cellSize, bounds.MinLon, bounds.MinLat, bounds.MaxLon, bounds.MaxLat);
+            return _buildings.GetOrAdd(key, _ =>
+            {
+                var dict = new Dictionary<Rgba32, IPath>();
+                foreach (var group in buildings.GroupBy(b => ProceduralCityRenderer.GetBuildingColor(b.Use)))
+                {
+                    var pb = new PathBuilder();
+                    foreach (var item in group)
+                    {
+                        pb.AddPolygon(new Polygon(new LinearLineSegment(item.Poly.ExteriorRing.Coordinates.Select(c => ProceduralCityRenderer.ToPointF(c.X, c.Y, bounds)).ToArray())));
+                    }
+                    dict[group.Key] = pb.Build();
+                }
+
+                return new CachedBuildings { PathsByColor = dict };
+            });
+        }
+
         internal class CachedRoads
         {
             public IPath SecondaryPath { get; init; }
             public IPath PrimaryPath { get; init; }
+        }
+
+        internal class CachedBuildings
+        {
+            public Dictionary<Rgba32, IPath> PathsByColor { get; init; } = new();
         }
     }
 }

--- a/CityModelCache.cs
+++ b/CityModelCache.cs
@@ -1,5 +1,6 @@
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Drawing;
+using SixLabors.ImageSharp.PixelFormats;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -57,9 +58,11 @@ namespace StrategyGame
                     var pb = new PathBuilder();
                     foreach (var item in group)
                     {
-                        pb.AddPolygon(new Polygon(new LinearLineSegment(item.Poly.ExteriorRing.Coordinates.Select(c => ProceduralCityRenderer.ToPointF(c.X, c.Y, bounds)).ToArray())));
+                        var points = item.Poly.ExteriorRing.Coordinates.Select(c => ProceduralCityRenderer.ToPointF(c.X, c.Y, bounds)).ToArray();
+                        pb.AddLines(points);
+                        pb.CloseFigure();
                     }
-                    dict[group.Key] = pb.Build();
+                    dict[(Rgba32)group.Key] = pb.Build();
                 }
 
                 return new CachedBuildings { PathsByColor = dict };

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -153,7 +153,6 @@ namespace economy_sim
             panelMap.MouseWheel += PanelMap_MouseWheel;
             mapUpdateTimer = new System.Windows.Forms.Timer { Interval = 40 };
             mapUpdateTimer.Tick += MapUpdateTimer_Tick;
-            mapUpdateTimer.Start();
             playerRoleManager = new PlayerRoleManager();
             allCitiesInWorld = new List<StrategyGame.City>();
             allCountries = new List<StrategyGame.Country>();
@@ -288,6 +287,11 @@ namespace economy_sim
 
             pictureBox1.Size = panelMap.ClientSize;
             pictureBox1.Location = new SD.Point(0, 0);
+
+            if (!mapUpdateTimer.Enabled)
+            {
+                mapUpdateTimer.Start();
+            }
         }
 
        
@@ -2383,7 +2387,12 @@ namespace economy_sim
 
         private async Task PreloadMapTilesAsync()
         {
-            if (mapManager == null) return;
+            if (mapManager == null || cityTileManager == null)
+            {
+                RefreshMap();
+                if (mapManager == null || cityTileManager == null)
+                    return;
+            }
 
             SD.Rectangle view;
             float zoom;
@@ -2409,6 +2418,14 @@ namespace economy_sim
 
             try
             {
+                if (mapManager == null || cityTileManager == null)
+                {
+                    RefreshMap();
+                    if (mapManager == null || cityTileManager == null)
+                    {
+                        return;
+                    }
+                }
                 await PreloadMapTilesAsync();
 
                 SD.Rectangle view;

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -24,7 +24,6 @@ namespace StrategyGame
             var img = new Image<Rgba32>(MultiResolutionMapManager.TileSizePx, MultiResolutionMapManager.TileSizePx, new Rgba32(0, 0, 0, 0));
             var tilePoly = ToPolygon(tileBounds);
 
-            var allBuildingsToDraw = new List<(Nts.Polygon Poly, LandUseType Use)>();
             var processedModelIds = new HashSet<Guid>();
             
             var relevantUrbanAreas = UrbanAreaManager.Query(tileBounds);
@@ -48,45 +47,46 @@ namespace StrategyGame
 
                 DrawRoads(img, modelId.Value, model.RoadNetwork, tileBounds, cellSize);
                 
-                // Process building geometry in parallel
-                var buildingGeoms = model.Buildings
-                    .AsParallel()
-                    .Select(b => new { b.LandUse, Visible = b.Footprint.Intersection(tilePoly) })
-                    .Where(b => b.Visible != null && !b.Visible.IsEmpty)
-                    .ToList();
-
-                foreach(var b in buildingGeoms)
+                // Query visible buildings using the model's spatial index
+                var tileEnv = tilePoly.EnvelopeInternal;
+                var candidates = (model.BuildingIndex?.Query(tileEnv).Cast<Building>() ?? model.Buildings);
+                var toDraw = new List<(Nts.Polygon, LandUseType)>();
+                foreach (var b in candidates)
                 {
-                    if (b.Visible is Nts.Polygon p) lock (allBuildingsToDraw) allBuildingsToDraw.Add((p, b.LandUse));
-                    else if (b.Visible is Nts.MultiPolygon mp)
+                    var env = b.Footprint.EnvelopeInternal;
+                    if (!env.Intersects(tileEnv)) continue;
+                    var baseGeom = b.SimplifiedFootprint ?? b.Footprint;
+                    Nts.Geometry clipped = tileEnv.Contains(env)
+                        ? baseGeom
+                        : baseGeom.Intersection(tilePoly);
+
+                    if (clipped is Nts.Polygon p && !p.IsEmpty)
+                        toDraw.Add((p, b.LandUse));
+                    else if (clipped is Nts.MultiPolygon mp)
                     {
                         for (int i = 0; i < mp.NumGeometries; i++)
-                            if (mp.GetGeometryN(i) is Nts.Polygon pp) lock (allBuildingsToDraw) allBuildingsToDraw.Add((pp, b.LandUse));
+                            if (mp.GetGeometryN(i) is Nts.Polygon pp && !pp.IsEmpty)
+                                toDraw.Add((pp, b.LandUse));
                     }
                 }
+
+                DrawBuildings(img, modelId.Value, toDraw, tileBounds, cellSize);
             }
 
-            // Call the optimized, batched drawing methods
-            DrawBuildings(img, allBuildingsToDraw, tileBounds);
-            
             return img;
         }
-        
-        // Batched building drawing
-        private static void DrawBuildings(Image<Rgba32> img, List<(Nts.Polygon Poly, LandUseType Use)> buildings, GeoBounds bounds)
+
+        // Batched building drawing with caching
+        private static void DrawBuildings(Image<Rgba32> img, Guid modelId, List<(Nts.Polygon Poly, LandUseType Use)> buildings, GeoBounds bounds, int cellSize)
         {
             var sw = Stopwatch.StartNew();
-            var buildingsByColor = buildings.GroupBy(b => GetBuildingColor(b.Use));
+            var cached = CityModelCache.GetOrAddBuildings(modelId, cellSize, bounds, buildings);
 
             img.Mutate(ctx =>
             {
-                foreach (var group in buildingsByColor)
+                foreach (var kvp in cached.PathsByColor)
                 {
-                    var color = group.Key;
-                    var paths = new PathCollection(group.Select(item =>
-                        new Polygon(new LinearLineSegment(item.Poly.ExteriorRing.Coordinates.Select(c => ToPointF(c.X, c.Y, bounds)).ToArray()))
-                    ));
-                    ctx.Fill(color, paths);
+                    ctx.Fill(kvp.Key, kvp.Value);
                 }
             });
             PerformanceTracker.Record("CityRenderer-BuildingRendering", sw.Elapsed);
@@ -153,6 +153,6 @@ namespace StrategyGame
                 (float)((lon - b.MinLon) / (b.MaxLon - b.MinLon) * MultiResolutionMapManager.TileSizePx),
                 (float)((b.MaxLat - lat) / (b.MaxLat - b.MinLat) * MultiResolutionMapManager.TileSizePx));
         private static Nts.Polygon ToPolygon(GeoBounds b) => new Nts.Polygon(new Nts.LinearRing(new[] { new Nts.Coordinate(b.MinLon, b.MinLat), new Nts.Coordinate(b.MaxLon, b.MinLat), new Nts.Coordinate(b.MaxLon, b.MaxLat), new Nts.Coordinate(b.MinLon, b.MaxLat), new Nts.Coordinate(b.MinLon, b.MinLat) }));
-        private static Rgba32 GetBuildingColor(LandUseType use) => use switch { LandUseType.Commercial => new Rgba32(200, 50, 50, 180), LandUseType.Residential => new Rgba32(50, 50, 200, 180), LandUseType.Industrial => new Rgba32(120, 120, 120, 180), _ => new Rgba32(60, 160, 60, 180) };
+        internal static Rgba32 GetBuildingColor(LandUseType use) => use switch { LandUseType.Commercial => new Rgba32(200, 50, 50, 180), LandUseType.Residential => new Rgba32(50, 50, 200, 180), LandUseType.Industrial => new Rgba32(120, 120, 120, 180), _ => new Rgba32(60, 160, 60, 180) };
     }
 }

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -3,12 +3,14 @@ using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Drawing.Processing;
+using NetTopologySuite.Simplify;
 using System.Linq;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using SixLabors.ImageSharp.Drawing;
+using economy_sim;
 
 namespace StrategyGame
 {
@@ -61,7 +63,7 @@ namespace StrategyGame
 
             // Call the optimized, batched drawing methods
             DrawBuildings(img, allBuildingsToDraw, tileBounds);
-            DrawRoads(img, allRoadsToDraw, tileBounds);
+            DrawRoads(img, allRoadsToDraw, tileBounds, cellSize);
             
             return img;
         }
@@ -87,9 +89,50 @@ namespace StrategyGame
         }
 
         // Batched road drawing
-        private static void DrawRoads(Image<Rgba32> img, IEnumerable<LineSegment> roads, GeoBounds bounds)
+        private static IEnumerable<LineSegment> SimplifyRoads(IEnumerable<LineSegment> roads, GeoBounds bounds)
+        {
+            double tolerance = (bounds.MaxLon - bounds.MinLon) / MultiResolutionMapManager.TileSizePx * 2.0;
+
+            var gf = Nts.GeometryFactory.Default;
+            foreach (var group in roads.GroupBy(r => r.Type))
+            {
+                var lineStrings = group.Select(s =>
+                    gf.CreateLineString(new[]
+                    {
+                        new Nts.Coordinate(s.X1, s.Y1),
+                        new Nts.Coordinate(s.X2, s.Y2)
+                    })).ToArray();
+
+                if (lineStrings.Length == 0) continue;
+
+                var multi = gf.CreateMultiLineString(lineStrings);
+                var simplified = NetTopologySuite.Simplify.DouglasPeuckerSimplifier.Simplify(multi, tolerance) as Nts.MultiLineString;
+                if (simplified == null) continue;
+
+                for (int i = 0; i < simplified.NumGeometries; i++)
+                {
+                    if (simplified.GetGeometryN(i) is Nts.LineString ln)
+                    {
+                        for (int j = 0; j < ln.NumPoints - 1; j++)
+                        {
+                            var c1 = ln.GetCoordinateN(j);
+                            var c2 = ln.GetCoordinateN(j + 1);
+                            yield return new LineSegment(c1.X, c1.Y, c2.X, c2.Y, group.Key);
+                        }
+                    }
+                }
+            }
+        }
+
+        private static void DrawRoads(Image<Rgba32> img, IEnumerable<LineSegment> roads, GeoBounds bounds, int cellSize)
         {
             var sw = Stopwatch.StartNew();
+            if (cellSize <= 40)
+            {
+                roads = roads.Where(r => r.Type == RoadType.Primary);
+            }
+
+            roads = SimplifyRoads(roads, bounds).ToList();
             var primaryPathBuilder = new PathBuilder();
             var secondaryPathBuilder = new PathBuilder();
             foreach (var seg in roads)
@@ -98,8 +141,8 @@ namespace StrategyGame
                 pathBuilder.AddLine(ToPointF(seg.X1, seg.Y1, bounds), ToPointF(seg.X2, seg.Y2, bounds));
             }
 
-            var primaryPen = Pens.Solid(new Rgba32(180, 180, 180, 200), 2f);
-            var secondaryPen = Pens.Solid(new Rgba32(180, 180, 180, 200), 1f);
+            var primaryPen = SixLabors.ImageSharp.Drawing.Processing.Pens.Solid(new Rgba32(180, 180, 180, 200), 2f);
+            var secondaryPen = SixLabors.ImageSharp.Drawing.Processing.Pens.Solid(new Rgba32(180, 180, 180, 200), 1f);
 
             img.Mutate(ctx => ctx
                 .Draw(secondaryPen, secondaryPathBuilder.Build())
@@ -108,7 +151,10 @@ namespace StrategyGame
             PerformanceTracker.Record("CityRenderer-RoadDrawing", sw.Elapsed);
         }
 
-        private static PointF ToPointF(double lon, double lat, GeoBounds b) => new PointF((float)((lon - b.MinLon) / (b.MaxLon - b.MinLon) * MultiResolutionMapManager.TileSizePx), (float)((b.MaxLat - lat) / (b.MaxLat - b.MinLat) * MultiResolutionMapManager.TileSizePx));
+        private static SixLabors.ImageSharp.PointF ToPointF(double lon, double lat, GeoBounds b) =>
+            new SixLabors.ImageSharp.PointF(
+                (float)((lon - b.MinLon) / (b.MaxLon - b.MinLon) * MultiResolutionMapManager.TileSizePx),
+                (float)((b.MaxLat - lat) / (b.MaxLat - b.MinLat) * MultiResolutionMapManager.TileSizePx));
         private static Nts.Polygon ToPolygon(GeoBounds b) => new Nts.Polygon(new Nts.LinearRing(new[] { new Nts.Coordinate(b.MinLon, b.MinLat), new Nts.Coordinate(b.MaxLon, b.MinLat), new Nts.Coordinate(b.MaxLon, b.MaxLat), new Nts.Coordinate(b.MinLon, b.MaxLat), new Nts.Coordinate(b.MinLon, b.MinLat) }));
         private static Rgba32 GetBuildingColor(LandUseType use) => use switch { LandUseType.Commercial => new Rgba32(200, 50, 50, 180), LandUseType.Residential => new Rgba32(50, 50, 200, 180), LandUseType.Industrial => new Rgba32(120, 120, 120, 180), _ => new Rgba32(60, 160, 60, 180) };
     }

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -7,6 +7,7 @@ using NetTopologySuite.Simplify;
 using System.Linq;
 using System;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using SixLabors.ImageSharp.Drawing;
@@ -16,6 +17,7 @@ namespace StrategyGame
 {
     public static class ProceduralCityRenderer
     {
+        private static readonly ConcurrentDictionary<Guid, CityDataModel> _modelCache = new();
         // This method is now async to support awaiting the data model.
         public static async Task<Image<Rgba32>> RenderCityTileAsync(GeoBounds tileBounds, int cellSize)
         {
@@ -23,7 +25,6 @@ namespace StrategyGame
             var tilePoly = ToPolygon(tileBounds);
 
             var allBuildingsToDraw = new List<(Nts.Polygon Poly, LandUseType Use)>();
-            var allRoadsToDraw = new List<LineSegment>();
             var processedModelIds = new HashSet<Guid>();
             
             var relevantUrbanAreas = UrbanAreaManager.Query(tileBounds);
@@ -31,17 +32,21 @@ namespace StrategyGame
             // This loop now awaits the new async methods, preventing deadlocks.
             foreach (var urban in relevantUrbanAreas)
             {
-                if (!urban.EnvelopeInternal.Intersects(tilePoly.EnvelopeInternal) || !urban.Intersects(tilePoly)) continue;
+                if (!urban.EnvelopeInternal.Intersects(tilePoly.EnvelopeInternal) || !urban.Intersects(tilePoly))
+                    continue;
 
-                // Use the new async GetCityDataModelIdAsync
                 var modelId = await RoadNetworkGenerator.GetCityDataModelIdAsync(urban).ConfigureAwait(false);
-                if (!modelId.HasValue || !processedModelIds.Add(modelId.Value)) continue;
-                
-                // Use the new async LoadCityDataModelAsync
-                var model = await RoadNetworkGenerator.LoadCityDataModelAsync(modelId.Value).ConfigureAwait(false);
-                if (model == null) continue;
+                if (!modelId.HasValue || !processedModelIds.Add(modelId.Value))
+                    continue;
 
-                allRoadsToDraw.AddRange(model.RoadNetwork);
+                if (!_modelCache.TryGetValue(modelId.Value, out var model))
+                {
+                    model = await RoadNetworkGenerator.LoadCityDataModelAsync(modelId.Value).ConfigureAwait(false);
+                    if (model == null) continue;
+                    _modelCache[modelId.Value] = model;
+                }
+
+                DrawRoads(img, modelId.Value, model.RoadNetwork, tileBounds, cellSize);
                 
                 // Process building geometry in parallel
                 var buildingGeoms = model.Buildings
@@ -63,7 +68,6 @@ namespace StrategyGame
 
             // Call the optimized, batched drawing methods
             DrawBuildings(img, allBuildingsToDraw, tileBounds);
-            DrawRoads(img, allRoadsToDraw, tileBounds, cellSize);
             
             return img;
         }
@@ -89,7 +93,7 @@ namespace StrategyGame
         }
 
         // Batched road drawing
-        private static IEnumerable<LineSegment> SimplifyRoads(IEnumerable<LineSegment> roads, GeoBounds bounds)
+        internal static IEnumerable<LineSegment> SimplifyRoads(IEnumerable<LineSegment> roads, GeoBounds bounds)
         {
             double tolerance = (bounds.MaxLon - bounds.MinLon) / MultiResolutionMapManager.TileSizePx * 2.0;
 
@@ -124,7 +128,7 @@ namespace StrategyGame
             }
         }
 
-        private static void DrawRoads(Image<Rgba32> img, IEnumerable<LineSegment> roads, GeoBounds bounds, int cellSize)
+        private static void DrawRoads(Image<Rgba32> img, Guid modelId, IEnumerable<LineSegment> roads, GeoBounds bounds, int cellSize)
         {
             var sw = Stopwatch.StartNew();
             if (cellSize <= 40)
@@ -132,26 +136,19 @@ namespace StrategyGame
                 roads = roads.Where(r => r.Type == RoadType.Primary);
             }
 
-            roads = SimplifyRoads(roads, bounds).ToList();
-            var primaryPathBuilder = new PathBuilder();
-            var secondaryPathBuilder = new PathBuilder();
-            foreach (var seg in roads)
-            {
-                var pathBuilder = seg.Type == RoadType.Primary ? primaryPathBuilder : secondaryPathBuilder;
-                pathBuilder.AddLine(ToPointF(seg.X1, seg.Y1, bounds), ToPointF(seg.X2, seg.Y2, bounds));
-            }
+            var cached = CityModelCache.GetOrAddRoads(modelId, cellSize, roads, bounds);
 
             var primaryPen = SixLabors.ImageSharp.Drawing.Processing.Pens.Solid(new Rgba32(180, 180, 180, 200), 2f);
             var secondaryPen = SixLabors.ImageSharp.Drawing.Processing.Pens.Solid(new Rgba32(180, 180, 180, 200), 1f);
 
             img.Mutate(ctx => ctx
-                .Draw(secondaryPen, secondaryPathBuilder.Build())
-                .Draw(primaryPen, primaryPathBuilder.Build())
+                .Draw(secondaryPen, cached.SecondaryPath)
+                .Draw(primaryPen, cached.PrimaryPath)
             );
             PerformanceTracker.Record("CityRenderer-RoadDrawing", sw.Elapsed);
         }
 
-        private static SixLabors.ImageSharp.PointF ToPointF(double lon, double lat, GeoBounds b) =>
+        internal static SixLabors.ImageSharp.PointF ToPointF(double lon, double lat, GeoBounds b) =>
             new SixLabors.ImageSharp.PointF(
                 (float)((lon - b.MinLon) / (b.MaxLon - b.MinLon) * MultiResolutionMapManager.TileSizePx),
                 (float)((b.MaxLat - lat) / (b.MaxLat - b.MinLat) * MultiResolutionMapManager.TileSizePx));

--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -13,6 +13,8 @@ using System.Threading.Tasks;
 using System.Threading;
 using NetTopologySuite.IO;
 using NetTopologySuite.Index.Quadtree;
+using NetTopologySuite.Index.Strtree;
+using NetTopologySuite.Simplify;
 using System.Windows.Forms;
 
 namespace StrategyGame
@@ -22,6 +24,19 @@ namespace StrategyGame
         private static readonly ConcurrentDictionary<string, List<(Nts.LineString Line, RoadType Type)>> networkCache = new();
         private static readonly ConcurrentDictionary<string, CityDataModel> modelCache = new();
         private static readonly ConcurrentDictionary<string, SemaphoreSlim> _fileLocks = new();
+
+        private static void BuildBuildingStructures(CityDataModel model)
+        {
+            const double tol = 0.0001; // degrees ~10m
+            var index = new STRtree<Building>();
+            foreach (var b in model.Buildings)
+            {
+                b.SimplifiedFootprint = DouglasPeuckerSimplifier.Simplify(b.Footprint, tol);
+                index.Insert(b.Footprint.EnvelopeInternal, b);
+            }
+            index.Build();
+            model.BuildingIndex = index;
+        }
 
         public static CityGenerationData? Data { get; set; }
 
@@ -181,7 +196,9 @@ namespace StrategyGame
                 });
             }
 
-                return model;
+            BuildBuildingStructures(model);
+
+            return model;
             }
             finally
             {
@@ -240,6 +257,7 @@ namespace StrategyGame
             LandUseSimulator.Run(result);
             result.Buildings = BuildingGenerator.GenerateBuildings(result);
             BuildingRefiner.RefineBuildings(result);
+            BuildBuildingStructures(result);
 
             Debug.WriteLine($">> Generated {result.Parcels.Count} parcels, {result.Buildings.Count} buildings for {hash}");
 


### PR DESCRIPTION
## Summary
- simplify road segments with Douglas–Peucker
- hide secondary roads when zoomed out
- fix ambiguous types and add missing using statements

## Testing
- `dotnet build "economy sim.sln" -v minimal -p:EnableWindowsTargeting=true`

------
https://chatgpt.com/codex/tasks/task_e_6879ffb909dc8323b7ceaa540e4455bf