### PR TITLE
Improve city tile rendering performance

### DIFF
--- a/CityModelCache.cs
+++ b/CityModelCache.cs
@@ -10,12 +10,13 @@ namespace StrategyGame
 {
     internal static class CityModelCache
     {
-        private static readonly ConcurrentDictionary<(Guid modelId, int cellSize), CachedRoads> _roads = new();
-        private static readonly ConcurrentDictionary<(Guid modelId, int cellSize, double minLon, double minLat, double maxLon, double maxLat), CachedBuildings> _buildings = new();
+        private static readonly ConcurrentDictionary<(int cellSize, double minLon, double minLat, double maxLon, double maxLat), CachedRoads> _roads = new();
+        private static readonly ConcurrentDictionary<(int cellSize, double minLon, double minLat, double maxLon, double maxLat), CachedBuildings> _buildings = new();
 
-        public static CachedRoads GetOrAddRoads(Guid modelId, int cellSize, IEnumerable<LineSegment> rawRoads, GeoBounds bounds)
+        public static CachedRoads GetOrAddRoads(int cellSize, GeoBounds bounds, IEnumerable<LineSegment> rawRoads)
         {
-            return _roads.GetOrAdd((modelId, cellSize), _ =>
+            var key = (cellSize, bounds.MinLon, bounds.MinLat, bounds.MaxLon, bounds.MaxLat);
+            return _roads.GetOrAdd(key, _ =>
             {
                 var tileBox = new NetTopologySuite.Geometries.Envelope(bounds.MinLon, bounds.MaxLon, bounds.MinLat, bounds.MaxLat);
                 var clipped = rawRoads.Where(r =>
@@ -47,9 +48,9 @@ namespace StrategyGame
             });
         }
 
-        public static CachedBuildings GetOrAddBuildings(Guid modelId, int cellSize, GeoBounds bounds, IEnumerable<(NetTopologySuite.Geometries.Polygon Poly, LandUseType Use)> buildings)
+        public static CachedBuildings GetOrAddBuildings(int cellSize, GeoBounds bounds, IEnumerable<(NetTopologySuite.Geometries.Polygon Poly, LandUseType Use)> buildings)
         {
-            var key = (modelId, cellSize, bounds.MinLon, bounds.MinLat, bounds.MaxLon, bounds.MaxLat);
+            var key = (cellSize, bounds.MinLon, bounds.MinLat, bounds.MaxLon, bounds.MaxLat);
             return _buildings.GetOrAdd(key, _ =>
             {
                 var dict = new Dictionary<Rgba32, IPath>();

--- a/CityModelCache.cs
+++ b/CityModelCache.cs
@@ -10,12 +10,13 @@ namespace StrategyGame
 {
     internal static class CityModelCache
     {
-        private static readonly ConcurrentDictionary<(Guid modelId, int cellSize), CachedRoads> _roads = new();
+        private static readonly ConcurrentDictionary<(Guid modelId, int cellSize, double minLon, double minLat, double maxLon, double maxLat), CachedRoads> _roads = new();
         private static readonly ConcurrentDictionary<(Guid modelId, int cellSize, double minLon, double minLat, double maxLon, double maxLat), CachedBuildings> _buildings = new();
 
         public static CachedRoads GetOrAddRoads(Guid modelId, int cellSize, IEnumerable<LineSegment> rawRoads, GeoBounds bounds)
         {
-            return _roads.GetOrAdd((modelId, cellSize), _ =>
+            var key = (modelId, cellSize, bounds.MinLon, bounds.MinLat, bounds.MaxLon, bounds.MaxLat);
+            return _roads.GetOrAdd(key, _ =>
             {
                 var tileBox = new NetTopologySuite.Geometries.Envelope(bounds.MinLon, bounds.MaxLon, bounds.MinLat, bounds.MaxLat);
                 var clipped = rawRoads.Where(r =>

--- a/CityModelCache.cs
+++ b/CityModelCache.cs
@@ -10,13 +10,13 @@ namespace StrategyGame
 {
     internal static class CityModelCache
     {
-        private static readonly ConcurrentDictionary<(Guid modelId, int cellSize, double minLon, double minLat, double maxLon, double maxLat), CachedRoads> _roads = new();
-        private static readonly ConcurrentDictionary<(Guid modelId, int cellSize, double minLon, double minLat, double maxLon, double maxLat), CachedBuildings> _buildings = new();
+        private static readonly ConcurrentDictionary<(int cellSize, double minLon, double minLat, double maxLon, double maxLat), CachedRoads> _roadTiles = new();
+        private static readonly ConcurrentDictionary<(int cellSize, double minLon, double minLat, double maxLon, double maxLat), CachedBuildings> _buildingTiles = new();
 
-        public static CachedRoads GetOrAddRoads(Guid modelId, int cellSize, IEnumerable<LineSegment> rawRoads, GeoBounds bounds)
+        public static CachedRoads GetOrAddRoads(int cellSize, GeoBounds bounds, IEnumerable<LineSegment> rawRoads)
         {
-            var key = (modelId, cellSize, bounds.MinLon, bounds.MinLat, bounds.MaxLon, bounds.MaxLat);
-            return _roads.GetOrAdd(key, _ =>
+            var key = (cellSize, bounds.MinLon, bounds.MinLat, bounds.MaxLon, bounds.MaxLat);
+            return _roadTiles.GetOrAdd(key, _ =>
             {
                 var tileBox = new NetTopologySuite.Geometries.Envelope(bounds.MinLon, bounds.MaxLon, bounds.MinLat, bounds.MaxLat);
                 var clipped = rawRoads.Where(r =>
@@ -48,10 +48,10 @@ namespace StrategyGame
             });
         }
 
-        public static CachedBuildings GetOrAddBuildings(Guid modelId, int cellSize, GeoBounds bounds, IEnumerable<(NetTopologySuite.Geometries.Polygon Poly, LandUseType Use)> buildings)
+        public static CachedBuildings GetOrAddBuildings(int cellSize, GeoBounds bounds, IEnumerable<(NetTopologySuite.Geometries.Polygon Poly, LandUseType Use)> buildings)
         {
-            var key = (modelId, cellSize, bounds.MinLon, bounds.MinLat, bounds.MaxLon, bounds.MaxLat);
-            return _buildings.GetOrAdd(key, _ =>
+            var key = (cellSize, bounds.MinLon, bounds.MinLat, bounds.MaxLon, bounds.MaxLat);
+            return _buildingTiles.GetOrAdd(key, _ =>
             {
                 var dict = new Dictionary<Rgba32, IPath>();
                 foreach (var group in buildings.GroupBy(b => ProceduralCityRenderer.GetBuildingColor(b.Use)))

--- a/CityModelCache.cs
+++ b/CityModelCache.cs
@@ -10,13 +10,12 @@ namespace StrategyGame
 {
     internal static class CityModelCache
     {
-        private static readonly ConcurrentDictionary<(int cellSize, double minLon, double minLat, double maxLon, double maxLat), CachedRoads> _roads = new();
-        private static readonly ConcurrentDictionary<(int cellSize, double minLon, double minLat, double maxLon, double maxLat), CachedBuildings> _buildings = new();
+        private static readonly ConcurrentDictionary<(Guid modelId, int cellSize), CachedRoads> _roads = new();
+        private static readonly ConcurrentDictionary<(Guid modelId, int cellSize, double minLon, double minLat, double maxLon, double maxLat), CachedBuildings> _buildings = new();
 
-        public static CachedRoads GetOrAddRoads(int cellSize, GeoBounds bounds, IEnumerable<LineSegment> rawRoads)
+        public static CachedRoads GetOrAddRoads(Guid modelId, int cellSize, IEnumerable<LineSegment> rawRoads, GeoBounds bounds)
         {
-            var key = (cellSize, bounds.MinLon, bounds.MinLat, bounds.MaxLon, bounds.MaxLat);
-            return _roads.GetOrAdd(key, _ =>
+            return _roads.GetOrAdd((modelId, cellSize), _ =>
             {
                 var tileBox = new NetTopologySuite.Geometries.Envelope(bounds.MinLon, bounds.MaxLon, bounds.MinLat, bounds.MaxLat);
                 var clipped = rawRoads.Where(r =>
@@ -48,9 +47,9 @@ namespace StrategyGame
             });
         }
 
-        public static CachedBuildings GetOrAddBuildings(int cellSize, GeoBounds bounds, IEnumerable<(NetTopologySuite.Geometries.Polygon Poly, LandUseType Use)> buildings)
+        public static CachedBuildings GetOrAddBuildings(Guid modelId, int cellSize, GeoBounds bounds, IEnumerable<(NetTopologySuite.Geometries.Polygon Poly, LandUseType Use)> buildings)
         {
-            var key = (cellSize, bounds.MinLon, bounds.MinLat, bounds.MaxLon, bounds.MaxLat);
+            var key = (modelId, cellSize, bounds.MinLon, bounds.MinLat, bounds.MaxLon, bounds.MaxLat);
             return _buildings.GetOrAdd(key, _ =>
             {
                 var dict = new Dictionary<Rgba32, IPath>();

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -25,9 +25,6 @@ namespace StrategyGame
         private readonly ConcurrentDictionary<(int cellSize, int x, int y), SKBitmap> _tileCache = new();
         private readonly ConcurrentDictionary<(int cellSize, int x, int y), Task<SKBitmap>> _inFlight = new();
         private readonly SemaphoreSlim _preloadLimiter = new(8, 8);
-        private readonly object _viewBufferLock = new();
-        private SKBitmap? _viewBuffer;
-        private SKSurface? _viewSurface;
         public static readonly bool GpuAvailable;
 
         static CityTileManager()
@@ -227,27 +224,22 @@ namespace StrategyGame
             int cellSize = GetCellSize(zoom);
             int tileSize = MultiResolutionMapManager.TileSizePx;
 
+            if (viewArea.Width <= 0 || viewArea.Height <= 0 || cellSize <= 0)
+                return new SKBitmap(1, 1);
+
             var info = new SKImageInfo(viewArea.Width, viewArea.Height);
 
-            lock (_viewBufferLock)
-            {
-                if (_viewBuffer == null || _viewBuffer.Width != info.Width || _viewBuffer.Height != info.Height)
-                {
-                    _viewSurface?.Dispose();
-                    _viewBuffer?.Dispose();
-                    _viewBuffer = new SKBitmap(info);
-                    _viewSurface = SKSurface.Create(info, _viewBuffer.GetPixels(), _viewBuffer.RowBytes);
-                }
+            using var surface = SKSurface.Create(info);
+            if (surface == null)
+                return new SKBitmap(info.Width, info.Height);
 
-                var canvas = _viewSurface!.Canvas;
-                canvas.Clear(SKColors.Transparent);
+            var canvas = surface.Canvas;
+            canvas.Clear(SKColors.Transparent);
 
             using (var baseMap = _mapManager.AssembleView(zoom, viewArea, triggerRefresh))
             {
                 if (baseMap != null)
-                {
                     canvas.DrawBitmap(baseMap, SKRect.Create(0, 0, viewArea.Width, viewArea.Height));
-                }
             }
 
             int tileStartX = Math.Max(0, viewArea.X / tileSize);
@@ -266,26 +258,58 @@ namespace StrategyGame
                         tx * tileSize - viewArea.X + tileSize,
                         ty * tileSize - viewArea.Y + tileSize);
 
-                    SKBitmap tileBitmap = null;
-                    if (_tileCache.TryGetValue(key, out var cachedTile))
-                    {
-                        tileBitmap = cachedTile;
-                    }
+                    if (rect.Width <= 0 || rect.Height <= 0)
+                        continue;
 
-                    if (tileBitmap != null)
+                    SKBitmap texture = null;
+                    lock (_masterCacheLock)
+                        _tileTextures.TryGetValue(key, out texture);
+
+                    if (texture != null && !texture.IsDisposed)
                     {
-                        canvas.DrawBitmap(tileBitmap, rect);
+                        try
+                        {
+                            canvas.DrawBitmap(texture, rect);
+                        }
+                        catch (Exception ex)
+                        {
+                            Debug.WriteLine($"Error drawing texture for tile {key}: {ex.Message}");
+                        }
                     }
                     else
                     {
-                        _ = GetTileAsync(zoom, tx, ty, CancellationToken.None);
+                        lock (_tileLoadLock)
+                        {
+                            if (!_tilesBeingLoaded.Contains(key))
+                            {
+                                _tilesBeingLoaded.Add(key);
+                                _ = Task.Run(async () =>
+                                {
+                                    try
+                                    {
+                                        var bmp = await GetTileAsync(zoom, tx, ty, CancellationToken.None);
+                                        if (bmp != null)
+                                        {
+                                            UploadTileTexture(key, bmp);
+                                            triggerRefresh?.Invoke();
+                                        }
+                                    }
+                                    finally
+                                    {
+                                        lock (_tileLoadLock)
+                                            _tilesBeingLoaded.Remove(key);
+                                    }
+                                });
+                            }
+                        }
                     }
                 }
             }
 
-            _viewSurface!.Canvas.Flush();
+            var snapshot = surface.Snapshot();
+            var result = SKBitmap.FromImage(snapshot);
             PerformanceTracker.Record("CityTileManager-AssembleView", sw.Elapsed);
-            return _viewBuffer!;
+            return result;
         }
 
         public Task PreloadVisibleTilesAsync(float zoom, SD.Rectangle viewRect, int radius = 1, Action triggerRefresh = null, CancellationToken token = default)

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -47,23 +47,6 @@ namespace StrategyGame
             Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
             "data", "city_tile_cache");
 
-        private sealed class ImagePixelOwner : IDisposable
-        {
-            public Image<Rgba32> Image { get; }
-            public MemoryHandle Handle { get; }
-
-            public ImagePixelOwner(Image<Rgba32> image)
-            {
-                Image = image;
-                Handle = image.Frames.RootFrame.DangerousTryGetSinglePixelMemory(out var memory) ? memory.Pin() : throw new InvalidOperationException("Unable to pin pixel memory.");
-            }
-
-            public void Dispose()
-            {
-                Handle.Dispose();
-                Image.Dispose();
-            }
-        }
 
         public CityTileManager(int baseWidth, int baseHeight, MultiResolutionMapManager mapManager)
         {
@@ -88,16 +71,25 @@ namespace StrategyGame
         private static unsafe SKBitmap ImageSharpToSkia(Image<Rgba32> img)
         {
             var sw = Stopwatch.StartNew();
-            var info = new SKImageInfo(img.Width, img.Height, SKColorType.Rgba8888, SKAlphaType.Unpremul);
-            var owner = new ImagePixelOwner(img);
-            var skBitmap = new SKBitmap();
+            int w = img.Width;
+            int h = img.Height;
+            var info = new SKImageInfo(w, h, SKColorType.Rgba8888, SKAlphaType.Premul);
 
-            skBitmap.InstallPixels(
-                info,
-                (IntPtr)owner.Handle.Pointer,
-                img.Width * Unsafe.SizeOf<Rgba32>(),
-                (addr, ctx) => ((ImagePixelOwner)ctx!).Dispose(),
-                owner);
+            var skBitmap = new SKBitmap(info);
+
+            img.ProcessPixelRows(accessor =>
+            {
+                for (int y = 0; y < h; y++)
+                {
+                    IntPtr dst = skBitmap.GetPixels() + y * skBitmap.RowBytes;
+                    var src = accessor.GetRowSpan(y);
+                    fixed (void* srcPtr = src)
+                    {
+                        Buffer.MemoryCopy(srcPtr, (void*)dst, src.Length * sizeof(Rgba32),
+                                          src.Length * sizeof(Rgba32));
+                    }
+                }
+            });
 
             PerformanceTracker.Record("CityTileManager-ImageSharpToSkia", sw.Elapsed);
             return skBitmap;

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -24,6 +24,7 @@ namespace StrategyGame
         private readonly MultiResolutionMapManager _mapManager;
         private readonly ConcurrentDictionary<(int cellSize, int x, int y), SKBitmap> _tileCache = new();
         private readonly ConcurrentDictionary<(int cellSize, int x, int y), Task<SKBitmap>> _inFlight = new();
+        private readonly SemaphoreSlim _preloadLimiter = new(8, 8);
         public static readonly bool GpuAvailable;
 
         static CityTileManager()
@@ -100,6 +101,26 @@ namespace StrategyGame
             return skBitmap;
         }
 
+        private static async Task SaveTileAsync(string path, Image<Rgba32> image)
+        {
+            string? dir = Path.GetDirectoryName(path);
+            if (!string.IsNullOrEmpty(dir))
+                Directory.CreateDirectory(dir);
+
+            var fileLock = GetFileLock(path);
+            await fileLock.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                await using var fs = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None, 4096, true);
+                await image.SaveAsPngAsync(fs).ConfigureAwait(false);
+            }
+            finally
+            {
+                fileLock.Release();
+                image.Dispose();
+            }
+        }
+
 
 
         private int GetCellSize(float zoom)
@@ -153,14 +174,17 @@ namespace StrategyGame
             int cellSize = GetCellSize(zoom);
             var key = (cellSize, tileX, tileY);
 
-            // This is a thread-safe way to get an existing task or create a new one.
-            return _inFlight.GetOrAdd(key, (k) => LoadTileInternalAsync(k.cellSize, k.x, k.y, token));
+            if (_tileCache.TryGetValue(key, out var cached))
+                return Task.FromResult(cached);
+
+            return _inFlight.GetOrAdd(key, _ => LoadTileInternalAsync(cellSize, tileX, tileY, token));
         }
 
         private async Task<SKBitmap> LoadTileInternalAsync(int cellSize, int tileX, int tileY, CancellationToken token)
         {
             var totalSw = Stopwatch.StartNew();
             var key = (cellSize, tileX, tileY);
+
             if (_tileCache.TryGetValue(key, out var cached))
             {
                 _inFlight.TryRemove(key, out _);
@@ -179,8 +203,7 @@ namespace StrategyGame
                     await using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, true);
                     var img = await SixLabors.ImageSharp.Image.LoadAsync<Rgba32>(fs, token).ConfigureAwait(false);
                     var sk = ImageSharpToSkia(img);
-                    _tileCache.TryAdd(key, sk); // Add to concurrent cache
-                    _inFlight.TryRemove(key, out _); // Clean up in-flight task
+                    _tileCache[key] = sk;
                     PerformanceTracker.Record("CityTileManager-LoadTile-FromDisk", loadSw.Elapsed);
                     return sk;
                 }
@@ -196,24 +219,10 @@ namespace StrategyGame
             var skBmp = ImageSharpToSkia(generated);
             PerformanceTracker.Record("CityTileManager-GenerateTile", genSw.Elapsed);
 
-            string dir = Path.GetDirectoryName(path);
-            Directory.CreateDirectory(dir);
-            var lockFile = GetFileLock(path);
-            await lockFile.WaitAsync(token).ConfigureAwait(false);
-            try
-            {
-                var saveSw = Stopwatch.StartNew();
-                await using var fs = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None, 4096, true);
-                await generated.SaveAsPngAsync(fs, token).ConfigureAwait(false);
-                PerformanceTracker.Record("CityTileManager-SaveTile", saveSw.Elapsed);
-            }
-            finally
-            {
-                lockFile.Release();
-            }
+            _tileCache[key] = skBmp;
+            _ = Task.Run(() => SaveTileAsync(path, generated));
 
-            _tileCache.TryAdd(key, skBmp); // Add to concurrent cache
-            _inFlight.TryRemove(key, out _); // Clean up in-flight task
+            _inFlight.TryRemove(key, out _);
             PerformanceTracker.Record("CityTileManager-LoadTile", totalSw.Elapsed);
             return skBmp;
         }
@@ -309,7 +318,12 @@ namespace StrategyGame
                 return;
             }
 
-            var tasks = missingTiles.Select(coord => GetTileAsync(zoom, coord.x, coord.y, token));
+            var tasks = missingTiles.Select(async coord =>
+            {
+                await _preloadLimiter.WaitAsync(token).ConfigureAwait(false);
+                try { await GetTileAsync(zoom, coord.x, coord.y, token).ConfigureAwait(false); }
+                finally { _preloadLimiter.Release(); }
+            });
             await Task.WhenAll(tasks).ConfigureAwait(false);
             PerformanceTracker.Record("CityTileManager-PreloadTiles", sw.Elapsed);
             triggerRefresh?.Invoke();

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -25,6 +25,7 @@ namespace StrategyGame
         private readonly ConcurrentDictionary<(int cellSize, int x, int y), SKBitmap> _tileCache = new();
         private readonly ConcurrentDictionary<(int cellSize, int x, int y), Task<SKBitmap>> _inFlight = new();
         private readonly SemaphoreSlim _preloadLimiter = new(8, 8);
+        private readonly object _viewBufferLock = new();
         private SKBitmap? _viewBuffer;
         private SKSurface? _viewSurface;
         public static readonly bool GpuAvailable;
@@ -230,16 +231,18 @@ namespace StrategyGame
 
             var info = new SKImageInfo(viewArea.Width, viewArea.Height);
 
-            if (_viewBuffer == null || _viewBuffer.Width != info.Width || _viewBuffer.Height != info.Height)
+            lock (_viewBufferLock)
             {
-                _viewSurface?.Dispose();
-                _viewBuffer?.Dispose();
-                _viewBuffer = new SKBitmap(info);
-                _viewSurface = SKSurface.Create(info, _viewBuffer.GetPixels(), _viewBuffer.RowBytes);
-            }
+                if (_viewBuffer == null || _viewBuffer.Width != info.Width || _viewBuffer.Height != info.Height)
+                {
+                    _viewSurface?.Dispose();
+                    _viewBuffer?.Dispose();
+                    _viewBuffer = new SKBitmap(info);
+                    _viewSurface = SKSurface.Create(info, _viewBuffer.GetPixels(), _viewBuffer.RowBytes);
+                }
 
-            var canvas = _viewSurface!.Canvas;
-            canvas.Clear(SKColors.Transparent);
+                var canvas = _viewSurface!.Canvas;
+                canvas.Clear(SKColors.Transparent);
 
             using (var baseMap = _mapManager.AssembleView(zoom, viewArea, triggerRefresh))
             {

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -236,11 +236,9 @@ namespace StrategyGame
             var canvas = surface.Canvas;
             canvas.Clear(SKColors.Transparent);
 
-            using (var baseMap = _mapManager.AssembleView(zoom, viewArea, triggerRefresh))
-            {
-                if (baseMap != null)
-                    canvas.DrawBitmap(baseMap, SKRect.Create(0, 0, viewArea.Width, viewArea.Height));
-            }
+            var baseMap = _mapManager.AssembleView(zoom, viewArea, triggerRefresh);
+            if (baseMap != null)
+                canvas.DrawBitmap(baseMap, SKRect.Create(0, 0, viewArea.Width, viewArea.Height));
 
             int tileStartX = Math.Max(0, viewArea.X / tileSize);
             int tileStartY = Math.Max(0, viewArea.Y / tileSize);
@@ -307,6 +305,7 @@ namespace StrategyGame
             }
 
             var snapshot = surface.Snapshot();
+            baseMap?.Dispose();
             var result = SKBitmap.FromImage(snapshot);
             PerformanceTracker.Record("CityTileManager-AssembleView", sw.Elapsed);
             return result;

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -193,6 +193,26 @@ namespace StrategyGame
             }
 
             string path = GetTilePath(cellSize, tileX, tileY);
+            var fileLock = GetFileLock(path);
+            await fileLock.WaitAsync(token).ConfigureAwait(false);
+            try
+            {
+                await using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, true);
+                var img = await Image.LoadAsync<Rgba32>(fs, token).ConfigureAwait(false);
+                var fromDisk = ImageSharpToSkia(img);
+                _tileCache[key] = fromDisk;
+                _inFlight.TryRemove(key, out _);
+                PerformanceTracker.Record("CityTileManager-LoadTile-FromDisk", totalSw.Elapsed);
+                return fromDisk;
+            }
+            catch (FileNotFoundException)
+            {
+                // fall through to generate
+            }
+            finally
+            {
+                fileLock.Release();
+            }
 
             GeoBounds bounds = ComputeTileBounds(cellSize, tileX, tileY);
             var genSw = Stopwatch.StartNew();

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -193,25 +193,6 @@ namespace StrategyGame
             }
 
             string path = GetTilePath(cellSize, tileX, tileY);
-            if (File.Exists(path))
-            {
-                var loadSw = Stopwatch.StartNew();
-                var fileLock = GetFileLock(path);
-                await fileLock.WaitAsync(token).ConfigureAwait(false);
-                try
-                {
-                    await using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, true);
-                    var img = await SixLabors.ImageSharp.Image.LoadAsync<Rgba32>(fs, token).ConfigureAwait(false);
-                    var sk = ImageSharpToSkia(img);
-                    _tileCache[key] = sk;
-                    PerformanceTracker.Record("CityTileManager-LoadTile-FromDisk", loadSw.Elapsed);
-                    return sk;
-                }
-                finally
-                {
-                    fileLock.Release();
-                }
-            }
 
             GeoBounds bounds = ComputeTileBounds(cellSize, tileX, tileY);
             var genSw = Stopwatch.StartNew();
@@ -234,8 +215,8 @@ namespace StrategyGame
             int tileSize = MultiResolutionMapManager.TileSizePx;
 
             var info = new SKImageInfo(viewArea.Width, viewArea.Height);
-            var context = GpuAvailable ? MultiResolutionMapManager.SharedContext : null;
-            using var surface = context != null ? SKSurface.Create(context, false, info) : SKSurface.Create(info);
+            var result = new SKBitmap(info);
+            using var surface = SKSurface.Create(info, result.GetPixels(), result.RowBytes);
             var canvas = surface.Canvas;
             canvas.Clear(SKColors.Transparent);
 
@@ -280,8 +261,6 @@ namespace StrategyGame
                 }
             }
 
-            var result = new SKBitmap(info);
-            surface.ReadPixels(result.Info, result.GetPixels(), result.RowBytes, 0, 0);
             PerformanceTracker.Record("CityTileManager-AssembleView", sw.Elapsed);
             return result;
         }

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -77,18 +77,16 @@ namespace StrategyGame
             var info = new SKImageInfo(w, h, SKColorType.Rgba8888, SKAlphaType.Premul);
 
             var skBitmap = new SKBitmap(info);
+            IntPtr dstPtr = skBitmap.GetPixels();
 
             img.ProcessPixelRows(accessor =>
             {
                 for (int y = 0; y < h; y++)
                 {
-                    IntPtr dst = skBitmap.GetPixels() + y * skBitmap.RowBytes;
-                    var src = accessor.GetRowSpan(y);
-                    fixed (void* srcPtr = src)
-                    {
-                        Buffer.MemoryCopy(srcPtr, (void*)dst, src.Length * sizeof(Rgba32),
-                                          src.Length * sizeof(Rgba32));
-                    }
+                    ReadOnlySpan<Rgba32> sourceRowSpan = accessor.GetRowSpan(y);
+                    ReadOnlySpan<byte> sourceByteSpan = MemoryMarshal.AsBytes(sourceRowSpan);
+                    Span<byte> destByteSpan = new Span<byte>((void*)(dstPtr + y * skBitmap.RowBytes), sourceByteSpan.Length);
+                    sourceByteSpan.CopyTo(destByteSpan);
                 }
             });
 

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -295,7 +295,7 @@ namespace StrategyGame
             return _viewBuffer!;
         }
 
-        public async Task PreloadVisibleTilesAsync(float zoom, SD.Rectangle viewRect, int radius = 1, Action triggerRefresh = null, CancellationToken token = default)
+        public Task PreloadVisibleTilesAsync(float zoom, SD.Rectangle viewRect, int radius = 1, Action triggerRefresh = null, CancellationToken token = default)
         {
             var sw = Stopwatch.StartNew();
             int cellSize = GetCellSize(zoom);
@@ -324,7 +324,7 @@ namespace StrategyGame
             {
                 PerformanceTracker.Record("CityTileManager-PreloadTiles", sw.Elapsed);
                 triggerRefresh?.Invoke();
-                return;
+                return Task.CompletedTask;
             }
 
             var tasks = missingTiles.Select(async coord =>
@@ -332,10 +332,15 @@ namespace StrategyGame
                 await _preloadLimiter.WaitAsync(token).ConfigureAwait(false);
                 try { await GetTileAsync(zoom, coord.x, coord.y, token).ConfigureAwait(false); }
                 finally { _preloadLimiter.Release(); }
-            });
-            await Task.WhenAll(tasks).ConfigureAwait(false);
-            PerformanceTracker.Record("CityTileManager-PreloadTiles", sw.Elapsed);
-            triggerRefresh?.Invoke();
+            }).ToArray();
+
+            _ = Task.WhenAll(tasks).ContinueWith(_ =>
+            {
+                PerformanceTracker.Record("CityTileManager-PreloadTiles", sw.Elapsed);
+                triggerRefresh?.Invoke();
+            }, TaskScheduler.Default);
+
+            return Task.CompletedTask;
         }
     }
     }

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -25,6 +25,8 @@ namespace StrategyGame
         private readonly ConcurrentDictionary<(int cellSize, int x, int y), SKBitmap> _tileCache = new();
         private readonly ConcurrentDictionary<(int cellSize, int x, int y), Task<SKBitmap>> _inFlight = new();
         private readonly SemaphoreSlim _preloadLimiter = new(8, 8);
+        private SKBitmap? _viewBuffer;
+        private SKSurface? _viewSurface;
         public static readonly bool GpuAvailable;
 
         static CityTileManager()
@@ -235,9 +237,16 @@ namespace StrategyGame
             int tileSize = MultiResolutionMapManager.TileSizePx;
 
             var info = new SKImageInfo(viewArea.Width, viewArea.Height);
-            var result = new SKBitmap(info);
-            using var surface = SKSurface.Create(info, result.GetPixels(), result.RowBytes);
-            var canvas = surface.Canvas;
+
+            if (_viewBuffer == null || _viewBuffer.Width != info.Width || _viewBuffer.Height != info.Height)
+            {
+                _viewSurface?.Dispose();
+                _viewBuffer?.Dispose();
+                _viewBuffer = new SKBitmap(info);
+                _viewSurface = SKSurface.Create(info, _viewBuffer.GetPixels(), _viewBuffer.RowBytes);
+            }
+
+            var canvas = _viewSurface!.Canvas;
             canvas.Clear(SKColors.Transparent);
 
             using (var baseMap = _mapManager.AssembleView(zoom, viewArea, triggerRefresh))
@@ -281,8 +290,9 @@ namespace StrategyGame
                 }
             }
 
+            _viewSurface!.Canvas.Flush();
             PerformanceTracker.Record("CityTileManager-AssembleView", sw.Elapsed);
-            return result;
+            return _viewBuffer!;
         }
 
         public async Task PreloadVisibleTilesAsync(float zoom, SD.Rectangle viewRect, int radius = 1, Action triggerRefresh = null, CancellationToken token = default)

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -266,14 +266,13 @@ namespace economy_sim
 
                 var viewRect = new SD.Rectangle(mapViewOrigin, panelMap.ClientSize);
 
-                Task.Run(() =>
+                Task.Run(async () =>
                 {
                     string tileDir = Path.Combine(
                         Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
                         "data", "tile_cache");
 
-                    mapManager.PreloadVisibleTiles(mapZoom, viewRect);
-                    _ = cityTileManager.PreloadVisibleTilesAsync(mapZoom, viewRect);
+                    await cityTileManager.PreloadVisibleTilesAsync(mapZoom, viewRect, token: simCts.Token);
 
                     this.Invoke((MethodInvoker)(() =>
                     {

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -81,7 +81,7 @@ namespace economy_sim
         private DateTime lastCityModelUpdate = DateTime.Now;
 
         //threading
-        private CancellationTokenSource simCts; // Add this line
+        private CancellationTokenSource simCts = new CancellationTokenSource();
         private void LoadGlobalData()
         {
             string dataDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "data");
@@ -248,6 +248,7 @@ namespace economy_sim
         {
             // Start the simulation loop on a background thread
             // now that the form is fully loaded and displayed.
+            simCts?.Cancel();
             simCts = new CancellationTokenSource();
             Task.Run(() => RunGameSimulationLoop(simCts.Token), simCts.Token);
         }

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -360,8 +360,7 @@ namespace economy_sim
             // 2. Initialize Factory Blueprints (this also populates Market.GoodDefinitions now)
             FactoryBlueprints.InitializeBlueprints();
 
-            // Load urban area polygons for procedural generation
-            UrbanAreaManager.LoadUrbanAreas();
+            // Urban areas and spatial index initialize lazily
             CheckAndPromptForMissingCityData();
 
             // 3. Load World Setup from JSON

--- a/MultiResolutionMapManager.cs
+++ b/MultiResolutionMapManager.cs
@@ -368,6 +368,7 @@ namespace StrategyGame
                                 try
                                 {
                                     canvas.DrawBitmap(texture, rect);
+                                    canvas.Flush();
                                 }
                                 catch (AccessViolationException ex)
                                 {

--- a/MultiResolutionMapManager.cs
+++ b/MultiResolutionMapManager.cs
@@ -53,6 +53,9 @@ namespace StrategyGame
         private readonly object _masterCacheLock = new();
         private readonly Dictionary<(int cellSize, int x, int y), SKBitmap> _tileTextures = new();
 
+        private SKBitmap? _viewBuffer;
+        private SKSurface? _viewSurface;
+
         public static readonly bool GpuAvailable;
         internal static readonly GRContext? SharedContext;
 
@@ -331,10 +334,17 @@ namespace StrategyGame
             int tileEndY = (viewArea.Bottom + tileSize - 1) / tileSize;
 
             var info = new SKImageInfo(viewArea.Width, viewArea.Height);
-            var context = GpuAvailable ? SharedContext : null;
-                using var surface = context != null ? SKSurface.Create(context, false, info) : SKSurface.Create(info);
-                var canvas = surface.Canvas;
-                canvas.Clear(SKColors.Transparent);
+
+            if (_viewBuffer == null || _viewBuffer.Width != info.Width || _viewBuffer.Height != info.Height)
+            {
+                _viewSurface?.Dispose();
+                _viewBuffer?.Dispose();
+                _viewBuffer = new SKBitmap(info);
+                _viewSurface = SKSurface.Create(info, _viewBuffer.GetPixels(), _viewBuffer.RowBytes);
+            }
+
+            var canvas = _viewSurface!.Canvas;
+            canvas.Clear(SKColors.Transparent);
 
                 for (int ty = tileStartY; ty < tileEndY; ty++)
                 {
@@ -351,32 +361,23 @@ namespace StrategyGame
                         if (rect.Width <= 0 || rect.Height <= 0)
                             continue;
 
-                        // --- START: Replacement Logic ---
-                        SKBitmap textureCopy = null;
                         lock (_masterCacheLock)
                         {
                             if (_tileTextures.TryGetValue(key, out var texture))
                             {
-                                // Create a private, safe copy of the texture inside the lock
-                                textureCopy = texture.Copy();
-                            }
-                        }
-
-                        if (textureCopy != null)
-                        {
-                            using (textureCopy)
-                            {
                                 try
                                 {
-                                    canvas.DrawBitmap(textureCopy, rect);
+                                    canvas.DrawBitmap(texture, rect);
                                 }
                                 catch (AccessViolationException ex)
                                 {
-                                    DebugLogger.Log($"Access violation drawing texture copy {key}: {ex.Message}");
+                                    DebugLogger.Log($"Access violation drawing texture {key}: {ex.Message}");
                                 }
+                                continue;
                             }
                         }
-                        else
+
+                        // If not in cache, start loading
                         {
                             lock (_tileLoadLock)
                             {
@@ -404,13 +405,11 @@ namespace StrategyGame
                                 }
                             }
                         }
-                        // --- END: Replacement Logic ---
                     }
                 }
 
-                var result = new SKBitmap(info);
-                surface.ReadPixels(result.Info, result.GetPixels(), result.RowBytes, 0, 0);
-                return result;
+                _viewSurface!.Canvas.Flush();
+                return _viewBuffer!;
         }
 
         private static void OverlayFeatures(SystemDrawing.Bitmap bmp, ZoomLevel level)

--- a/MultiResolutionMapManager.cs
+++ b/MultiResolutionMapManager.cs
@@ -53,6 +53,7 @@ namespace StrategyGame
         private readonly object _masterCacheLock = new();
         private readonly Dictionary<(int cellSize, int x, int y), SKBitmap> _tileTextures = new();
 
+        private readonly object _viewBufferLock = new();
         private SKBitmap? _viewBuffer;
         private SKSurface? _viewSurface;
 
@@ -336,16 +337,18 @@ namespace StrategyGame
 
             var info = new SKImageInfo(viewArea.Width, viewArea.Height);
 
-            if (_viewBuffer == null || _viewBuffer.Width != info.Width || _viewBuffer.Height != info.Height)
+            lock (_viewBufferLock)
             {
-                _viewSurface?.Dispose();
-                _viewBuffer?.Dispose();
-                _viewBuffer = new SKBitmap(info);
-                _viewSurface = SKSurface.Create(info, _viewBuffer.GetPixels(), _viewBuffer.RowBytes);
-            }
+                if (_viewBuffer == null || _viewBuffer.Width != info.Width || _viewBuffer.Height != info.Height)
+                {
+                    _viewSurface?.Dispose();
+                    _viewBuffer?.Dispose();
+                    _viewBuffer = new SKBitmap(info);
+                    _viewSurface = SKSurface.Create(info, _viewBuffer.GetPixels(), _viewBuffer.RowBytes);
+                }
 
-            var canvas = _viewSurface!.Canvas;
-            canvas.Clear(SKColors.Transparent);
+                var canvas = _viewSurface!.Canvas;
+                canvas.Clear(SKColors.Transparent);
 
                 for (int ty = tileStartY; ty < tileEndY; ty++)
                 {

--- a/MultiResolutionMapManager.cs
+++ b/MultiResolutionMapManager.cs
@@ -267,8 +267,9 @@ namespace StrategyGame
                 {
                     _tileCache[key] = bmp;
                     _tileLru.AddLast(key);
-                    EnforceTileLimit();
                 }
+
+                EnforceTileLimit();
                 UploadTileTexture(key, bmp);
             }
 
@@ -638,17 +639,19 @@ namespace StrategyGame
 
         private void EnforceTileLimit()
         {
-            while (_tileLru.Count > TileCacheLimit)
+            lock (_masterCacheLock)
             {
-                var oldest = _tileLru.First.Value;
-                _tileLru.RemoveFirst();
-                if (_tileCache.TryGetValue(oldest, out var oldBmp))
+                while (_tileLru.Count > TileCacheLimit)
                 {
-                    oldBmp.Dispose();
-                    _tileCache.Remove(oldest);
-                }
-                lock (_masterCacheLock)
-                {
+                    var oldest = _tileLru.First.Value;
+                    _tileLru.RemoveFirst();
+
+                    if (_tileCache.TryGetValue(oldest, out var oldBmp))
+                    {
+                        oldBmp.Dispose();
+                        _tileCache.Remove(oldest);
+                    }
+
                     if (_tileTextures.TryGetValue(oldest, out var tex))
                     {
                         tex.Dispose();

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -26,75 +26,65 @@ namespace StrategyGame
             var tilePoly = ToPolygon(tileBounds);
 
             var processedModelIds = new HashSet<Guid>();
-            var relevantUrbanAreas = UrbanAreaManager.Query(tileBounds).Where(u => u.Intersects(tilePoly)).ToList();
+            var relevantUrbanAreas = UrbanAreaManager.Query(tileBounds);
 
-            var models = await Task.WhenAll(relevantUrbanAreas.Select(async u =>
+            var allRoads = new List<LineSegment>();
+            var allBuildings = new List<(Nts.Polygon Poly, LandUseType Use)>();
+
+            foreach (var urban in relevantUrbanAreas)
             {
-                var id = await RoadNetworkGenerator.GetCityDataModelIdAsync(u).ConfigureAwait(false);
-                if (!id.HasValue || !processedModelIds.Add(id.Value))
-                    return null;
+                if (!urban.EnvelopeInternal.Intersects(tilePoly.EnvelopeInternal) || !urban.Intersects(tilePoly))
+                    continue;
 
-                if (!_modelCache.TryGetValue(id.Value, out var m))
+                var modelId = await RoadNetworkGenerator.GetCityDataModelIdAsync(urban).ConfigureAwait(false);
+                if (!modelId.HasValue || !processedModelIds.Add(modelId.Value))
+                    continue;
+
+                if (!_modelCache.TryGetValue(modelId.Value, out var model))
                 {
-                    m = await RoadNetworkGenerator.LoadCityDataModelAsync(id.Value).ConfigureAwait(false);
-                    if (m == null) return null;
-                    _modelCache[id.Value] = m;
+                    model = await RoadNetworkGenerator.LoadCityDataModelAsync(modelId.Value).ConfigureAwait(false);
+                    if (model == null) continue;
+                    _modelCache[modelId.Value] = model;
                 }
-                return m;
-            }));
 
-            var roadCaches = new List<CityModelCache.CachedRoads>();
-            var buildingCaches = new List<CityModelCache.CachedBuildings>();
+                var env = tilePoly.EnvelopeInternal;
+                allRoads.AddRange(model.RoadNetwork.Where(seg =>
+                    !(Math.Max(seg.X1, seg.X2) < env.MinX ||
+                      Math.Min(seg.X1, seg.X2) > env.MaxX ||
+                      Math.Max(seg.Y1, seg.Y2) < env.MinY ||
+                      Math.Min(seg.Y1, seg.Y2) > env.MaxY)));
 
-            foreach (var model in models.Where(m => m != null))
-            {
-                IEnumerable<LineSegment> roads = model.RoadNetwork;
-                if (cellSize <= 40)
-                    roads = roads.Where(r => r.Type == RoadType.Primary);
-                var roadCache = CityModelCache.GetOrAddRoads(model.Id, cellSize, roads, tileBounds);
-                roadCaches.Add(roadCache);
-
-                var tileEnv = tilePoly.EnvelopeInternal;
-                var candidates = (model.BuildingIndex?.Query(tileEnv).Cast<Building>() ?? model.Buildings);
-                var toDraw = new List<(Nts.Polygon, LandUseType)>();
+                var candidates = (model.BuildingIndex?.Query(env).Cast<Building>() ?? model.Buildings);
                 foreach (var b in candidates)
                 {
-                    var env = b.Footprint.EnvelopeInternal;
-                    if (!env.Intersects(tileEnv)) continue;
+                    var be = b.Footprint.EnvelopeInternal;
+                    if (!be.Intersects(env)) continue;
+
                     var baseGeom = b.SimplifiedFootprint ?? b.Footprint;
-                    Nts.Geometry clipped = tileEnv.Contains(env)
-                        ? baseGeom
-                        : baseGeom.Intersection(tilePoly);
+                    var clipped = env.Contains(be) ? baseGeom : baseGeom.Intersection(tilePoly);
 
                     if (clipped is Nts.Polygon p && !p.IsEmpty)
-                        toDraw.Add((p, b.LandUse));
+                        allBuildings.Add((p, b.LandUse));
                     else if (clipped is Nts.MultiPolygon mp)
                     {
                         for (int i = 0; i < mp.NumGeometries; i++)
                             if (mp.GetGeometryN(i) is Nts.Polygon pp && !pp.IsEmpty)
-                                toDraw.Add((pp, b.LandUse));
+                                allBuildings.Add((pp, b.LandUse));
                     }
                 }
-
-                var buildingCache = PrepareBuildingCache(model.Id, toDraw, tileBounds, cellSize);
-                buildingCaches.Add(buildingCache);
             }
 
-            if (roadCaches.Count > 0)
-                DrawRoads(img, roadCaches, cellSize);
-            if (buildingCaches.Count > 0)
-                DrawBuildings(img, buildingCaches);
+            if (allRoads.Count > 0)
+                DrawRoads(img, allRoads, tileBounds, cellSize);
+            if (allBuildings.Count > 0)
+                DrawBuildings(img, allBuildings, tileBounds, cellSize);
 
             PerformanceTracker.Record("CityRenderer-RenderTile", sw.Elapsed);
             return img;
         }
 
-        // Convert building polygons into cached paths
-        private static CityModelCache.CachedBuildings PrepareBuildingCache(Guid modelId, List<(Nts.Polygon Poly, LandUseType Use)> buildings, GeoBounds bounds, int cellSize)
+        private static void DrawBuildings(Image<Rgba32> img, List<(Nts.Polygon Poly, LandUseType Use)> buildings, GeoBounds bounds, int cellSize)
         {
-            var sw = Stopwatch.StartNew();
-
-            // 1) Cull buildings that would be too small on screen
             if (cellSize <= 40)
             {
                 buildings = buildings.Where(b =>
@@ -106,13 +96,9 @@ namespace StrategyGame
                 }).ToList();
             }
 
-            // 2) Optionally drop residential buildings at very small scales
             if (cellSize <= 20)
-            {
                 buildings = buildings.Where(b => b.Use != LandUseType.Residential).ToList();
-            }
 
-            // 3) Dynamically simplify footprints based on zoom level
             double tol = (bounds.MaxLon - bounds.MinLon)
                          / MultiResolutionMapManager.TileSizePx
                          * (cellSize <= 80 ? 2.5 : 1.0);
@@ -124,9 +110,7 @@ namespace StrategyGame
                 if (simplified == null || simplified.IsEmpty) continue;
 
                 if (simplified is Nts.Polygon p)
-                {
                     reduced.Add((p, use));
-                }
                 else if (simplified is Nts.MultiPolygon mp)
                 {
                     for (int i = 0; i < mp.NumGeometries; i++)
@@ -137,21 +121,16 @@ namespace StrategyGame
                 }
             }
 
-            var cached = CityModelCache.GetOrAddBuildings(modelId, cellSize, bounds, reduced);
-            PerformanceTracker.Record("CityRenderer-BuildingRendering", sw.Elapsed);
-            return cached;
-        }
+            var sw = Stopwatch.StartNew();
+            var cached = CityModelCache.GetOrAddBuildings(cellSize, bounds, reduced);
 
-        private static void DrawBuildings(Image<Rgba32> img, IEnumerable<CityModelCache.CachedBuildings> buildings)
-        {
             img.Mutate(ctx =>
             {
-                foreach (var cached in buildings)
-                {
-                    foreach (var kvp in cached.PathsByColor)
-                        ctx.Fill(kvp.Key, kvp.Value);
-                }
+                foreach (var kvp in cached.PathsByColor)
+                    ctx.Fill(kvp.Key, kvp.Value);
             });
+
+            PerformanceTracker.Record("CityRenderer-BuildingRendering", sw.Elapsed);
         }
 
         // Batched road drawing
@@ -190,20 +169,21 @@ namespace StrategyGame
             }
         }
 
-        private static void DrawRoads(Image<Rgba32> img, IEnumerable<CityModelCache.CachedRoads> roads, int cellSize)
+        private static void DrawRoads(Image<Rgba32> img, List<LineSegment> roads, GeoBounds bounds, int cellSize)
         {
             var sw = Stopwatch.StartNew();
+            if (cellSize <= 40)
+                roads = roads.Where(r => r.Type == RoadType.Primary).ToList();
+
+            var cached = CityModelCache.GetOrAddRoads(cellSize, bounds, roads);
+
             var primaryPen = SixLabors.ImageSharp.Drawing.Processing.Pens.Solid(new Rgba32(180, 180, 180, 200), 2f);
             var secondaryPen = SixLabors.ImageSharp.Drawing.Processing.Pens.Solid(new Rgba32(180, 180, 180, 200), 1f);
 
             img.Mutate(ctx =>
-            {
-                foreach (var cached in roads)
-                {
-                    ctx.Draw(secondaryPen, cached.SecondaryPath);
-                    ctx.Draw(primaryPen, cached.PrimaryPath);
-                }
-            });
+                ctx.Draw(secondaryPen, cached.SecondaryPath)
+                   .Draw(primaryPen, cached.PrimaryPath));
+
             PerformanceTracker.Record("CityRenderer-RoadDrawing", sw.Elapsed);
         }
 

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -26,7 +26,9 @@ namespace StrategyGame
             var tilePoly = ToPolygon(tileBounds);
 
             var processedModelIds = new HashSet<Guid>();
-            
+            var allRoads = new List<LineSegment>();
+            var allBuildings = new List<(Nts.Polygon Poly, LandUseType Use)>();
+
             var relevantUrbanAreas = UrbanAreaManager.Query(tileBounds);
 
             // This loop now awaits the new async methods, preventing deadlocks.
@@ -46,12 +48,20 @@ namespace StrategyGame
                     _modelCache[modelId.Value] = model;
                 }
 
-                DrawRoads(img, modelId.Value, model.RoadNetwork, tileBounds, cellSize);
-                
-                // Query visible buildings using the model's spatial index
+                // Collect roads intersecting this tile
                 var tileEnv = tilePoly.EnvelopeInternal;
+                foreach (var seg in model.RoadNetwork)
+                {
+                    double minX = Math.Min(seg.X1, seg.X2);
+                    double maxX = Math.Max(seg.X1, seg.X2);
+                    double minY = Math.Min(seg.Y1, seg.Y2);
+                    double maxY = Math.Max(seg.Y1, seg.Y2);
+                    if (!(maxX < tileEnv.MinX || minX > tileEnv.MaxX || maxY < tileEnv.MinY || minY > tileEnv.MaxY))
+                        allRoads.Add(seg);
+                }
+
+                // Query visible buildings using the model's spatial index
                 var candidates = (model.BuildingIndex?.Query(tileEnv).Cast<Building>() ?? model.Buildings);
-                var toDraw = new List<(Nts.Polygon, LandUseType)>();
                 foreach (var b in candidates)
                 {
                     var env = b.Footprint.EnvelopeInternal;
@@ -62,24 +72,27 @@ namespace StrategyGame
                         : baseGeom.Intersection(tilePoly);
 
                     if (clipped is Nts.Polygon p && !p.IsEmpty)
-                        toDraw.Add((p, b.LandUse));
+                        allBuildings.Add((p, b.LandUse));
                     else if (clipped is Nts.MultiPolygon mp)
                     {
                         for (int i = 0; i < mp.NumGeometries; i++)
                             if (mp.GetGeometryN(i) is Nts.Polygon pp && !pp.IsEmpty)
-                                toDraw.Add((pp, b.LandUse));
+                                allBuildings.Add((pp, b.LandUse));
                     }
                 }
-
-                DrawBuildings(img, modelId.Value, toDraw, tileBounds, cellSize);
             }
+
+            if (allRoads.Count > 0)
+                DrawRoads(img, allRoads, tileBounds, cellSize);
+            if (allBuildings.Count > 0)
+                DrawBuildings(img, allBuildings, tileBounds, cellSize);
 
             PerformanceTracker.Record("CityRenderer-RenderTile", sw.Elapsed);
             return img;
         }
 
         // Batched building drawing with caching and dynamic LOD
-        private static void DrawBuildings(Image<Rgba32> img, Guid modelId, List<(Nts.Polygon Poly, LandUseType Use)> buildings, GeoBounds bounds, int cellSize)
+        private static void DrawBuildings(Image<Rgba32> img, List<(Nts.Polygon Poly, LandUseType Use)> buildings, GeoBounds bounds, int cellSize)
         {
             var sw = Stopwatch.StartNew();
 
@@ -126,7 +139,7 @@ namespace StrategyGame
                 }
             }
 
-            var cached = CityModelCache.GetOrAddBuildings(modelId, cellSize, bounds, reduced);
+            var cached = CityModelCache.GetOrAddBuildings(cellSize, bounds, reduced);
 
             img.Mutate(ctx =>
             {
@@ -173,7 +186,7 @@ namespace StrategyGame
             }
         }
 
-        private static void DrawRoads(Image<Rgba32> img, Guid modelId, IEnumerable<LineSegment> roads, GeoBounds bounds, int cellSize)
+        private static void DrawRoads(Image<Rgba32> img, IEnumerable<LineSegment> roads, GeoBounds bounds, int cellSize)
         {
             var sw = Stopwatch.StartNew();
             if (cellSize <= 40)
@@ -181,7 +194,7 @@ namespace StrategyGame
                 roads = roads.Where(r => r.Type == RoadType.Primary);
             }
 
-            var cached = CityModelCache.GetOrAddRoads(modelId, cellSize, roads, bounds);
+            var cached = CityModelCache.GetOrAddRoads(cellSize, bounds, roads);
 
             var primaryPen = SixLabors.ImageSharp.Drawing.Processing.Pens.Solid(new Rgba32(180, 180, 180, 200), 2f);
             var secondaryPen = SixLabors.ImageSharp.Drawing.Processing.Pens.Solid(new Rgba32(180, 180, 180, 200), 1f);

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -26,29 +26,34 @@ namespace StrategyGame
             var tilePoly = ToPolygon(tileBounds);
 
             var processedModelIds = new HashSet<Guid>();
-            
-            var relevantUrbanAreas = UrbanAreaManager.Query(tileBounds);
+            var relevantUrbanAreas = UrbanAreaManager.Query(tileBounds).Where(u => u.Intersects(tilePoly)).ToList();
 
-            // This loop now awaits the new async methods, preventing deadlocks.
-            foreach (var urban in relevantUrbanAreas)
+            var models = await Task.WhenAll(relevantUrbanAreas.Select(async u =>
             {
-                if (!urban.EnvelopeInternal.Intersects(tilePoly.EnvelopeInternal) || !urban.Intersects(tilePoly))
-                    continue;
+                var id = await RoadNetworkGenerator.GetCityDataModelIdAsync(u).ConfigureAwait(false);
+                if (!id.HasValue || !processedModelIds.Add(id.Value))
+                    return null;
 
-                var modelId = await RoadNetworkGenerator.GetCityDataModelIdAsync(urban).ConfigureAwait(false);
-                if (!modelId.HasValue || !processedModelIds.Add(modelId.Value))
-                    continue;
-
-                if (!_modelCache.TryGetValue(modelId.Value, out var model))
+                if (!_modelCache.TryGetValue(id.Value, out var m))
                 {
-                    model = await RoadNetworkGenerator.LoadCityDataModelAsync(modelId.Value).ConfigureAwait(false);
-                    if (model == null) continue;
-                    _modelCache[modelId.Value] = model;
+                    m = await RoadNetworkGenerator.LoadCityDataModelAsync(id.Value).ConfigureAwait(false);
+                    if (m == null) return null;
+                    _modelCache[id.Value] = m;
                 }
+                return m;
+            }));
 
-                DrawRoads(img, modelId.Value, model.RoadNetwork, tileBounds, cellSize);
-                
-                // Query visible buildings using the model's spatial index
+            var roadCaches = new List<CityModelCache.CachedRoads>();
+            var buildingCaches = new List<CityModelCache.CachedBuildings>();
+
+            foreach (var model in models.Where(m => m != null))
+            {
+                IEnumerable<LineSegment> roads = model.RoadNetwork;
+                if (cellSize <= 40)
+                    roads = roads.Where(r => r.Type == RoadType.Primary);
+                var roadCache = CityModelCache.GetOrAddRoads(model.Id, cellSize, roads, tileBounds);
+                roadCaches.Add(roadCache);
+
                 var tileEnv = tilePoly.EnvelopeInternal;
                 var candidates = (model.BuildingIndex?.Query(tileEnv).Cast<Building>() ?? model.Buildings);
                 var toDraw = new List<(Nts.Polygon, LandUseType)>();
@@ -71,15 +76,21 @@ namespace StrategyGame
                     }
                 }
 
-                DrawBuildings(img, modelId.Value, toDraw, tileBounds, cellSize);
+                var buildingCache = PrepareBuildingCache(model.Id, toDraw, tileBounds, cellSize);
+                buildingCaches.Add(buildingCache);
             }
