### PR TITLE
Pre-generate city models asynchronously

### DIFF
--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -228,21 +228,27 @@ namespace StrategyGame
             var skBmp = ImageSharpToSkia(generated);
             PerformanceTracker.Record("CityTileManager-GenerateTile", genSw.Elapsed);
 
-            string dir = Path.GetDirectoryName(path);
-            Directory.CreateDirectory(dir);
-            var lockFile = GetFileLock(path);
-            await lockFile.WaitAsync(token).ConfigureAwait(false);
-            try
+            // Save the generated tile image in the background. The caller
+            // shouldn't wait for disk IO before receiving the bitmap.
+            _ = Task.Run(async () =>
             {
-                var saveSw = Stopwatch.StartNew();
-                await using var fs = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None, 4096, true);
-                await generated.SaveAsPngAsync(fs, token).ConfigureAwait(false);
-                PerformanceTracker.Record("CityTileManager-SaveTile", saveSw.Elapsed);
-            }
-            finally
-            {
-                lockFile.Release();
-            }
+                string dir = Path.GetDirectoryName(path);
+                Directory.CreateDirectory(dir);
+                var lockFile = GetFileLock(path);
+                await lockFile.WaitAsync(CancellationToken.None).ConfigureAwait(false);
+                try
+                {
+                    var saveSw = Stopwatch.StartNew();
+                    await using var fs = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None, 4096, true);
+                    await generated.SaveAsPngAsync(fs, CancellationToken.None).ConfigureAwait(false);
+                    PerformanceTracker.Record("CityTileManager-SaveTile", saveSw.Elapsed);
+                }
+                finally
+                {
+                    lockFile.Release();
+                    generated.Dispose();
+                }
+            });
 
             _tileCache.TryAdd(key, skBmp); // Add to concurrent cache
             _inFlight.TryRemove(key, out _); // Clean up in-flight task

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -24,7 +24,6 @@ namespace StrategyGame
         private readonly MultiResolutionMapManager _mapManager;
         private readonly ConcurrentDictionary<(int cellSize, int x, int y), SKBitmap> _tileCache = new();
         private readonly ConcurrentDictionary<(int cellSize, int x, int y), Task<SKBitmap>> _inFlight = new();
-        private readonly ConcurrentDictionary<Guid, CityDataModel> _cityModelCache = new();
         private readonly ConcurrentDictionary<Guid, Task> _cityModelLoadTasks = new();
         public static readonly bool GpuAvailable;
 
@@ -84,9 +83,9 @@ namespace StrategyGame
             }
         }
 
