### PR TITLE
Add SimulationLODManager and integrate LOD updates

### DIFF
--- a/MainGame.cs
+++ b/MainGame.cs
@@ -481,6 +481,7 @@ namespace economy_sim
                                 }
                                 currentState.Cities.Add(currentCity);
                                 allCitiesInWorld.Add(currentCity);
+                                SimulationLODManager.Instance.RegisterCity(currentCity);
                             }
                         }
                         // Recalculate state population/budget from cities if specified as 0 in JSON, or for verification
@@ -611,6 +612,7 @@ namespace economy_sim
             }
             defaultState.Cities.Add(defaultCity);
             allCitiesInWorld.Add(defaultCity);
+            SimulationLODManager.Instance.RegisterCity(defaultCity);
 
             allCountries.Add(defaultCountry);
             comboBoxCountry.Items.Add(defaultCountry.Name);
@@ -872,18 +874,25 @@ namespace economy_sim
             {
                 foreach (var city in allCitiesInWorld)
                 {
-                    Market.ResetCitySupplyDemand(city);
-                    foreach (var factory in city.Factories)
+                    if (SimulationLODManager.Instance.ShouldSimulateHighFidelity(city))
                     {
-                        factory.Produce(city.Stockpile, city);
+                        Market.ResetCitySupplyDemand(city);
+                        foreach (var factory in city.Factories)
+                        {
+                            factory.Produce(city.Stockpile, city);
+                        }
+                        StrategyGame.Economy.UpdateCityEconomy(city); // Populates ImportNeeds and ExportableSurplus
+                        city.ProgressConstruction();
+                        if (constructionForm.Visible && constructionForm.CurrentCity == city)
+                        {
+                            constructionForm.UpdateProjects();
+                        }
+                        Market.UpdateCityPrices(city);
                     }
-                    StrategyGame.Economy.UpdateCityEconomy(city); // Populates ImportNeeds and ExportableSurplus
-                    city.ProgressConstruction();
-                    if (constructionForm.Visible && constructionForm.CurrentCity == city)
+                    else
                     {
-                        constructionForm.UpdateProjects();
+                        SimulationLODManager.Instance.LowFidelityStep(city);
                     }
-                    Market.UpdateCityPrices(city);
                 }
             }
             // --- End City Economies Update Phase ---
@@ -1162,6 +1171,10 @@ namespace economy_sim
                 if (citiesToUpdate.Count == 0 && allCitiesInWorld != null)
                     citiesToUpdate = allCitiesInWorld.Take(citiesPerTick).ToList();
 
+                StrategyGame.City playerFocus = null;
+                this.Invoke((Action)(() => { playerFocus = GetSelectedCity(); }));
+                SimulationLODManager.Instance.PlayerCity = playerFocus;
+
                 await Task.Run(() =>
                 {
                     if (Market.AllCorporations != null && allCitiesInWorld != null && FactoryBlueprints.AllBlueprints.Any())
@@ -1176,12 +1189,19 @@ namespace economy_sim
 
                     foreach (var city in citiesToUpdate)
                     {
-                        Market.ResetCitySupplyDemand(city);
-                        foreach (var factory in city.Factories)
-                            factory.Produce(city.Stockpile, city);
-                        StrategyGame.Economy.UpdateCityEconomy(city);
-                        city.ProgressConstruction();
-                        Market.UpdateCityPrices(city);
+                        if (SimulationLODManager.Instance.ShouldSimulateHighFidelity(city))
+                        {
+                            Market.ResetCitySupplyDemand(city);
+                            foreach (var factory in city.Factories)
+                                factory.Produce(city.Stockpile, city);
+                            StrategyGame.Economy.UpdateCityEconomy(city);
+                            city.ProgressConstruction();
+                            Market.UpdateCityPrices(city);
+                        }
+                        else
+                        {
+                            SimulationLODManager.Instance.LowFidelityStep(city);
+                        }
                     }
 
                     if (allCitiesInWorld != null && allCitiesInWorld.Count > 1)

--- a/SimulationLODManager.cs
+++ b/SimulationLODManager.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EconomySim.Protocols;
+using Messaging;
+
+namespace StrategyGame
+{
+    /// <summary>
+    /// Manages level-of-detail (LOD) for city simulation. Cities close to the player
+    /// or otherwise flagged as important run full updates while distant cities are
+    /// updated using cheaper logic and only emit summary events.
+    /// </summary>
+    public class SimulationLODManager
+    {
+        private class CityInfo
+        {
+            public float ActivityLevel;
+            public bool HighPriority;
+        }
+
+        private readonly Dictionary<City, CityInfo> _cityInfo = new();
+        private City? _playerCity;
+        private readonly MessageBus _bus;
+
+        public static SimulationLODManager Instance { get; } = new SimulationLODManager(GameServices.Bus);
+
+        private SimulationLODManager(MessageBus bus)
+        {
+            _bus = bus;
+        }
+
+        /// <summary>
+        /// Set the city that represents the player's current focus.
+        /// </summary>
+        public City? PlayerCity
+        {
+            get => _playerCity;
+            set => _playerCity = value;
+        }
+
+        /// <summary>
+        /// Register a city with the LOD manager.
+        /// </summary>
+        public void RegisterCity(City city)
+        {
+            if (!_cityInfo.ContainsKey(city))
+                _cityInfo[city] = new CityInfo { ActivityLevel = 1f };
+        }
+
+        /// <summary>
+        /// Mark a city as narratively important so it always runs at high fidelity.
+        /// </summary>
+        public void SetHighPriority(City city, bool value)
+        {
+            if (!_cityInfo.ContainsKey(city))
+                RegisterCity(city);
+            _cityInfo[city].HighPriority = value;
+        }
+
+        /// <summary>
+        /// Determine if a city should run a high fidelity update this tick.
+        /// </summary>
+        public bool ShouldSimulateHighFidelity(City city)
+        {
+            if (!_cityInfo.TryGetValue(city, out var info))
+                return true;
+            return info.HighPriority || ReferenceEquals(city, _playerCity);
+        }
+
+        /// <summary>
+        /// Perform a lightweight update and publish summary events.
+        /// </summary>
+        public void LowFidelityStep(City city)
+        {
+            city.SimulateGrowth();
+
+            float gdp = (float)city.PopClasses.Sum(p => p.Size * p.IncomePerPerson);
+            var builder = new FlatBuffers.FlatBufferBuilder(64);
+            var idOffset = builder.CreateString(city.ProceduralData?.Id.ToString() ?? string.Empty);
+            EconomyUpdatedEvent.StartEconomyUpdatedEvent(builder);
+            EconomyUpdatedEvent.AddCityId(builder, idOffset);
+            EconomyUpdatedEvent.AddTimestamp(builder, (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+            EconomyUpdatedEvent.AddGdp(builder, gdp);
+            EconomyUpdatedEvent.AddInflation(builder, 0f);
+            var evtOffset = EconomyUpdatedEvent.EndEconomyUpdatedEvent(builder);
+            EconomyUpdatedEvent.FinishSizePrefixedEconomyUpdatedEventBuffer(builder, evtOffset);
+            var buffer = new FlatBuffers.ByteBuffer(builder.SizedByteArray());
+            var evt = EconomyUpdatedEvent.GetRootAsEconomyUpdatedEvent(buffer);
+            _bus.Publish(evt);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add SimulationLODManager to control high/low fidelity city updates
- register all cities with the LOD manager
- only run expensive updates for important or player-focused cities
- emit summary events for low-fidelity cities so CityGen still updates

## Testing
- `dotnet build "economy sim.sln" -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_687dcaacdbe08323892f68eb0d44aa76