+
+            if (roadCaches.Count > 0)
+                DrawRoads(img, roadCaches, cellSize);
+            if (buildingCaches.Count > 0)
+                DrawBuildings(img, buildingCaches);
 
             PerformanceTracker.Record("CityRenderer-RenderTile", sw.Elapsed);
             return img;
         }
 
-        // Batched building drawing with caching and dynamic LOD
-        private static void DrawBuildings(Image<Rgba32> img, Guid modelId, List<(Nts.Polygon Poly, LandUseType Use)> buildings, GeoBounds bounds, int cellSize)
+        // Convert building polygons into cached paths
+        private static CityModelCache.CachedBuildings PrepareBuildingCache(Guid modelId, List<(Nts.Polygon Poly, LandUseType Use)> buildings, GeoBounds bounds, int cellSize)
         {
             var sw = Stopwatch.StartNew();
 
@@ -127,14 +138,20 @@ namespace StrategyGame
             }
 
             var cached = CityModelCache.GetOrAddBuildings(modelId, cellSize, bounds, reduced);
+            PerformanceTracker.Record("CityRenderer-BuildingRendering", sw.Elapsed);
+            return cached;
+        }
 
+        private static void DrawBuildings(Image<Rgba32> img, IEnumerable<CityModelCache.CachedBuildings> buildings)
+        {
             img.Mutate(ctx =>
             {
-                foreach (var kvp in cached.PathsByColor)
-                    ctx.Fill(kvp.Key, kvp.Value);
+                foreach (var cached in buildings)
+                {
+                    foreach (var kvp in cached.PathsByColor)
+                        ctx.Fill(kvp.Key, kvp.Value);
+                }
             });
-
-            PerformanceTracker.Record("CityRenderer-BuildingRendering", sw.Elapsed);
         }
 
         // Batched road drawing
