### PR TITLE
Add building destruction events via message bus

### DIFF
--- a/Building.cs
+++ b/Building.cs
@@ -1,10 +1,12 @@
 using Nts = NetTopologySuite.Geometries;
+using System;
 using System.Collections.Concurrent;
 
 namespace StrategyGame
 {
     public class Building
     {
+        public Guid Id { get; set; } = Guid.NewGuid();
         public Nts.Polygon Footprint { get; set; }
         // Simplified footprints cached by cell size for rendering
         public ConcurrentDictionary<int, Nts.Geometry> SimplifiedFootprints { get; } = new();

--- a/BuildingDestroyedEvent.cs
+++ b/BuildingDestroyedEvent.cs
@@ -1,0 +1,6 @@
+using System;
+
+namespace StrategyGame
+{
+    public record BuildingDestroyedEvent(Guid CityId, Guid BuildingId, LandUseType LandUse);
+}

--- a/City.cs
+++ b/City.cs
@@ -257,5 +257,17 @@ namespace StrategyGame
                 suburb.RailwayKilometers += value / Suburbs.Count; // Distribute railway kilometers
             }
         }
+
+        public void DestroyBuilding(Guid buildingId)
+        {
+            if (ProceduralData == null) return;
+            var building = ProceduralData.Buildings.FirstOrDefault(b => b.Id == buildingId);
+            if (building == null) return;
+
+            ProceduralData.Buildings.Remove(building);
+
+            var evt = new BuildingDestroyedEvent(ProceduralData.Id, building.Id, building.LandUse);
+            GameServices.Bus.Publish(evt);
+        }
     }
 }

--- a/CityGeneration.cs
+++ b/CityGeneration.cs
@@ -329,7 +329,7 @@ namespace StrategyGame
 
                         if (cleanedFootprint is Nts.Polygon cleanedP && cleanedP.IsValid && !cleanedP.IsEmpty)
                         {
-                            buildingBag.Add(new Building { Footprint = cleanedP, LandUse = parcel.LandUse });
+                            buildingBag.Add(new Building { Id = Guid.NewGuid(), Footprint = cleanedP, LandUse = parcel.LandUse });
                         }
                     }
                 }
@@ -530,6 +530,13 @@ namespace StrategyGame
         {
             LandUseSimulator.Run(model);
             BuildingRefiner.RefineBuildings(model);
+
+            if (model.Buildings.Count > 0 && Random.Shared.NextDouble() < 0.05)
+            {
+                var building = model.Buildings[0];
+                model.Buildings.RemoveAt(0);
+                GameServices.Bus.Publish(new BuildingDestroyedEvent(model.Id, building.Id, building.LandUse));
+            }
         }
     }
 }

--- a/GlobalMarket.cs
+++ b/GlobalMarket.cs
@@ -45,6 +45,8 @@ namespace StrategyGame // Reverted from EconomySim
             RecentTradeEvents = new List<GlobalTradeEvent>();
             TradeHistory = new List<DetailedTradeRecord>();
             GlobalTradeValue = 0;
+
+            GameServices.Bus.Subscribe<BuildingDestroyedEvent>(HandleBuildingDestroyed);
             
             // Initialize with goods from the Market class
             foreach (var goodDef in Market.GoodDefinitions.Values)
@@ -199,6 +201,15 @@ namespace StrategyGame // Reverted from EconomySim
             }
             // Execute international trade between countries
             InternationalTrade.ExecuteTradeTurn(allCountries, this, tradeManager);
+        }
+
+        private void HandleBuildingDestroyed(BuildingDestroyedEvent evt)
+        {
+            // Simple example: reduce global supply of Tools when an industrial building is lost
+            if (evt.LandUse == LandUseType.Industrial && GlobalSupply.ContainsKey("Tools"))
+            {
+                GlobalSupply["Tools"] = Math.Max(0, GlobalSupply["Tools"] - 10);
+            }
         }
           public void RecordTrade(string goodName, string exportingCountry, string importingCountry, 
                                int quantity, double totalValue)

--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -116,18 +116,19 @@ namespace StrategyGame
                 bw.Write(parcel.LandValue);
             }
 
-                bw.Write(model.Buildings.Count);
-                foreach (var building in model.Buildings)
-                {
-                    byte[] data = wkbWriter.Write(building.Footprint);
-                    bw.Write(data.Length);
-                    bw.Write(data);
-                    bw.Write((int)building.LandUse);
-                    bw.Write(building.Level);
-                    bw.Write(building.PopulationCapacity);
-                    bw.Write(building.EconomicOutput);
-                    bw.Write(building.PollutionOutput);
-                }
+            bw.Write(model.Buildings.Count);
+            foreach (var building in model.Buildings)
+            {
+                bw.Write(building.Id.ToByteArray());
+                byte[] data = wkbWriter.Write(building.Footprint);
+                bw.Write(data.Length);
+                bw.Write(data);
+                bw.Write((int)building.LandUse);
+                bw.Write(building.Level);
+                bw.Write(building.PopulationCapacity);
+                bw.Write(building.EconomicOutput);
+                bw.Write(building.PollutionOutput);
+            }
             }
             finally
             {
@@ -189,6 +190,7 @@ namespace StrategyGame
             int buildingCount = br.ReadInt32();
             for (int i = 0; i < buildingCount; i++)
             {
+                var id = new Guid(br.ReadBytes(16));
                 int len = br.ReadInt32();
                 byte[] data = br.ReadBytes(len);
                 var footprint = (Nts.Polygon)wkbReader.Read(data);
@@ -199,6 +201,7 @@ namespace StrategyGame
                 double poll = br.ReadDouble();
                 model.Buildings.Add(new Building
                 {
+                    Id = id,
                     Footprint = footprint,
                     LandUse = landUse,
                     Level = level,


### PR DESCRIPTION
## Summary
- assign unique `Guid` IDs to buildings
- publish `BuildingDestroyedEvent` when a building is removed
- randomly destroy a building in `CityEvolutionManager.SimulateYear`
- subscribe global market to building destruction events and reduce tool supply
- persist building IDs when saving/loading city models

## Testing
- `dotnet build "economy sim.sln" -v minimal` *(fails: SDK `Microsoft.NET.Sdk.WindowsDesktop` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687dc7e4a17c83238de453e78bc7847f