-        private void RequestModel(Guid modelId, Action triggerRefresh)
+        private void RequestModel(Guid modelId, Action? triggerRefresh)
         {
-            if (_cityModelCache.ContainsKey(modelId) || _cityModelLoadTasks.ContainsKey(modelId))
+            if (RoadNetworkGenerator.ModelCacheById.ContainsKey(modelId) || _cityModelLoadTasks.ContainsKey(modelId))
                 return;
 
             var loadTask = Task.Run(async () =>
@@ -95,10 +94,7 @@ namespace StrategyGame
                 {
                     var model = await RoadNetworkGenerator.LoadCityDataModelAsync(modelId).ConfigureAwait(false);
                     if (model != null)
-                    {
-                        _cityModelCache.TryAdd(model.Id, model);
                         triggerRefresh?.Invoke();
-                    }
                 }
                 finally
                 {
@@ -222,7 +218,7 @@ namespace StrategyGame
             var generated = await ProceduralCityRenderer.RenderCityTileAsync(
                 bounds,
                 cellSize,
-                _cityModelCache,
+                RoadNetworkGenerator.ModelCacheById,
                 id => RequestModel(id, triggerRefresh)
             ).ConfigureAwait(false);
             var skBmp = ImageSharpToSkia(generated);

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -225,9 +225,12 @@ namespace StrategyGame
             PerformanceTracker.Record("CityTileManager-GenerateTile", genSw.Elapsed);
 
             // Save the generated tile image in the background. The caller
-            // shouldn't wait for disk IO before receiving the bitmap.
+            // shouldn't wait for disk IO before receiving the bitmap. Clone
+            // the image so disposing it won't affect the SKBitmap.
             _ = Task.Run(async () =>
             {
+                using var imageToSave = generated.Clone();
+
                 string dir = Path.GetDirectoryName(path);
                 Directory.CreateDirectory(dir);
                 var lockFile = GetFileLock(path);
@@ -236,13 +239,12 @@ namespace StrategyGame
                 {
                     var saveSw = Stopwatch.StartNew();
                     await using var fs = new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.None, 4096, true);
-                    await generated.SaveAsPngAsync(fs, CancellationToken.None).ConfigureAwait(false);
+                    await imageToSave.SaveAsPngAsync(fs, CancellationToken.None).ConfigureAwait(false);
                     PerformanceTracker.Record("CityTileManager-SaveTile", saveSw.Elapsed);
                 }
                 finally
                 {
                     lockFile.Release();
-                    generated.Dispose();
                 }
             });
 

--- a/LoadingForm.Designer.cs
+++ b/LoadingForm.Designer.cs
@@ -1,0 +1,38 @@
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace economy_sim
+{
+    public partial class LoadingForm : Form
+    {
+        private ProgressBar progressBar;
+        private Label labelStatus;
+
+        private void InitializeComponent()
+        {
+            progressBar = new ProgressBar();
+            labelStatus = new Label();
+            SuspendLayout();
+
+            progressBar.Dock = DockStyle.Bottom;
+            progressBar.Minimum = 0;
+            progressBar.Maximum = 100;
+            progressBar.Style = ProgressBarStyle.Continuous;
+
+            labelStatus.Dock = DockStyle.Fill;
+            labelStatus.TextAlign = ContentAlignment.MiddleCenter;
+
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(300, 80);
+            Controls.Add(labelStatus);
+            Controls.Add(progressBar);
+            FormBorderStyle = FormBorderStyle.FixedDialog;
+            StartPosition = FormStartPosition.CenterScreen;
+            Text = "Loading";
+            ControlBox = false;
+
+            ResumeLayout(false);
+        }
+    }
+}

--- a/LoadingForm.cs
+++ b/LoadingForm.cs
@@ -1,0 +1,20 @@
+using System.Windows.Forms;
+
+namespace economy_sim
+{
+    public partial class LoadingForm : Form
+    {
+        public LoadingForm()
+        {
+            InitializeComponent();
+        }
+
+        public void UpdateProgress(int processed, int total)
+        {
+            int percent = total > 0 ? (int)(processed * 100.0 / total) : 0;
+            if (percent > 100) percent = 100;
+            progressBar.Value = percent;
+            labelStatus.Text = $"Generating city models {processed}/{total}";
+        }
+    }
+}

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -244,8 +244,10 @@ namespace economy_sim
                 MainGame_Shown(s, e); // Call your new handler
             };
         }
-        private void MainGame_Shown(object sender, EventArgs e)
+        private async void MainGame_Shown(object sender, EventArgs e)
         {
+            await PreGenerateMissingCityDataAsync();
+
             // Start the simulation loop on a background thread
             // now that the form is fully loaded and displayed.
             simCts = new CancellationTokenSource();
@@ -362,7 +364,6 @@ namespace economy_sim
 
             // Load urban area polygons for procedural generation
             UrbanAreaManager.LoadUrbanAreas();
-            CheckAndPromptForMissingCityData();
 
             // 3. Load World Setup from JSON
             string jsonFilePath = "world_setup.json";
@@ -2074,6 +2075,37 @@ namespace economy_sim
             {
                 await Task.Delay(100).ConfigureAwait(false);
             }
+        }
+
+        private async Task PreGenerateMissingCityDataAsync()
+        {
+            var missing = new List<Nts.Polygon>();
+            foreach (var urban in UrbanAreaManager.UrbanPolygons)
+            {
+                if (!RoadNetworkGenerator.HasCityDataModel(urban))
+                    missing.Add(urban);
+            }
+
+            if (missing.Count == 0)
+                return;
+
+            using var loading = new LoadingForm();
+            loading.UpdateProgress(0, missing.Count);
+            loading.Show();
+
+            foreach (var urban in missing)
+                cityGenerationManager.QueueArea(urban);
+
+            while (true)
+            {
+                int completed = missing.Count(a => RoadNetworkGenerator.HasCityDataModel(a));
+                loading.UpdateProgress(completed, missing.Count);
+                if (completed >= missing.Count && !cityGenerationManager.IsProcessing())
+                    break;
+                await Task.Delay(500).ConfigureAwait(true);
+            }
+
+            loading.Close();
         }
 
         /// <summary>

