### PR TITLE
Optimize map tile rendering

### DIFF
--- a/Building.cs
+++ b/Building.cs
@@ -1,12 +1,13 @@
 using Nts = NetTopologySuite.Geometries;
+using System.Collections.Concurrent;
 
 namespace StrategyGame
 {
     public class Building
     {
         public Nts.Polygon Footprint { get; set; }
-        // A simplified version of the footprint used for rendering
-        public Nts.Geometry? SimplifiedFootprint { get; set; }
+        // Simplified footprints cached by cell size for rendering
+        public ConcurrentDictionary<int, Nts.Geometry> SimplifiedFootprints { get; } = new();
         public LandUseType LandUse { get; set; }
 
         // Fields used by the BuildingRefiner

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -24,6 +24,8 @@ namespace StrategyGame
         private readonly MultiResolutionMapManager _mapManager;
         private readonly ConcurrentDictionary<(int cellSize, int x, int y), SKBitmap> _tileCache = new();
         private readonly ConcurrentDictionary<(int cellSize, int x, int y), Task<SKBitmap>> _inFlight = new();
+        private readonly ConcurrentDictionary<Guid, CityDataModel> _cityModelCache = new();
+        private readonly ConcurrentDictionary<Guid, Task> _cityModelLoadTasks = new();
         public static readonly bool GpuAvailable;
 
         static CityTileManager()
@@ -80,6 +82,31 @@ namespace StrategyGame
                 }
                 return sem;
             }
+        }
+
+        private void RequestModel(Guid modelId, Action triggerRefresh)
+        {
+            if (_cityModelCache.ContainsKey(modelId) || _cityModelLoadTasks.ContainsKey(modelId))
+                return;
+
+            var loadTask = Task.Run(async () =>
+            {
+                try
+                {
+                    var model = await RoadNetworkGenerator.LoadCityDataModelAsync(modelId).ConfigureAwait(false);
+                    if (model != null)
+                    {
+                        _cityModelCache.TryAdd(model.Id, model);
+                        triggerRefresh?.Invoke();
+                    }
+                }
+                finally
+                {
+                    _cityModelLoadTasks.TryRemove(modelId, out _);
+                }
+            });
+
+            _cityModelLoadTasks.TryAdd(modelId, loadTask);
         }
 
         private static unsafe SKBitmap ImageSharpToSkia(Image<Rgba32> img)
@@ -148,16 +175,16 @@ namespace StrategyGame
             return Path.Combine(tileFolder, $"{tileX}_{tileY}.png");
         }
 
-        public Task<SKBitmap> GetTileAsync(float zoom, int tileX, int tileY, CancellationToken token)
+        public Task<SKBitmap> GetTileAsync(float zoom, int tileX, int tileY, CancellationToken token, Action triggerRefresh = null)
         {
             int cellSize = GetCellSize(zoom);
             var key = (cellSize, tileX, tileY);
 
             // This is a thread-safe way to get an existing task or create a new one.
-            return _inFlight.GetOrAdd(key, (k) => LoadTileInternalAsync(k.cellSize, k.x, k.y, token));
+            return _inFlight.GetOrAdd(key, (k) => LoadTileInternalAsync(k.cellSize, k.x, k.y, token, triggerRefresh));
         }
 
-        private async Task<SKBitmap> LoadTileInternalAsync(int cellSize, int tileX, int tileY, CancellationToken token)
+        private async Task<SKBitmap> LoadTileInternalAsync(int cellSize, int tileX, int tileY, CancellationToken token, Action triggerRefresh)
         {
             var totalSw = Stopwatch.StartNew();
             var key = (cellSize, tileX, tileY);
@@ -192,7 +219,12 @@ namespace StrategyGame
 
             GeoBounds bounds = ComputeTileBounds(cellSize, tileX, tileY);
             var genSw = Stopwatch.StartNew();
-            var generated = await ProceduralCityRenderer.RenderCityTileAsync(bounds, cellSize).ConfigureAwait(false);
+            var generated = ProceduralCityRenderer.RenderCityTile(
+                bounds,
+                cellSize,
+                _cityModelCache,
+                id => RequestModel(id, triggerRefresh)
+            );
             var skBmp = ImageSharpToSkia(generated);
             PerformanceTracker.Record("CityTileManager-GenerateTile", genSw.Elapsed);
 
@@ -266,7 +298,7 @@ namespace StrategyGame
                     }
                     else
                     {
-                        _ = GetTileAsync(zoom, tx, ty, CancellationToken.None);
+                        _ = GetTileAsync(zoom, tx, ty, CancellationToken.None, triggerRefresh);
                     }
                 }
             }
