### PR TITLE
Implement aesthetic mapping layer

### DIFF
--- a/CityGen/AestheticMappingLayer.cs
+++ b/CityGen/AestheticMappingLayer.cs
@@ -1,0 +1,48 @@
+using System;
+using Messaging;
+
+namespace StrategyGame.CityGen
+{
+    /// <summary>
+    /// Maps high level economic and cultural metrics into parameters
+    /// that drive procedural city generation. Consumes events from the
+    /// global message bus and exposes the latest parameters.
+    /// </summary>
+    public static class AestheticMappingLayer
+    {
+        /// <summary>
+        /// Event carrying metrics used for mapping.
+        /// </summary>
+        public record CityMetricsEvent(decimal Gdp, float PopulationDensity, float CultureIndex);
+
+        /// <summary>
+        /// Parameter set influencing generation subsystems.
+        /// </summary>
+        public class CityGenerationParameters
+        {
+            public double RoadDensity { get; set; } = 1.0;
+            public double BuildingHeightScale { get; set; } = 1.0;
+            public double GreenSpaceRatio { get; set; } = 0.1;
+        }
+
+        public static CityGenerationParameters Parameters { get; } = new();
+
+        /// <summary>
+        /// Subscribe to the message bus for incoming metric events.
+        /// </summary>
+        public static void Initialize(MessageBus bus)
+        {
+            if (bus == null) throw new ArgumentNullException(nameof(bus));
+            bus.Subscribe<CityMetricsEvent>(HandleMetricsEvent);
+        }
+
+        private static void HandleMetricsEvent(CityMetricsEvent evt)
+        {
+            // Simple rule mapping GDP, population and culture to parameters.
+            Parameters.RoadDensity = Math.Clamp((double)evt.PopulationDensity * 2 + (double)(evt.Gdp / 10_000_000m), 0.5, 3.0);
+            Parameters.BuildingHeightScale = Math.Clamp((double)(evt.Gdp / 5_000_000m) + evt.CultureIndex, 0.5, 5.0);
+            Parameters.GreenSpaceRatio = Math.Clamp(1 - evt.PopulationDensity + evt.CultureIndex * 0.1, 0.05, 0.5);
+        }
+    }
+}
+

--- a/CityGeneration.cs
+++ b/CityGeneration.cs
@@ -289,9 +289,10 @@ namespace StrategyGame
             var buildingBag = new ConcurrentBag<Building>();
             var gf = Nts.GeometryFactory.Default;
 
-            const double CommercialInset = -0.00002;
-            const double ResidentialInset = -0.00004;
-            const double IndustrialInset = -0.00003;
+            double spacingFactor = 1 - CityGen.AestheticMappingLayer.Parameters.GreenSpaceRatio;
+            double CommercialInset = -0.00002 * spacingFactor;
+            double ResidentialInset = -0.00004 * spacingFactor;
+            double IndustrialInset = -0.00003 * spacingFactor;
 
             // Create a partitioner to process parcels in efficient, thread-safe chunks.
             var partitioner = Partitioner.Create(model.Parcels, true);
@@ -379,6 +380,8 @@ namespace StrategyGame
                     b.Level = 0;
                     break;
             }
+
+            b.Level = (int)Math.Max(1, b.Level * CityGen.AestheticMappingLayer.Parameters.BuildingHeightScale);
         }
     }
 

--- a/GameServices.cs
+++ b/GameServices.cs
@@ -1,0 +1,17 @@
+using Messaging;
+
+namespace StrategyGame
+{
+    /// <summary>
+    /// Provides access to shared services like the global message bus.
+    /// </summary>
+    public static class GameServices
+    {
+        public static MessageBus Bus { get; } = new MessageBus();
+
+        static GameServices()
+        {
+            CityGen.AestheticMappingLayer.Initialize(Bus);
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -8,6 +8,8 @@ namespace StrategyGame
         [STAThread]
         static void Main()
         {
+            // Ensure shared services are initialized
+            _ = GameServices.Bus;
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
             Application.Run(new economy_sim.MainGame());

--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -331,10 +331,10 @@ namespace StrategyGame
 
         private static List<Nts.LineString> GenerateLocalRoads(Nts.Polygon area, List<Nts.LineString> highways)
         {
-            const double roadSegmentLength = 0.005;
+            double roadSegmentLength = 0.005 * CityGen.AestheticMappingLayer.Parameters.RoadDensity;
             // Make the iteration limit proportional to the area. Ensures small
             // towns generate quickly while large cities have room to expand.
-            int maxIterations = (int)Math.Max(500, area.Area * 5000000);
+            int maxIterations = (int)Math.Max(500, area.Area * 5000000 * CityGen.AestheticMappingLayer.Parameters.RoadDensity);
             var gf = Nts.GeometryFactory.Default;
             var random = new Random();
             var roadNetwork = new List<Nts.LineString>(highways);


### PR DESCRIPTION
## Summary
- add `AestheticMappingLayer` which subscribes to the global message bus
- expose `GameServices.Bus` and initialise the mapping layer
- scale road generation and building properties via aesthetic parameters
- invoke game services from the program entry point

## Testing
- `dotnet build "economy sim.sln" -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687dc3d75e448323866e4dbed254e9de