@@ -173,23 +190,20 @@ namespace StrategyGame
             }
         }
 
-        private static void DrawRoads(Image<Rgba32> img, Guid modelId, IEnumerable<LineSegment> roads, GeoBounds bounds, int cellSize)
+        private static void DrawRoads(Image<Rgba32> img, IEnumerable<CityModelCache.CachedRoads> roads, int cellSize)
         {
             var sw = Stopwatch.StartNew();
-            if (cellSize <= 40)
-            {
-                roads = roads.Where(r => r.Type == RoadType.Primary);
-            }
-
-            var cached = CityModelCache.GetOrAddRoads(modelId, cellSize, roads, bounds);
-
             var primaryPen = SixLabors.ImageSharp.Drawing.Processing.Pens.Solid(new Rgba32(180, 180, 180, 200), 2f);
             var secondaryPen = SixLabors.ImageSharp.Drawing.Processing.Pens.Solid(new Rgba32(180, 180, 180, 200), 1f);
 
-            img.Mutate(ctx => ctx
-                .Draw(secondaryPen, cached.SecondaryPath)
-                .Draw(primaryPen, cached.PrimaryPath)
-            );
+            img.Mutate(ctx =>
+            {
+                foreach (var cached in roads)
+                {
+                    ctx.Draw(secondaryPen, cached.SecondaryPath);
+                    ctx.Draw(primaryPen, cached.PrimaryPath);
+                }
+            });
             PerformanceTracker.Record("CityRenderer-RoadDrawing", sw.Elapsed);
         }
 

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -26,9 +26,7 @@ namespace StrategyGame
             var tilePoly = ToPolygon(tileBounds);
 
             var processedModelIds = new HashSet<Guid>();