--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -23,6 +23,9 @@ namespace StrategyGame
     {
         private static readonly ConcurrentDictionary<string, List<(Nts.LineString Line, RoadType Type)>> networkCache = new();
         private static readonly ConcurrentDictionary<string, CityDataModel> modelCache = new();
+        private static readonly ConcurrentDictionary<Guid, CityDataModel> modelCacheById = new();
+
+        public static IReadOnlyDictionary<Guid, CityDataModel> ModelCacheById => modelCacheById;
         private static readonly ConcurrentDictionary<string, SemaphoreSlim> _fileLocks = new();
 
         private static void BuildBuildingStructures(CityDataModel model)
@@ -52,6 +55,12 @@ namespace StrategyGame
         private static SemaphoreSlim GetFileLock(string path)
         {
             return _fileLocks.GetOrAdd(path, p => new SemaphoreSlim(1, 1));
+        }
+
+        private static void AddToCache(string hash, CityDataModel model)
+        {
+            modelCache[hash] = model;
+            modelCacheById[model.Id] = model;
         }
 
 
@@ -215,7 +224,10 @@ namespace StrategyGame
             string cacheDir = GetCacheDir();
 
             if (modelCache.TryGetValue(hash, out var cachedModel))
+            {
+                modelCacheById[cachedModel.Id] = cachedModel;
                 return cachedModel;
+            }
 
             string hashPath = Path.Combine(cacheDir, $"{hash}.txt");
             if (File.Exists(hashPath))
@@ -227,7 +239,7 @@ namespace StrategyGame
                     if (File.Exists(modelPath))
                     {
                         var loaded = await LoadModelBinaryAsync(modelPath);
-                        modelCache[hash] = loaded;
+                        AddToCache(hash, loaded);
                         return loaded;
                     }
                 }
@@ -280,7 +292,7 @@ namespace StrategyGame
                 Console.WriteLine($"[CRITICAL ERROR] Failed to serialize CityDataModel: {errorMessage}");
             }
 
-            modelCache[hash] = result;
+            AddToCache(hash, result);
             return result;
         }
 
@@ -548,7 +560,10 @@ namespace StrategyGame
             
             // Check in-memory cache first
             if (modelCache.TryGetValue(hash, out var cachedModel))
+            {
+                modelCacheById[cachedModel.Id] = cachedModel;
                 return cachedModel.Id;
+            }
                 
             // Check disk cache
             string hashPath = Path.Combine(cacheDir, $"{hash}.txt");
@@ -613,13 +628,22 @@ namespace StrategyGame
 
         public static async Task<CityDataModel?> LoadCityDataModelAsync(Guid id)
         {
+            if (modelCacheById.TryGetValue(id, out var cached))
+                return cached;
+
             string cacheDir = GetCacheDir();
             string modelPath = Path.Combine(cacheDir, $"{id}.bin");
             if (!File.Exists(modelPath)) return null;
 
             try
             {
-                return await LoadModelBinaryAsync(modelPath).ConfigureAwait(false);
+                var model = await LoadModelBinaryAsync(modelPath).ConfigureAwait(false);
+                if (model.UrbanArea != null)
+                {
+                    string hash = ComputeHash(model.UrbanArea);
+                    AddToCache(hash, model);
+                }
+                return model;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- add a simple LoadingForm with a progress bar
- automatically pre-generate missing city models on startup
- update renderer startup flow

## Testing
- `dotnet build "economy sim.sln" -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d8cd82f448323b4827444bb201773