@@ -309,7 +341,7 @@ namespace StrategyGame
                 return;
             }
 
-            var tasks = missingTiles.Select(coord => GetTileAsync(zoom, coord.x, coord.y, token));
+            var tasks = missingTiles.Select(coord => GetTileAsync(zoom, coord.x, coord.y, token, triggerRefresh));
             await Task.WhenAll(tasks).ConfigureAwait(false);
             PerformanceTracker.Record("CityTileManager-PreloadTiles", sw.Elapsed);
             triggerRefresh?.Invoke();

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -219,12 +219,12 @@ namespace StrategyGame
 
             GeoBounds bounds = ComputeTileBounds(cellSize, tileX, tileY);
             var genSw = Stopwatch.StartNew();
-            var generated = ProceduralCityRenderer.RenderCityTile(
+            var generated = await ProceduralCityRenderer.RenderCityTileAsync(
                 bounds,
                 cellSize,
                 _cityModelCache,
                 id => RequestModel(id, triggerRefresh)
-            );
+            ).ConfigureAwait(false);
             var skBmp = ImageSharpToSkia(generated);
             PerformanceTracker.Record("CityTileManager-GenerateTile", genSw.Elapsed);
 

--- a/MultiResolutionMapManager.cs
+++ b/MultiResolutionMapManager.cs
@@ -601,12 +601,18 @@ namespace StrategyGame
             return (int)Math.Round(size);
         }
 