-            var allRoads = new List<LineSegment>();
-            var allBuildings = new List<(Nts.Polygon Poly, LandUseType Use)>();
-
+            
             var relevantUrbanAreas = UrbanAreaManager.Query(tileBounds);
 
             // This loop now awaits the new async methods, preventing deadlocks.
@@ -48,20 +46,12 @@ namespace StrategyGame
                     _modelCache[modelId.Value] = model;
                 }
 
-                // Collect roads intersecting this tile
-                var tileEnv = tilePoly.EnvelopeInternal;
-                foreach (var seg in model.RoadNetwork)
-                {
-                    double minX = Math.Min(seg.X1, seg.X2);
-                    double maxX = Math.Max(seg.X1, seg.X2);
-                    double minY = Math.Min(seg.Y1, seg.Y2);
-                    double maxY = Math.Max(seg.Y1, seg.Y2);
-                    if (!(maxX < tileEnv.MinX || minX > tileEnv.MaxX || maxY < tileEnv.MinY || minY > tileEnv.MaxY))
-                        allRoads.Add(seg);
-                }
-
+                DrawRoads(img, modelId.Value, model.RoadNetwork, tileBounds, cellSize);
+                
                 // Query visible buildings using the model's spatial index
+                var tileEnv = tilePoly.EnvelopeInternal;
                 var candidates = (model.BuildingIndex?.Query(tileEnv).Cast<Building>() ?? model.Buildings);
