### PR TITLE
Add FlatBuffers events for city metrics

### DIFF
--- a/City.cs
+++ b/City.cs
@@ -3,6 +3,9 @@ using System.Linq;
 using System; // Added for Console
 using StrategyGame; // Added to reference Suburb class
 using StrategyGame; // Ensure namespace for ProjectType and ConstructionProject is included
+using Messaging;
+using EconomySim.Protocols;
+using FlatBuffers;
 
 namespace StrategyGame
 {
@@ -33,6 +36,11 @@ namespace StrategyGame
         public List<SellOrder> SellOrders { get; set; }
         public List<Suburb> Suburbs { get; private set; } // Added Suburbs property
         public List<ConstructionProject> ActiveProjects { get; private set; } // Added to track active construction projects
+
+        // Metrics for event generation
+        public double LastRecordedGdp { get; set; }
+        public double LastAveragePrice { get; set; }
+        public int LastPopulation { get; set; }
 
         public City(string name)
         {
@@ -119,11 +127,16 @@ namespace StrategyGame
             clerks.Needs["Education"] = 0.5;
             PopClasses.Add(clerks);
             DebugLogger.Log($"[City] Created Clerks class - Size: {clerks.Size}, Income: {clerks.IncomePerPerson}", DebugLogger.LogCategory.Pop);
+
+            LastPopulation = Population;
+            LastRecordedGdp = PopClasses.Sum(p => p.Size * p.IncomePerPerson);
+            LastAveragePrice = LocalPrices.Values.DefaultIfEmpty(0).Average();
         }
 
         public void SimulateGrowth()
         {
             double surplus = Budget - CityExpenses;
+            int previousPopulation = Population;
             if (surplus > 0)
             {
                 int growth = (int)(surplus / 1000); // Example: population grows with surplus
@@ -137,6 +150,25 @@ namespace StrategyGame
                 }
 
                 Budget += surplus * 0.05; // Example: reinvest surplus
+            }
+
+            if (Population != LastPopulation)
+            {
+                var builder = new FlatBufferBuilder(64);
+                var idOffset = builder.CreateString(ProceduralData?.Id.ToString() ?? string.Empty);
+                PopulationUpdatedEvent.StartPopulationUpdatedEvent(builder);
+                PopulationUpdatedEvent.AddCityId(builder, idOffset);
+                PopulationUpdatedEvent.AddTimestamp(builder, (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+                PopulationUpdatedEvent.AddPopulation(builder, Population);
+                float birthRate = previousPopulation > 0 ? (float)(Population - previousPopulation) / previousPopulation : 0f;
+                PopulationUpdatedEvent.AddBirthRate(builder, birthRate);
+                PopulationUpdatedEvent.AddDeathRate(builder, 0f);
+                var evtOffset = PopulationUpdatedEvent.EndPopulationUpdatedEvent(builder);
+                PopulationUpdatedEvent.FinishSizePrefixedPopulationUpdatedEventBuffer(builder, evtOffset);
+                var buffer = new ByteBuffer(builder.SizedByteArray());
+                var evt = PopulationUpdatedEvent.GetRootAsPopulationUpdatedEvent(buffer);
+                GameServices.Bus.Publish(evt);
+                LastPopulation = Population;
             }
         }
 

--- a/Economy.cs
+++ b/Economy.cs
@@ -1,6 +1,9 @@
 using System.Collections.Generic;
 using System;
 using System.Linq;
+using FlatBuffers;
+using Messaging;
+using EconomySim.Protocols;
 
 namespace StrategyGame
 {
@@ -136,6 +139,30 @@ namespace StrategyGame
 
             // Process detailed city economy including buy/sell order generation
             CityEconomy.ProcessCityEconomy(city);
+
+            // Calculate key metrics
+            double gdp = city.PopClasses.Sum(p => p.Size * p.IncomePerPerson);
+            double avgPrice = city.LocalPrices.Values.DefaultIfEmpty(0).Average();
+            double inflation = city.LastAveragePrice > 0 ? (avgPrice - city.LastAveragePrice) / city.LastAveragePrice : 0;
+
+            bool changed = Math.Abs(gdp - city.LastRecordedGdp) > 0.01 || Math.Abs(inflation) > 0.0001;
+            if (changed)
+            {
+                var builder = new FlatBufferBuilder(64);
+                var idOffset = builder.CreateString(city.ProceduralData?.Id.ToString() ?? string.Empty);
+                EconomyUpdatedEvent.StartEconomyUpdatedEvent(builder);
+                EconomyUpdatedEvent.AddCityId(builder, idOffset);
+                EconomyUpdatedEvent.AddTimestamp(builder, (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+                EconomyUpdatedEvent.AddGdp(builder, (float)gdp);
+                EconomyUpdatedEvent.AddInflation(builder, (float)inflation);
+                var evtOffset = EconomyUpdatedEvent.EndEconomyUpdatedEvent(builder);
+                EconomyUpdatedEvent.FinishSizePrefixedEconomyUpdatedEventBuffer(builder, evtOffset);
+                var buffer = new ByteBuffer(builder.SizedByteArray());
+                var evt = EconomyUpdatedEvent.GetRootAsEconomyUpdatedEvent(buffer);
+                GameServices.Bus.Publish(evt);
+                city.LastRecordedGdp = gdp;
+                city.LastAveragePrice = avgPrice;
+            }
         }
 
         public static void UpdatePopGrowth(PopClass pop)

--- a/Generated/EconomySim/Protocols/EconomyUpdatedEvent.cs
+++ b/Generated/EconomySim/Protocols/EconomyUpdatedEvent.cs
@@ -7,34 +7,47 @@ namespace EconomySim.Protocols
 
 using global::System;
 using global::System.Collections.Generic;
-using global::Google.FlatBuffers;
+using global::FlatBuffers;
 
 public struct EconomyUpdatedEvent : IFlatbufferObject
 {
   private Table __p;
   public ByteBuffer ByteBuffer { get { return __p.bb; } }
-  public static void ValidateVersion() { FlatBufferConstants.FLATBUFFERS_25_2_10(); }
+  public static void ValidateVersion() { FlatBufferConstants.FLATBUFFERS_2_0_8(); }
   public static EconomyUpdatedEvent GetRootAsEconomyUpdatedEvent(ByteBuffer _bb) { return GetRootAsEconomyUpdatedEvent(_bb, new EconomyUpdatedEvent()); }
   public static EconomyUpdatedEvent GetRootAsEconomyUpdatedEvent(ByteBuffer _bb, EconomyUpdatedEvent obj) { return (obj.__assign(_bb.GetInt(_bb.Position) + _bb.Position, _bb)); }
-  public static bool VerifyEconomyUpdatedEvent(ByteBuffer _bb) {Google.FlatBuffers.Verifier verifier = new Google.FlatBuffers.Verifier(_bb); return verifier.VerifyBuffer("", false, EconomyUpdatedEventVerify.Verify); }
   public void __init(int _i, ByteBuffer _bb) { __p = new Table(_i, _bb); }
   public EconomyUpdatedEvent __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
 
-  public float Gdp { get { int o = __p.__offset(4); return o != 0 ? __p.bb.GetFloat(o + __p.bb_pos) : (float)0.0f; } }
-  public float Inflation { get { int o = __p.__offset(6); return o != 0 ? __p.bb.GetFloat(o + __p.bb_pos) : (float)0.0f; } }
+  public string CityId { get { int o = __p.__offset(4); return o != 0 ? __p.__string(o + __p.bb_pos) : null; } }
+#if ENABLE_SPAN_T
+  public Span<byte> GetCityIdBytes() { return __p.__vector_as_span<byte>(4, 1); }
+#else
+  public ArraySegment<byte>? GetCityIdBytes() { return __p.__vector_as_arraysegment(4); }
+#endif
+  public byte[] GetCityIdArray() { return __p.__vector_as_array<byte>(4); }
+  public ulong Timestamp { get { int o = __p.__offset(6); return o != 0 ? __p.bb.GetUlong(o + __p.bb_pos) : (ulong)0; } }
+  public float Gdp { get { int o = __p.__offset(8); return o != 0 ? __p.bb.GetFloat(o + __p.bb_pos) : (float)0.0f; } }
+  public float Inflation { get { int o = __p.__offset(10); return o != 0 ? __p.bb.GetFloat(o + __p.bb_pos) : (float)0.0f; } }
 
   public static Offset<EconomySim.Protocols.EconomyUpdatedEvent> CreateEconomyUpdatedEvent(FlatBufferBuilder builder,
+      StringOffset city_idOffset = default(StringOffset),
+      ulong timestamp = 0,
       float gdp = 0.0f,
       float inflation = 0.0f) {
-    builder.StartTable(2);
+    builder.StartTable(4);
+    EconomyUpdatedEvent.AddTimestamp(builder, timestamp);
     EconomyUpdatedEvent.AddInflation(builder, inflation);
     EconomyUpdatedEvent.AddGdp(builder, gdp);
+    EconomyUpdatedEvent.AddCityId(builder, city_idOffset);
     return EconomyUpdatedEvent.EndEconomyUpdatedEvent(builder);
   }
 
-  public static void StartEconomyUpdatedEvent(FlatBufferBuilder builder) { builder.StartTable(2); }
-  public static void AddGdp(FlatBufferBuilder builder, float gdp) { builder.AddFloat(0, gdp, 0.0f); }
-  public static void AddInflation(FlatBufferBuilder builder, float inflation) { builder.AddFloat(1, inflation, 0.0f); }
+  public static void StartEconomyUpdatedEvent(FlatBufferBuilder builder) { builder.StartTable(4); }
+  public static void AddCityId(FlatBufferBuilder builder, StringOffset cityIdOffset) { builder.AddOffset(0, cityIdOffset.Value, 0); }
+  public static void AddTimestamp(FlatBufferBuilder builder, ulong timestamp) { builder.AddUlong(1, timestamp, 0); }
+  public static void AddGdp(FlatBufferBuilder builder, float gdp) { builder.AddFloat(2, gdp, 0.0f); }
+  public static void AddInflation(FlatBufferBuilder builder, float inflation) { builder.AddFloat(3, inflation, 0.0f); }
   public static Offset<EconomySim.Protocols.EconomyUpdatedEvent> EndEconomyUpdatedEvent(FlatBufferBuilder builder) {
     int o = builder.EndTable();
     return new Offset<EconomySim.Protocols.EconomyUpdatedEvent>(o);
@@ -43,16 +56,5 @@ public struct EconomyUpdatedEvent : IFlatbufferObject
   public static void FinishSizePrefixedEconomyUpdatedEventBuffer(FlatBufferBuilder builder, Offset<EconomySim.Protocols.EconomyUpdatedEvent> offset) { builder.FinishSizePrefixed(offset.Value); }
 }
 
-
-static public class EconomyUpdatedEventVerify
-{
-  static public bool Verify(Google.FlatBuffers.Verifier verifier, uint tablePos)
-  {
-    return verifier.VerifyTableStart(tablePos)
-      && verifier.VerifyField(tablePos, 4 /*Gdp*/, 4 /*float*/, 4, false)
-      && verifier.VerifyField(tablePos, 6 /*Inflation*/, 4 /*float*/, 4, false)
-      && verifier.VerifyTableEnd(tablePos);
-  }
-}
 
 }

--- a/Generated/EconomySim/Protocols/PopulationUpdatedEvent.cs
+++ b/Generated/EconomySim/Protocols/PopulationUpdatedEvent.cs
@@ -7,38 +7,51 @@ namespace EconomySim.Protocols
 
 using global::System;
 using global::System.Collections.Generic;
-using global::Google.FlatBuffers;
+using global::FlatBuffers;
 
 public struct PopulationUpdatedEvent : IFlatbufferObject
 {
   private Table __p;
   public ByteBuffer ByteBuffer { get { return __p.bb; } }
-  public static void ValidateVersion() { FlatBufferConstants.FLATBUFFERS_25_2_10(); }
+  public static void ValidateVersion() { FlatBufferConstants.FLATBUFFERS_2_0_8(); }
   public static PopulationUpdatedEvent GetRootAsPopulationUpdatedEvent(ByteBuffer _bb) { return GetRootAsPopulationUpdatedEvent(_bb, new PopulationUpdatedEvent()); }
   public static PopulationUpdatedEvent GetRootAsPopulationUpdatedEvent(ByteBuffer _bb, PopulationUpdatedEvent obj) { return (obj.__assign(_bb.GetInt(_bb.Position) + _bb.Position, _bb)); }
-  public static bool VerifyPopulationUpdatedEvent(ByteBuffer _bb) {Google.FlatBuffers.Verifier verifier = new Google.FlatBuffers.Verifier(_bb); return verifier.VerifyBuffer("", false, PopulationUpdatedEventVerify.Verify); }
   public void __init(int _i, ByteBuffer _bb) { __p = new Table(_i, _bb); }
   public PopulationUpdatedEvent __assign(int _i, ByteBuffer _bb) { __init(_i, _bb); return this; }
 
-  public int Population { get { int o = __p.__offset(4); return o != 0 ? __p.bb.GetInt(o + __p.bb_pos) : (int)0; } }
-  public float BirthRate { get { int o = __p.__offset(6); return o != 0 ? __p.bb.GetFloat(o + __p.bb_pos) : (float)0.0f; } }
-  public float DeathRate { get { int o = __p.__offset(8); return o != 0 ? __p.bb.GetFloat(o + __p.bb_pos) : (float)0.0f; } }
+  public string CityId { get { int o = __p.__offset(4); return o != 0 ? __p.__string(o + __p.bb_pos) : null; } }
+#if ENABLE_SPAN_T
+  public Span<byte> GetCityIdBytes() { return __p.__vector_as_span<byte>(4, 1); }
+#else
+  public ArraySegment<byte>? GetCityIdBytes() { return __p.__vector_as_arraysegment(4); }
+#endif
+  public byte[] GetCityIdArray() { return __p.__vector_as_array<byte>(4); }
+  public ulong Timestamp { get { int o = __p.__offset(6); return o != 0 ? __p.bb.GetUlong(o + __p.bb_pos) : (ulong)0; } }
+  public int Population { get { int o = __p.__offset(8); return o != 0 ? __p.bb.GetInt(o + __p.bb_pos) : (int)0; } }
+  public float BirthRate { get { int o = __p.__offset(10); return o != 0 ? __p.bb.GetFloat(o + __p.bb_pos) : (float)0.0f; } }
+  public float DeathRate { get { int o = __p.__offset(12); return o != 0 ? __p.bb.GetFloat(o + __p.bb_pos) : (float)0.0f; } }
 
   public static Offset<EconomySim.Protocols.PopulationUpdatedEvent> CreatePopulationUpdatedEvent(FlatBufferBuilder builder,
+      StringOffset city_idOffset = default(StringOffset),
+      ulong timestamp = 0,
       int population = 0,
       float birth_rate = 0.0f,
       float death_rate = 0.0f) {
-    builder.StartTable(3);
+    builder.StartTable(5);
+    PopulationUpdatedEvent.AddTimestamp(builder, timestamp);
     PopulationUpdatedEvent.AddDeathRate(builder, death_rate);
     PopulationUpdatedEvent.AddBirthRate(builder, birth_rate);
     PopulationUpdatedEvent.AddPopulation(builder, population);
+    PopulationUpdatedEvent.AddCityId(builder, city_idOffset);
     return PopulationUpdatedEvent.EndPopulationUpdatedEvent(builder);
   }
 
-  public static void StartPopulationUpdatedEvent(FlatBufferBuilder builder) { builder.StartTable(3); }
-  public static void AddPopulation(FlatBufferBuilder builder, int population) { builder.AddInt(0, population, 0); }
-  public static void AddBirthRate(FlatBufferBuilder builder, float birthRate) { builder.AddFloat(1, birthRate, 0.0f); }
-  public static void AddDeathRate(FlatBufferBuilder builder, float deathRate) { builder.AddFloat(2, deathRate, 0.0f); }
+  public static void StartPopulationUpdatedEvent(FlatBufferBuilder builder) { builder.StartTable(5); }
+  public static void AddCityId(FlatBufferBuilder builder, StringOffset cityIdOffset) { builder.AddOffset(0, cityIdOffset.Value, 0); }
+  public static void AddTimestamp(FlatBufferBuilder builder, ulong timestamp) { builder.AddUlong(1, timestamp, 0); }
+  public static void AddPopulation(FlatBufferBuilder builder, int population) { builder.AddInt(2, population, 0); }
+  public static void AddBirthRate(FlatBufferBuilder builder, float birthRate) { builder.AddFloat(3, birthRate, 0.0f); }
+  public static void AddDeathRate(FlatBufferBuilder builder, float deathRate) { builder.AddFloat(4, deathRate, 0.0f); }
   public static Offset<EconomySim.Protocols.PopulationUpdatedEvent> EndPopulationUpdatedEvent(FlatBufferBuilder builder) {
     int o = builder.EndTable();
     return new Offset<EconomySim.Protocols.PopulationUpdatedEvent>(o);
@@ -47,17 +60,5 @@ public struct PopulationUpdatedEvent : IFlatbufferObject
   public static void FinishSizePrefixedPopulationUpdatedEventBuffer(FlatBufferBuilder builder, Offset<EconomySim.Protocols.PopulationUpdatedEvent> offset) { builder.FinishSizePrefixed(offset.Value); }
 }
 
-
-static public class PopulationUpdatedEventVerify
-{
-  static public bool Verify(Google.FlatBuffers.Verifier verifier, uint tablePos)
-  {
-    return verifier.VerifyTableStart(tablePos)
-      && verifier.VerifyField(tablePos, 4 /*Population*/, 4 /*int*/, 4, false)
-      && verifier.VerifyField(tablePos, 6 /*BirthRate*/, 4 /*float*/, 4, false)
-      && verifier.VerifyField(tablePos, 8 /*DeathRate*/, 4 /*float*/, 4, false)
-      && verifier.VerifyTableEnd(tablePos);
-  }
-}
 
 }

--- a/Protocols/EconomyUpdatedEvent.fbs
+++ b/Protocols/EconomyUpdatedEvent.fbs
@@ -1,6 +1,8 @@
 namespace EconomySim.Protocols;
 
 table EconomyUpdatedEvent {
+  city_id:string;
+  timestamp:ulong;
   gdp:float;
   inflation:float;
 }

--- a/Protocols/PopulationUpdatedEvent.fbs
+++ b/Protocols/PopulationUpdatedEvent.fbs
@@ -1,6 +1,8 @@
 namespace EconomySim.Protocols;
 
 table PopulationUpdatedEvent {
+  city_id:string;
+  timestamp:ulong;
   population:int;
   birth_rate:float;
   death_rate:float;


### PR DESCRIPTION
## Summary
- extend EconomyUpdatedEvent and PopulationUpdatedEvent schemas with city id and timestamp
- regenerate FlatBuffers C# sources
- publish `EconomyUpdatedEvent` from `Economy.UpdateCityEconomy`
- publish `PopulationUpdatedEvent` from `City.SimulateGrowth`

## Testing
- `dotnet build "economy sim.sln" -v minimal` *(fails: SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_687dc4d27e4c83239fc69b5ab1707fa2