-        private static SystemDrawing.Bitmap ImageSharpToBitmap(Image<Rgba32> img)
+        private static unsafe SystemDrawing.Bitmap ImageSharpToBitmap(Image<Rgba32> img)
         {
-            using var ms = new MemoryStream();
-            img.SaveAsBmp(ms);
-            ms.Position = 0;
-            return new SystemDrawing.Bitmap(ms);
+            var bmp = new SystemDrawing.Bitmap(img.Width, img.Height, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+            var bmpData = bmp.LockBits(
+                new SystemDrawing.Rectangle(0, 0, img.Width, img.Height),
+                System.Drawing.Imaging.ImageLockMode.WriteOnly,
+                bmp.PixelFormat);
+
+            img.CopyPixelDataTo(new Span<byte>((byte*)bmpData.Scan0, bmpData.Stride * bmpData.Height));
+
+            bmp.UnlockBits(bmpData);
+            return bmp;
         }
 
         private static SystemDrawing.Bitmap CreateWaterTile(int width, int height)

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -100,22 +100,26 @@ namespace StrategyGame
         {
             var sw = Stopwatch.StartNew();
 
-            // 1) Cull buildings that would be too small on screen
-            if (cellSize <= 40)
+            // Consolidated culling loop to reduce allocations
+            var culledBuildings = new List<(Nts.Polygon Poly, LandUseType Use, Building Bld)>();
+            bool cullBySize = cellSize <= 40;
+            bool cullResidential = cellSize <= 20;
+
+            foreach (var bld in buildings)
             {
-                buildings = buildings.Where(b =>
+                if (cullResidential && bld.Use == LandUseType.Residential)
+                    continue;
+
+                if (cullBySize)
                 {
-                    var env = b.Poly.EnvelopeInternal;
+                    var env = bld.Poly.EnvelopeInternal;
                     var p0 = ToPointF(env.MinX, env.MinY, bounds);
                     var p1 = ToPointF(env.MaxX, env.MaxY, bounds);
-                    return Math.Abs(p1.X - p0.X) > 4 || Math.Abs(p1.Y - p0.Y) > 4;
-                }).ToList();
-            }
+                    if (Math.Abs(p1.X - p0.X) < 4 && Math.Abs(p1.Y - p0.Y) < 4)
+                        continue;
+                }
 
-            // 2) Optionally drop residential buildings at very small scales
-            if (cellSize <= 20)
-            {
-                buildings = buildings.Where(b => b.Use != LandUseType.Residential).ToList();
+                culledBuildings.Add(bld);
             }
 
             // 3) Dynamically simplify footprints based on zoom level
@@ -124,7 +128,7 @@ namespace StrategyGame
                          * (cellSize <= 80 ? 2.5 : 1.0);
 
             var reduced = new List<(Nts.Polygon Poly, LandUseType Use)>();
-            foreach (var (poly, use, bld) in buildings)
+            foreach (var (poly, use, bld) in culledBuildings)
             {
                 var simplified = bld.SimplifiedFootprints.GetOrAdd(cellSize, _ =>
                 {
@@ -163,31 +167,23 @@ namespace StrategyGame
             double tolerance = (bounds.MaxLon - bounds.MinLon) / MultiResolutionMapManager.TileSizePx * 2.0;
 
             var gf = Nts.GeometryFactory.Default;
-            foreach (var group in roads.GroupBy(r => r.Type))
+            foreach (var road in roads)
             {
-                var lineStrings = group.Select(s =>
-                    gf.CreateLineString(new[]
-                    {
-                        new Nts.Coordinate(s.X1, s.Y1),
-                        new Nts.Coordinate(s.X2, s.Y2)
-                    })).ToArray();
-
-                if (lineStrings.Length == 0) continue;
-
-                var multi = gf.CreateMultiLineString(lineStrings);
-                var simplified = NetTopologySuite.Simplify.DouglasPeuckerSimplifier.Simplify(multi, tolerance) as Nts.MultiLineString;
-                if (simplified == null) continue;
-
-                for (int i = 0; i < simplified.NumGeometries; i++)
+                var line = gf.CreateLineString(new[]
                 {
-                    if (simplified.GetGeometryN(i) is Nts.LineString ln)
+                    new Nts.Coordinate(road.X1, road.Y1),
+                    new Nts.Coordinate(road.X2, road.Y2)
+                });
+
+                var simplified = DouglasPeuckerSimplifier.Simplify(line, tolerance);
+
+                if (simplified is Nts.LineString ln)
+                {
+                    for (int j = 0; j < ln.NumPoints - 1; j++)
                     {
-                        for (int j = 0; j < ln.NumPoints - 1; j++)
-                        {
-                            var c1 = ln.GetCoordinateN(j);
-                            var c2 = ln.GetCoordinateN(j + 1);
-                            yield return new LineSegment(c1.X, c1.Y, c2.X, c2.Y, group.Key);
-                        }
+                        var c1 = ln.GetCoordinateN(j);
+                        var c2 = ln.GetCoordinateN(j + 1);
+                        yield return new LineSegment(c1.X, c1.Y, c2.X, c2.Y, road.Type);
                     }
                 }
             }

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -7,9 +7,7 @@ using NetTopologySuite.Simplify;
 using System.Linq;
 using System;
 using System.Collections.Generic;
-using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.Threading.Tasks;
 using SixLabors.ImageSharp.Drawing;
 using economy_sim;
 
@@ -17,33 +15,34 @@ namespace StrategyGame
 {
     public static class ProceduralCityRenderer
     {
-        private static readonly ConcurrentDictionary<Guid, CityDataModel> _modelCache = new();
-        // This method is now async to support awaiting the data model.
-        public static async Task<Image<Rgba32>> RenderCityTileAsync(GeoBounds tileBounds, int cellSize)
+        // Rendering should never block on disk. Models must be supplied via cache.
+        public static Image<Rgba32> RenderCityTile(
+            GeoBounds tileBounds,
+            int cellSize,
+            IReadOnlyDictionary<Guid, CityDataModel> cityModelCache,
+            Action<Guid> requestModel)
         {
             var sw = Stopwatch.StartNew();
             var img = new Image<Rgba32>(MultiResolutionMapManager.TileSizePx, MultiResolutionMapManager.TileSizePx, new Rgba32(0, 0, 0, 0));
             var tilePoly = ToPolygon(tileBounds);
 
             var processedModelIds = new HashSet<Guid>();
-            
+
             var relevantUrbanAreas = UrbanAreaManager.Query(tileBounds);
 
-            // This loop now awaits the new async methods, preventing deadlocks.
             foreach (var urban in relevantUrbanAreas)
             {
                 if (!urban.EnvelopeInternal.Intersects(tilePoly.EnvelopeInternal) || !urban.Intersects(tilePoly))
                     continue;
 
-                var modelId = await RoadNetworkGenerator.GetCityDataModelIdAsync(urban).ConfigureAwait(false);
+                var modelId = RoadNetworkGenerator.GetCityDataModelIdAsync(urban).Result;
                 if (!modelId.HasValue || !processedModelIds.Add(modelId.Value))
                     continue;
 
-                if (!_modelCache.TryGetValue(modelId.Value, out var model))
+                if (!cityModelCache.TryGetValue(modelId.Value, out var model))
                 {
-                    model = await RoadNetworkGenerator.LoadCityDataModelAsync(modelId.Value).ConfigureAwait(false);
-                    if (model == null) continue;
-                    _modelCache[modelId.Value] = model;
+                    requestModel(modelId.Value);
+                    continue;
                 }
 
                 DrawRoads(img, modelId.Value, model.RoadNetwork, tileBounds, cellSize);

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -4,9 +4,11 @@ using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Drawing.Processing;
 using NetTopologySuite.Simplify;
+using NetTopologySuite.Geometries.Prepared;
 using System.Linq;
 using System;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using SixLabors.ImageSharp.Drawing;
 using economy_sim;
@@ -16,6 +18,7 @@ namespace StrategyGame
     public static class ProceduralCityRenderer
     {
         // Rendering should never block on disk. Models must be supplied via cache.
+        private static readonly ConcurrentDictionary<(Guid modelId, int cellSize), List<LineSegment>> _simplifiedRoadCache = new();
         public static Image<Rgba32> RenderCityTile(
             GeoBounds tileBounds,
             int cellSize,
@@ -26,13 +29,16 @@ namespace StrategyGame
             var img = new Image<Rgba32>(MultiResolutionMapManager.TileSizePx, MultiResolutionMapManager.TileSizePx, new Rgba32(0, 0, 0, 0));
             var tilePoly = ToPolygon(tileBounds);
 
+            var preparedFactory = new PreparedGeometryFactory();
+            var preparedTilePoly = preparedFactory.Create(tilePoly);
+
             var processedModelIds = new HashSet<Guid>();
 
             var relevantUrbanAreas = UrbanAreaManager.Query(tileBounds);
 
             foreach (var urban in relevantUrbanAreas)
             {
-                if (!urban.EnvelopeInternal.Intersects(tilePoly.EnvelopeInternal) || !urban.Intersects(tilePoly))
+                if (!preparedTilePoly.Intersects(urban))
                     continue;
 
                 var modelId = RoadNetworkGenerator.GetCityDataModelIdAsync(urban).Result;
@@ -180,19 +186,30 @@ namespace StrategyGame
         private static void DrawRoads(Image<Rgba32> img, Guid modelId, IEnumerable<LineSegment> roads, GeoBounds bounds, int cellSize)
         {
             var sw = Stopwatch.StartNew();
-            if (cellSize <= 40)
+
+            var simplifiedRoads = _simplifiedRoadCache.GetOrAdd((modelId, cellSize), _ =>
             {
-                roads = roads.Where(r => r.Type == RoadType.Primary);
+                var filteredRoads = cellSize <= 40
+                    ? roads.Where(r => r.Type == RoadType.Primary).ToList()
+                    : roads.ToList();
+
+                return SimplifyRoads(filteredRoads, bounds).ToList();
+            });
+
+            if (!simplifiedRoads.Any())
+            {
+                PerformanceTracker.Record("CityRenderer-RoadDrawing", sw.Elapsed);
+                return;
             }
 
-            var cached = CityModelCache.GetOrAddRoads(modelId, cellSize, roads, bounds);
+            var cachedPaths = CityModelCache.GetOrAddRoads(modelId, cellSize, simplifiedRoads, bounds);
 
             var primaryPen = SixLabors.ImageSharp.Drawing.Processing.Pens.Solid(new Rgba32(180, 180, 180, 200), 2f);
             var secondaryPen = SixLabors.ImageSharp.Drawing.Processing.Pens.Solid(new Rgba32(180, 180, 180, 200), 1f);
 
             img.Mutate(ctx => ctx
-                .Draw(secondaryPen, cached.SecondaryPath)
-                .Draw(primaryPen, cached.PrimaryPath)
+                .Draw(secondaryPen, cachedPaths.SecondaryPath)
+                .Draw(primaryPen, cachedPaths.PrimaryPath)
             );
             PerformanceTracker.Record("CityRenderer-RoadDrawing", sw.Elapsed);
         }

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -10,6 +10,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Threading.Tasks;
 using SixLabors.ImageSharp.Drawing;
 using economy_sim;
 
@@ -19,7 +20,7 @@ namespace StrategyGame
     {
         // Rendering should never block on disk. Models must be supplied via cache.
         private static readonly ConcurrentDictionary<(Guid modelId, int cellSize), List<LineSegment>> _simplifiedRoadCache = new();
-        public static Image<Rgba32> RenderCityTile(
+        public static async Task<Image<Rgba32>> RenderCityTileAsync(
             GeoBounds tileBounds,
             int cellSize,
             IReadOnlyDictionary<Guid, CityDataModel> cityModelCache,
@@ -36,12 +37,23 @@ namespace StrategyGame
 
             var relevantUrbanAreas = UrbanAreaManager.Query(tileBounds);
 
+            var modelIdTasks = new List<Task<(Guid? Id, Nts.Polygon Urban)>>();
             foreach (var urban in relevantUrbanAreas)
             {
                 if (!preparedTilePoly.Intersects(urban))
                     continue;
 
-                var modelId = RoadNetworkGenerator.GetCityDataModelIdAsync(urban).Result;
+                modelIdTasks.Add(async () =>
+                {
+                    var id = await RoadNetworkGenerator.GetCityDataModelIdAsync(urban).ConfigureAwait(false);
+                    return (id, urban);
+                }());
+            }
+
+            var results = await Task.WhenAll(modelIdTasks).ConfigureAwait(false);
+
+            foreach (var (modelId, urban) in results)
+            {
                 if (!modelId.HasValue || !processedModelIds.Add(modelId.Value))
                     continue;
 
@@ -52,8 +64,7 @@ namespace StrategyGame
                 }
 
                 DrawRoads(img, modelId.Value, model.RoadNetwork, tileBounds, cellSize);
-                
-                // Query visible buildings using the model's spatial index
+
                 var tileEnv = tilePoly.EnvelopeInternal;
                 var candidates = (model.BuildingIndex?.Query(tileEnv).Cast<Building>() ?? model.Buildings);
                 var toDraw = new List<(Nts.Polygon, LandUseType, Building)>();
@@ -63,7 +74,6 @@ namespace StrategyGame
                     if (!env.Intersects(tileEnv)) continue;
                     var baseGeom = b.SimplifiedFootprints.TryGetValue(0, out var g) ? g : b.Footprint;
 
-                    // Skip expensive clipping; ImageSharp will clip while filling
                     if (baseGeom is Nts.Polygon p && !p.IsEmpty)
                     {
                         toDraw.Add((p, b.LandUse, b));

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -57,17 +57,19 @@ namespace StrategyGame
                     var env = b.Footprint.EnvelopeInternal;
                     if (!env.Intersects(tileEnv)) continue;
                     var baseGeom = b.SimplifiedFootprints.TryGetValue(0, out var g) ? g : b.Footprint;
-                    Nts.Geometry clipped = tileEnv.Contains(env)
-                        ? baseGeom
-                        : baseGeom.Intersection(tilePoly);
 
-                    if (clipped is Nts.Polygon p && !p.IsEmpty)
+                    // Skip expensive clipping; ImageSharp will clip while filling
+                    if (baseGeom is Nts.Polygon p && !p.IsEmpty)
+                    {
                         toDraw.Add((p, b.LandUse, b));
-                    else if (clipped is Nts.MultiPolygon mp)
+                    }
+                    else if (baseGeom is Nts.MultiPolygon mp)
                     {
                         for (int i = 0; i < mp.NumGeometries; i++)
+                        {
                             if (mp.GetGeometryN(i) is Nts.Polygon pp && !pp.IsEmpty)
                                 toDraw.Add((pp, b.LandUse, b));
+                        }
                     }
                 }
 

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -51,23 +51,23 @@ namespace StrategyGame
                 // Query visible buildings using the model's spatial index
                 var tileEnv = tilePoly.EnvelopeInternal;
                 var candidates = (model.BuildingIndex?.Query(tileEnv).Cast<Building>() ?? model.Buildings);
-                var toDraw = new List<(Nts.Polygon, LandUseType)>();
+                var toDraw = new List<(Nts.Polygon, LandUseType, Building)>();
                 foreach (var b in candidates)
                 {
                     var env = b.Footprint.EnvelopeInternal;
                     if (!env.Intersects(tileEnv)) continue;
-                    var baseGeom = b.SimplifiedFootprint ?? b.Footprint;
+                    var baseGeom = b.SimplifiedFootprints.TryGetValue(0, out var g) ? g : b.Footprint;
                     Nts.Geometry clipped = tileEnv.Contains(env)
                         ? baseGeom
                         : baseGeom.Intersection(tilePoly);
 
                     if (clipped is Nts.Polygon p && !p.IsEmpty)
-                        toDraw.Add((p, b.LandUse));
+                        toDraw.Add((p, b.LandUse, b));
                     else if (clipped is Nts.MultiPolygon mp)
                     {
                         for (int i = 0; i < mp.NumGeometries; i++)
                             if (mp.GetGeometryN(i) is Nts.Polygon pp && !pp.IsEmpty)
-                                toDraw.Add((pp, b.LandUse));
+                                toDraw.Add((pp, b.LandUse, b));
                     }
                 }
 
@@ -79,7 +79,7 @@ namespace StrategyGame
         }
 
         // Batched building drawing with caching and dynamic LOD
-        private static void DrawBuildings(Image<Rgba32> img, Guid modelId, List<(Nts.Polygon Poly, LandUseType Use)> buildings, GeoBounds bounds, int cellSize)
+        private static void DrawBuildings(Image<Rgba32> img, Guid modelId, List<(Nts.Polygon Poly, LandUseType Use, Building Bld)> buildings, GeoBounds bounds, int cellSize)
         {
             var sw = Stopwatch.StartNew();
 
@@ -107,10 +107,13 @@ namespace StrategyGame
                          * (cellSize <= 80 ? 2.5 : 1.0);
 
             var reduced = new List<(Nts.Polygon Poly, LandUseType Use)>();
-            foreach (var (poly, use) in buildings)
+            foreach (var (poly, use, bld) in buildings)
             {
-                var simplified = DouglasPeuckerSimplifier.Simplify(poly, tol);
-                if (simplified == null || simplified.IsEmpty) continue;
+                var simplified = bld.SimplifiedFootprints.GetOrAdd(cellSize, _ =>
+                {
+                    var simplifiedGeom = DouglasPeuckerSimplifier.Simplify(poly, tol);
+                    return (simplifiedGeom == null || simplifiedGeom.IsEmpty) ? poly : simplifiedGeom;
+                });
 
                 if (simplified is Nts.Polygon p)
                 {

--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -31,7 +31,10 @@ namespace StrategyGame
             var index = new STRtree<Building>();
             foreach (var b in model.Buildings)
             {
-                b.SimplifiedFootprint = DouglasPeuckerSimplifier.Simplify(b.Footprint, tol);
+                var simplified = DouglasPeuckerSimplifier.Simplify(b.Footprint, tol);
+                if (simplified == null || simplified.IsEmpty)
+                    simplified = b.Footprint;
+                b.SimplifiedFootprints[0] = simplified;
                 index.Insert(b.Footprint.EnvelopeInternal, b);
             }
             index.Build();


### PR DESCRIPTION
## Summary
- speed up ImageSharp-to-Bitmap conversion
- cache building geometry by zoom level
- use new cache while rendering
- store simplified building footprints when generating city data

## Testing
- `dotnet build "economy sim.sln" -v minimal` *(fails: SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cecc4ec388323859306623481ac32