+                var toDraw = new List<(Nts.Polygon, LandUseType)>();
                 foreach (var b in candidates)
                 {
                     var env = b.Footprint.EnvelopeInternal;
@@ -72,27 +62,24 @@ namespace StrategyGame
                         : baseGeom.Intersection(tilePoly);
 
                     if (clipped is Nts.Polygon p && !p.IsEmpty)
-                        allBuildings.Add((p, b.LandUse));
+                        toDraw.Add((p, b.LandUse));
                     else if (clipped is Nts.MultiPolygon mp)
                     {
                         for (int i = 0; i < mp.NumGeometries; i++)
                             if (mp.GetGeometryN(i) is Nts.Polygon pp && !pp.IsEmpty)
-                                allBuildings.Add((pp, b.LandUse));
+                                toDraw.Add((pp, b.LandUse));
                     }
                 }
-            }
 
-            if (allRoads.Count > 0)
-                DrawRoads(img, allRoads, tileBounds, cellSize);
-            if (allBuildings.Count > 0)
-                DrawBuildings(img, allBuildings, tileBounds, cellSize);
+                DrawBuildings(img, modelId.Value, toDraw, tileBounds, cellSize);
+            }
 
             PerformanceTracker.Record("CityRenderer-RenderTile", sw.Elapsed);
             return img;
         }
 
         // Batched building drawing with caching and dynamic LOD
