### PR TITLE
Optimize coordinate conversions

### DIFF
--- a/CityModelCache.cs
+++ b/CityModelCache.cs
@@ -31,12 +31,18 @@ namespace StrategyGame
 
                 var primaryBuilder = new PathBuilder();
                 var secondaryBuilder = new PathBuilder();
+                float sx = MultiResolutionMapManager.TileSizePx / (float)(bounds.MaxLon - bounds.MinLon);
+                float sy = MultiResolutionMapManager.TileSizePx / (float)(bounds.MaxLat - bounds.MinLat);
                 foreach (var seg in simplified)
                 {
                     var pb = seg.Type == RoadType.Primary ? primaryBuilder : secondaryBuilder;
                     pb.AddLine(
-                        ProceduralCityRenderer.ToPointF(seg.X1, seg.Y1, bounds),
-                        ProceduralCityRenderer.ToPointF(seg.X2, seg.Y2, bounds));
+                        new PointF(
+                            (float)((seg.X1 - bounds.MinLon) * sx),
+                            (float)((bounds.MaxLat - seg.Y1) * sy)),
+                        new PointF(
+                            (float)((seg.X2 - bounds.MinLon) * sx),
+                            (float)((bounds.MaxLat - seg.Y2) * sy)));
                 }
 
                 return new CachedRoads
@@ -53,12 +59,17 @@ namespace StrategyGame
             return _buildings.GetOrAdd(key, _ =>
             {
                 var dict = new Dictionary<Rgba32, IPath>();
+                float sx = MultiResolutionMapManager.TileSizePx / (float)(bounds.MaxLon - bounds.MinLon);
+                float sy = MultiResolutionMapManager.TileSizePx / (float)(bounds.MaxLat - bounds.MinLat);
                 foreach (var group in buildings.GroupBy(b => ProceduralCityRenderer.GetBuildingColor(b.Use)))
                 {
                     var pb = new PathBuilder();
                     foreach (var item in group)
                     {
-                        var points = item.Poly.ExteriorRing.Coordinates.Select(c => ProceduralCityRenderer.ToPointF(c.X, c.Y, bounds)).ToArray();
+                        var points = item.Poly.ExteriorRing.Coordinates.Select(c =>
+                            new PointF(
+                                (float)((c.X - bounds.MinLon) * sx),
+                                (float)((bounds.MaxLat - c.Y) * sy))).ToArray();
                         pb.AddLines(points);
                         pb.CloseFigure();
                     }

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -105,6 +105,8 @@ namespace StrategyGame
             bool cullBySize = cellSize <= 40;
             bool cullResidential = cellSize <= 20;
 
+            float sx = MultiResolutionMapManager.TileSizePx / (float)(bounds.MaxLon - bounds.MinLon);
+            float sy = MultiResolutionMapManager.TileSizePx / (float)(bounds.MaxLat - bounds.MinLat);
             foreach (var bld in buildings)
             {
                 if (cullResidential && bld.Use == LandUseType.Residential)
@@ -113,9 +115,11 @@ namespace StrategyGame
                 if (cullBySize)
                 {
                     var env = bld.Poly.EnvelopeInternal;
-                    var p0 = ToPointF(env.MinX, env.MinY, bounds);
-                    var p1 = ToPointF(env.MaxX, env.MaxY, bounds);
-                    if (Math.Abs(p1.X - p0.X) < 4 && Math.Abs(p1.Y - p0.Y) < 4)
+                    float p0x = (float)((env.MinX - bounds.MinLon) * sx);
+                    float p0y = (float)((bounds.MaxLat - env.MinY) * sy);
+                    float p1x = (float)((env.MaxX - bounds.MinLon) * sx);
+                    float p1y = (float)((bounds.MaxLat - env.MaxY) * sy);
+                    if (Math.Abs(p1x - p0x) < 4 && Math.Abs(p1y - p0y) < 4)
                         continue;
                 }
 


### PR DESCRIPTION
## Summary
- inline scale factors and avoid repeated `ToPointF` calls
- convert building culling and path generation using cached `sx`/`sy`

## Testing
- `dotnet build "economy sim.sln" -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cfa6934b883238322087548d48ae3