### PR TITLE
Optimize road rendering

### DIFF
--- a/CityModelCache.cs
+++ b/CityModelCache.cs
@@ -17,17 +17,20 @@ namespace StrategyGame
         {
             return _roads.GetOrAdd((modelId, cellSize), _ =>
             {
-                var tileBox = new NetTopologySuite.Geometries.Envelope(bounds.MinLon, bounds.MaxLon, bounds.MinLat, bounds.MaxLat);
-                var clipped = rawRoads.Where(r =>
+                var clippedSegments = new List<LineSegment>();
+                foreach (var seg in rawRoads)
                 {
-                    double minX = Math.Min(r.X1, r.X2);
-                    double maxX = Math.Max(r.X1, r.X2);
-                    double minY = Math.Min(r.Y1, r.Y2);
-                    double maxY = Math.Max(r.Y1, r.Y2);
-                    return !(maxX < tileBox.MinX || minX > tileBox.MaxX || maxY < tileBox.MinY || minY > tileBox.MaxY);
-                });
+                    double x1 = seg.X1;
+                    double y1 = seg.Y1;
+                    double x2 = seg.X2;
+                    double y2 = seg.Y2;
+                    if (GeometryUtil.ClipLine(bounds, ref x1, ref y1, ref x2, ref y2))
+                    {
+                        clippedSegments.Add(new LineSegment(x1, y1, x2, y2, seg.Type));
+                    }
+                }
 
-                var simplified = ProceduralCityRenderer.SimplifyRoads(clipped, bounds).ToList();
+                var simplified = ProceduralCityRenderer.SimplifyRoads(clippedSegments, bounds).ToList();
 
                 var primaryBuilder = new PathBuilder();
                 var secondaryBuilder = new PathBuilder();

--- a/CityTileManager.cs
+++ b/CityTileManager.cs
@@ -25,6 +25,7 @@ namespace StrategyGame
         private readonly ConcurrentDictionary<(int cellSize, int x, int y), SKBitmap> _tileCache = new();
         private readonly ConcurrentDictionary<(int cellSize, int x, int y), Task<SKBitmap>> _inFlight = new();
         private readonly ConcurrentDictionary<Guid, Task> _cityModelLoadTasks = new();
+        private static readonly SemaphoreSlim _tileProcessingLimiter = new SemaphoreSlim(Environment.ProcessorCount);
         public static readonly bool GpuAvailable;
 
         static CityTileManager()
@@ -202,7 +203,10 @@ namespace StrategyGame
                     await using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, true);
                     var img = await SixLabors.ImageSharp.Image.LoadAsync<Rgba32>(fs, token).ConfigureAwait(false);
                     var sk = ImageSharpToSkia(img);
-                    _tileCache.TryAdd(key, sk); // Add to concurrent cache
+                    if (_tileCache.TryAdd(key, sk))
+                    {
+                        triggerRefresh?.Invoke();
+                    }
                     _inFlight.TryRemove(key, out _); // Clean up in-flight task
                     PerformanceTracker.Record("CityTileManager-LoadTile-FromDisk", loadSw.Elapsed);
                     return sk;
@@ -248,7 +252,10 @@ namespace StrategyGame
                 }
             });
 
-            _tileCache.TryAdd(key, skBmp); // Add to concurrent cache
+            if (_tileCache.TryAdd(key, skBmp))
+            {
+                triggerRefresh?.Invoke();
+            }
             _inFlight.TryRemove(key, out _); // Clean up in-flight task
             PerformanceTracker.Record("CityTileManager-LoadTile", totalSw.Elapsed);
             return skBmp;
@@ -338,6 +345,21 @@ namespace StrategyGame
                 }
             }
 
+            if (missingTiles.Any())
+            {
+                var viewCenterX = viewRect.X + viewRect.Width / 2.0;
+                var viewCenterY = viewRect.Y + viewRect.Height / 2.0;
+                missingTiles = missingTiles
+                    .OrderBy(tile =>
+                    {
+                        var tileCenterX = tile.x * tileSize + tileSize / 2.0;
+                        var tileCenterY = tile.y * tileSize + tileSize / 2.0;
+                        return Math.Pow(tileCenterX - viewCenterX, 2) +
+                               Math.Pow(tileCenterY - viewCenterY, 2);
+                    })
+                    .ToList();
+            }
+
             if (!missingTiles.Any())
             {
                 PerformanceTracker.Record("CityTileManager-PreloadTiles", sw.Elapsed);
@@ -345,7 +367,18 @@ namespace StrategyGame
                 return;
             }
 