-        private static void DrawBuildings(Image<Rgba32> img, List<(Nts.Polygon Poly, LandUseType Use)> buildings, GeoBounds bounds, int cellSize)
+        private static void DrawBuildings(Image<Rgba32> img, Guid modelId, List<(Nts.Polygon Poly, LandUseType Use)> buildings, GeoBounds bounds, int cellSize)
         {
             var sw = Stopwatch.StartNew();
 
@@ -139,7 +126,7 @@ namespace StrategyGame
                 }
             }
 
-            var cached = CityModelCache.GetOrAddBuildings(cellSize, bounds, reduced);
+            var cached = CityModelCache.GetOrAddBuildings(modelId, cellSize, bounds, reduced);
 
             img.Mutate(ctx =>
             {
@@ -186,7 +173,7 @@ namespace StrategyGame
             }
         }
 
-        private static void DrawRoads(Image<Rgba32> img, IEnumerable<LineSegment> roads, GeoBounds bounds, int cellSize)
+        private static void DrawRoads(Image<Rgba32> img, Guid modelId, IEnumerable<LineSegment> roads, GeoBounds bounds, int cellSize)
         {
             var sw = Stopwatch.StartNew();
             if (cellSize <= 40)
@@ -194,7 +181,7 @@ namespace StrategyGame
                 roads = roads.Where(r => r.Type == RoadType.Primary);
             }
 
