### PR TITLE
Store city procedural data links

### DIFF
--- a/City.cs
+++ b/City.cs
@@ -15,6 +15,7 @@ namespace StrategyGame
         public double CityExpenses { get; set; }
         public List<Factory> Factories { get; set; }
         public Dictionary<string, Good> Stockpile { get; set; }
+        public CityDataModel ProceduralData { get; set; }
         
         // Local market data
         public Dictionary<string, double> LocalPrices { get; set; }

--- a/Economy.cs
+++ b/Economy.cs
@@ -205,6 +205,7 @@ namespace StrategyGame
         public int WorkersEmployed { get; set; } // This might become a sum of employed from JobSlots or represent total workforce
         public Dictionary<string, int> JobSlots { get; set; }
         public Dictionary<string, int> ActualEmployed { get; set; } // Tracks actual number employed in each slot type
+        public Building BuildingData { get; set; }
 
         public Factory(string name, int productionCapacity)
         {

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -467,6 +467,18 @@ namespace economy_sim
                                         }
                                     }
                                 }
+                                if (cityData.CityModelId != Guid.Empty)
+                                {
+                                    var model = RoadNetworkGenerator.LoadCityDataModelAsync(cityData.CityModelId).GetAwaiter().GetResult();
+                                    currentCity.ProceduralData = model;
+                                    if (model != null)
+                                    {
+                                        for (int idx = 0; idx < currentCity.Factories.Count && idx < model.Buildings.Count; idx++)
+                                        {
+                                            currentCity.Factories[idx].BuildingData = model.Buildings[idx];
+                                        }
+                                    }
+                                }
                                 currentState.Cities.Add(currentCity);
                                 allCitiesInWorld.Add(currentCity);
                             }
@@ -554,6 +566,17 @@ namespace economy_sim
             defaultCity.TaxRate = 0.05;
             defaultCity.CityExpenses = 1000;
 
+            var fallbackArea = new Nts.Polygon(new Nts.LinearRing(new[]
+            {
+                new Nts.Coordinate(0,0),
+                new Nts.Coordinate(0,1),
+                new Nts.Coordinate(1,1),
+                new Nts.Coordinate(1,0),
+                new Nts.Coordinate(0,0)
+            }));
+            var fallbackModel = RoadNetworkGenerator.GenerateModelAsync(fallbackArea, 10).GetAwaiter().GetResult();
+            defaultCity.ProceduralData = fallbackModel;
+
             // Add a basic farm to the default city
             StrategyGame.FactoryBlueprint farmBlueprint = StrategyGame.FactoryBlueprints.AllBlueprints.FirstOrDefault(bp => bp.FactoryTypeName == "Grain Farm");
             if (farmBlueprint != null)
@@ -583,6 +606,8 @@ namespace economy_sim
                     }
                 }
                 defaultCity.Factories.Add(farm);
+                if (fallbackModel != null && fallbackModel.Buildings.Any())
+                    farm.BuildingData = fallbackModel.Buildings.First();
             }
             defaultState.Cities.Add(defaultCity);
             allCitiesInWorld.Add(defaultCity);

--- a/WorldDataGenerator.cs
+++ b/WorldDataGenerator.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Nts = NetTopologySuite.Geometries;
 
 namespace StrategyGame
 {
@@ -904,6 +905,9 @@ new List<CountryTemplate>
         {
             var rnd = new Random();
             var world = new WorldSetupData { Countries = new List<CountryData>(), ConstructionCompanies = new List<ConstructionCompanyData>() };
+            UrbanAreaManager.LoadUrbanAreas();
+            if (RoadNetworkGenerator.Data == null)
+                RoadNetworkGenerator.Data = new CityGenerationData(new float[1, 1], new bool[1, 1], new float[1, 1]);
             var usedCountryNames = new HashSet<string>();
             var usedStateNames = new HashSet<string>();
             var usedCityNames = new HashSet<string>();
@@ -1010,6 +1014,24 @@ new List<CountryTemplate>
                             CityExpenses = rnd.Next(10000, (int)Math.Max(stateData.StateExpenses / (numCitiesToGenerate + 1), 10000) + 1),
                             InitialFactories = new List<InitialFactoryData>()
                         };
+
+                        Nts.Polygon area;
+                        if (UrbanAreaManager.UrbanPolygons.Count > 0)
+                            area = UrbanAreaManager.UrbanPolygons[rnd.Next(UrbanAreaManager.UrbanPolygons.Count)];
+                        else
+                        {
+                            var gf = Nts.GeometryFactory.Default;
+                            area = gf.CreatePolygon(new[]
+                            {
+                                new Nts.Coordinate(0,0),
+                                new Nts.Coordinate(0,1),
+                                new Nts.Coordinate(1,1),
+                                new Nts.Coordinate(1,0),
+                                new Nts.Coordinate(0,0)
+                            });
+                        }
+                        var model = RoadNetworkGenerator.GenerateModelAsync(area, 10).GetAwaiter().GetResult();
+                        cityData.CityModelId = model.Id;
 
                         world.ConstructionCompanies.Add(new ConstructionCompanyData
                         {

--- a/WorldDataStructures.cs
+++ b/WorldDataStructures.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace StrategyGame
@@ -19,6 +20,7 @@ namespace StrategyGame
         public double TaxRate { get; set; }
         public double CityExpenses { get; set; }
         public List<InitialFactoryData> InitialFactories { get; set; }
+        public Guid CityModelId { get; set; }
         // Add other city-specific initial properties if needed, e.g., starting stockpile
     }
 


### PR DESCRIPTION
## Summary
- add `ProceduralData` link to `City`
- let `Factory` point to the `Building` it occupies
- keep track of city models in `CityData`
- generate a city model when world data is created
- load stored model and bind factories to buildings
- add fallback model generation for default world

## Testing
- `dotnet build "economy sim.sln" -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_687db41324d08323b2811210b6fc1f71