-            var tasks = missingTiles.Select(coord => GetTileAsync(zoom, coord.x, coord.y, token, triggerRefresh));
+            var tasks = missingTiles.Select(async coord =>
+            {
+                await _tileProcessingLimiter.WaitAsync(token).ConfigureAwait(false);
+                try
+                {
+                    await GetTileAsync(zoom, coord.x, coord.y, token, triggerRefresh).ConfigureAwait(false);
+                }
+                finally
+                {
+                    _tileProcessingLimiter.Release();
+                }
+            });
             await Task.WhenAll(tasks).ConfigureAwait(false);
             PerformanceTracker.Record("CityTileManager-PreloadTiles", sw.Elapsed);
             triggerRefresh?.Invoke();

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -195,26 +195,85 @@ namespace StrategyGame
         {
             double tolerance = (bounds.MaxLon - bounds.MinLon) / MultiResolutionMapManager.TileSizePx * 2.0;
 
-            foreach (var road in roads)
+            foreach (var group in roads.GroupBy(r => r.Type))
             {
-                var line = _geomFactory.CreateLineString(new[]
+                var polylines = GroupSegments(group.ToList());
+                foreach (var lineCoords in polylines)
                 {
-                    new Nts.Coordinate(road.X1, road.Y1),
-                    new Nts.Coordinate(road.X2, road.Y2)
-                });
-
-                var simplified = DouglasPeuckerSimplifier.Simplify(line, tolerance);
-
-                if (simplified is Nts.LineString ln)
-                {
-                    for (int j = 0; j < ln.NumPoints - 1; j++)
+                    var line = _geomFactory.CreateLineString(lineCoords.Select(p => new Nts.Coordinate(p.X, p.Y)).ToArray());
+                    var simplified = DouglasPeuckerSimplifier.Simplify(line, tolerance);
+                    if (simplified is Nts.LineString ln)
                     {
-                        var c1 = ln.GetCoordinateN(j);
-                        var c2 = ln.GetCoordinateN(j + 1);
-                        yield return new LineSegment(c1.X, c1.Y, c2.X, c2.Y, road.Type);
+                        for (int j = 0; j < ln.NumPoints - 1; j++)
+                        {
+                            var c1 = ln.GetCoordinateN(j);
+                            var c2 = ln.GetCoordinateN(j + 1);
+                            yield return new LineSegment(c1.X, c1.Y, c2.X, c2.Y, group.Key);
+                        }
                     }
                 }
             }
+        }
+
+        private static List<List<(double X, double Y)>> GroupSegments(List<LineSegment> segments)
+        {
+            var result = new List<List<(double X, double Y)>>();
+            var remaining = new List<LineSegment>(segments);
+
+            while (remaining.Count > 0)
+            {
+                var seg = remaining[^1];
+                remaining.RemoveAt(remaining.Count - 1);
+                var poly = new List<(double X, double Y)> { (seg.X1, seg.Y1), (seg.X2, seg.Y2) };
+
+                bool changed;
+                do
+                {
+                    changed = false;
+                    for (int i = 0; i < remaining.Count; i++)
+                    {
+                        var s = remaining[i];
+                        if (PointsEqual(poly[^1], (s.X1, s.Y1)))
+                        {
+                            poly.Add((s.X2, s.Y2));
+                            remaining.RemoveAt(i);
+                            changed = true;
+                            break;
+                        }
+                        if (PointsEqual(poly[^1], (s.X2, s.Y2)))
+                        {
+                            poly.Add((s.X1, s.Y1));
+                            remaining.RemoveAt(i);
+                            changed = true;
+                            break;
+                        }
+                        if (PointsEqual(poly[0], (s.X2, s.Y2)))
+                        {
+                            poly.Insert(0, (s.X1, s.Y1));
+                            remaining.RemoveAt(i);
+                            changed = true;
+                            break;
+                        }
+                        if (PointsEqual(poly[0], (s.X1, s.Y1)))
+                        {
+                            poly.Insert(0, (s.X2, s.Y2));
+                            remaining.RemoveAt(i);
+                            changed = true;
+                            break;
+                        }
+                    }
+                } while (changed);
+
+                result.Add(poly);
+            }
+
+            return result;
+        }
+
+        private static bool PointsEqual((double X, double Y) a, (double X, double Y) b)
+        {
+            const double Eps = 1e-9;
+            return Math.Abs(a.X - b.X) < Eps && Math.Abs(a.Y - b.Y) < Eps;
         }
 
         private static void DrawRoads(Image<Rgba32> img, Guid modelId, IEnumerable<LineSegment> roads, GeoBounds bounds, int cellSize)


### PR DESCRIPTION
## Summary
- group connected road segments before simplification
- clip segments to tile boundaries when caching roads

## Testing
- `dotnet build "economy sim.sln" -v minimal` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_687da02757208323a5f21188d0170491