-            var cached = CityModelCache.GetOrAddRoads(cellSize, bounds, roads);
+            var cached = CityModelCache.GetOrAddRoads(modelId, cellSize, roads, bounds);
 
             var primaryPen = SixLabors.ImageSharp.Drawing.Processing.Pens.Solid(new Rgba32(180, 180, 180, 200), 2f);
             var secondaryPen = SixLabors.ImageSharp.Drawing.Processing.Pens.Solid(new Rgba32(180, 180, 180, 200), 1f);

--- a/UrbanAreaManager.cs
+++ b/UrbanAreaManager.cs
@@ -6,13 +6,23 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using System.IO;
+using System.Linq;
 
 namespace StrategyGame
 {
     public static class UrbanAreaManager
     {
-        public static List<Nts.Polygon> UrbanPolygons { get; private set; } = new();
-        private static STRtree<Nts.Polygon>? spatialIndex;
+        public static readonly List<Nts.Polygon> UrbanPolygons;
+        private static readonly STRtree<Nts.Polygon> _index;
+
+        static UrbanAreaManager()
+        {
+            UrbanPolygons = LoadAllUrbanPolygons();
+            _index = new STRtree<Nts.Polygon>();
+            foreach (var poly in UrbanPolygons)
+                _index.Insert(poly.EnvelopeInternal, poly);
+            _index.Build();
+        }
 
         private static readonly string RepoRoot =
             Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "..", "..", ".."));
@@ -23,12 +33,12 @@ namespace StrategyGame
         private static readonly string DataFileList = Path.Combine(RepoRoot, "DataFileNames");
         private static readonly Dictionary<string, string> DataFiles = LoadDataFiles();
 
-        public static void LoadUrbanAreas()
+        private static List<Nts.Polygon> LoadAllUrbanPolygons()
         {
-            UrbanPolygons.Clear();
+            var list = new List<Nts.Polygon>();
             string shp = GetDataFile("ne_10m_urban_areas.shp");
             if (!File.Exists(shp))
-                return;
+                return list;
 
             var reader = new ShapefileDataReader(shp, Nts.GeometryFactory.Default);
             while (reader.Read())
@@ -39,20 +49,16 @@ namespace StrategyGame
                     for (int i = 0; i < mp.NumGeometries; i++)
                     {
                         if (mp.GetGeometryN(i) is Nts.Polygon p)
-                            UrbanPolygons.Add(p);
+                            list.Add(p);
                     }
                 }
                 else if (geom is Nts.Polygon p)
                 {
-                    UrbanPolygons.Add(p);
+                    list.Add(p);
                 }
             }
 
-            spatialIndex = new STRtree<Nts.Polygon>();
-            foreach (var poly in UrbanPolygons)
-            {
-                spatialIndex.Insert(poly.EnvelopeInternal, poly);
-            }
+            return list;
         }
 
         public static void PrecomputeAllRoadNetworks()
@@ -69,13 +75,10 @@ namespace StrategyGame
             Debug.WriteLine($"Finished pre-computing all road networks in {sw.Elapsed.TotalSeconds:F2} seconds.");
         }
 
-        public static List<Nts.Polygon> Query(GeoBounds bounds)
+        public static IEnumerable<Nts.Polygon> Query(GeoBounds bounds)
         {
-            if (spatialIndex == null)
-                return UrbanPolygons;
-
             var env = new Nts.Envelope(bounds.MinLon, bounds.MaxLon, bounds.MinLat, bounds.MaxLat);
-            return spatialIndex.Query(env).Cast<Nts.Polygon>().ToList();
+            return _index.Query(env).Cast<Nts.Polygon>();
         }
 
         private static string GetDataFile(string name)


### PR DESCRIPTION
## Summary
- batch draw calls across all urban areas
- cache road and building paths per tile rather than per model

## Testing
- `dotnet restore` *(fails: SDK Microsoft.NET.Sdk.WindowsDesktop missing)*
- `dotnet build "economy sim.sln" -v minimal` *(fails: SDK Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a52e205b083239d8c50110d092196