### PR TITLE
Add message bus event logging

### DIFF
--- a/GameServices.cs
+++ b/GameServices.cs
@@ -11,6 +11,7 @@ namespace StrategyGame
 
         static GameServices()
         {
+            Bus.MessagePublished += EventLogger.Log;
             CityGen.AestheticMappingLayer.Initialize(Bus);
         }
     }

--- a/MainGame.Designer.cs
+++ b/MainGame.Designer.cs
@@ -68,6 +68,7 @@
             buttonGenerateTileCache = new Button();
             buttonGenerateCityData = new Button();
             buttonShowPerformance = new Button();
+            buttonOpenEventViewer = new Button();
             tabPageDiplomacy = new TabPage();
             labelProposedTrades = new Label();
             listBoxProposedTradeAgreements = new ListBox();
@@ -272,6 +273,7 @@
             tabPageDebug.Controls.Add(buttonGenerateTileCache);
             tabPageDebug.Controls.Add(buttonGenerateCityData);
             tabPageDebug.Controls.Add(buttonShowPerformance);
+            tabPageDebug.Controls.Add(buttonOpenEventViewer);
             tabPageDebug.Controls.Add(buttonToggleDebugMode);
             tabPageDebug.Location = new Point(4, 29);
             tabPageDebug.Margin = new Padding(5, 4, 5, 4);
@@ -473,6 +475,18 @@
             buttonShowPerformance.Text = "Performance Stats";
             buttonShowPerformance.UseVisualStyleBackColor = true;
             buttonShowPerformance.Click += ButtonShowPerformance_Click;
+
+            //
+            // buttonOpenEventViewer
+            //
+            buttonOpenEventViewer.Location = new Point(692, 662);
+            buttonOpenEventViewer.Margin = new Padding(5, 4, 5, 4);
+            buttonOpenEventViewer.Name = "buttonOpenEventViewer";
+            buttonOpenEventViewer.Size = new Size(160, 36);
+            buttonOpenEventViewer.TabIndex = 19;
+            buttonOpenEventViewer.Text = "Event Viewer";
+            buttonOpenEventViewer.UseVisualStyleBackColor = true;
+            buttonOpenEventViewer.Click += ButtonOpenEventViewer_Click;
 
             // 
             // tabPageDiplomacy
@@ -769,6 +783,7 @@
         private System.Windows.Forms.Button buttonGenerateTileCache;
         private System.Windows.Forms.Button buttonGenerateCityData;
         private System.Windows.Forms.Button buttonShowPerformance;
+        private System.Windows.Forms.Button buttonOpenEventViewer;
         private System.Windows.Forms.TabPage tabPageDiplomacy;
         private System.Windows.Forms.Label labelProposedTrades;
         private System.Windows.Forms.ListBox listBoxProposedTradeAgreements;

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -33,6 +33,7 @@ namespace economy_sim
         private FactoryStatsForm factoryStatsForm;
         private ConstructionForm constructionForm;
         private PerformanceStatsForm performanceStatsForm;
+        private EventViewer eventViewer;
         private List<State> states;
         private PlayerRoleManager playerRoleManager;
         private Random random = new Random(); // Add a Random instance for AI and other uses
@@ -218,6 +219,7 @@ namespace economy_sim
             factoryStatsForm = new FactoryStatsForm();
             constructionForm = new ConstructionForm();
             performanceStatsForm = new PerformanceStatsForm();
+            eventViewer = new EventViewer();
             tabControlMain.SelectedIndexChanged += TabControlMain_SelectedIndexChanged;
 
             this.listBoxCityStats.DrawMode = DrawMode.OwnerDrawFixed;
@@ -236,6 +238,9 @@ namespace economy_sim
 
             this.buttonShowPerformance.Location = new SD.Point(this.buttonShowConstruction.Right + 10, buttonsTargetY);
             this.buttonShowPerformance.Click += ButtonShowPerformance_Click;
+
+            this.buttonOpenEventViewer.Location = new SD.Point(this.buttonShowPerformance.Right + 10, buttonsTargetY);
+            this.buttonOpenEventViewer.Click += ButtonOpenEventViewer_Click;
 
             Console.WriteLine($"[Startup] TOTAL startup time: {totalSw.Elapsed.TotalSeconds:F2} seconds");
             this.Shown += (s, e) =>
@@ -1408,6 +1413,12 @@ namespace economy_sim
         {
             performanceStatsForm.Show();
             performanceStatsForm.BringToFront();
+        }
+
+        private void ButtonOpenEventViewer_Click(object sender, EventArgs e)
+        {
+            eventViewer.Show();
+            eventViewer.BringToFront();
         }
 
         private void UpdateOrderLists()

--- a/Messaging/MessageBus.cs
+++ b/Messaging/MessageBus.cs
@@ -16,6 +16,11 @@ namespace Messaging
         private readonly BlockingCollection<object> _queue = new();
         private readonly Thread _worker;
 
+        /// <summary>
+        /// Invoked whenever a message is published.
+        /// </summary>
+        public event Action<object>? MessagePublished;
+
         public MessageBus()
         {
             _worker = new Thread(EventLoop) { IsBackground = true };
@@ -42,7 +47,8 @@ namespace Messaging
         public void Publish<T>(T evt)
         {
             if (evt == null) throw new ArgumentNullException(nameof(evt));
-            _queue.Add(evt);
+            MessagePublished?.Invoke(evt!);
+            _queue.Add(evt!);
         }
 
         private void EventLoop()

--- a/Tools/EventLogger.cs
+++ b/Tools/EventLogger.cs
@@ -1,0 +1,47 @@
+using System;
+using System.IO;
+using System.Text.Json;
+
+namespace StrategyGame
+{
+    /// <summary>
+    /// Logs all events published through the message bus to a JSON lines file.
+    /// </summary>
+    public static class EventLogger
+    {
+        private static readonly string logFilePath;
+
+        private record LogEntry(DateTime Timestamp, string Type, string Json);
+
+        static EventLogger()
+        {
+            var logsDir = Path.Combine(Directory.GetCurrentDirectory(), "logs");
+            if (!Directory.Exists(logsDir))
+            {
+                Directory.CreateDirectory(logsDir);
+            }
+
+            logFilePath = Path.Combine(logsDir,
+                $"event_log_{DateTime.Now:yyyy-MM-dd_HH-mm-ss}.jsonl");
+        }
+
+        /// <summary>
+        /// Serialize and append the provided event to the log file.
+        /// </summary>
+        public static void Log(object evt)
+        {
+            try
+            {
+                var entry = new LogEntry(DateTime.Now,
+                    evt.GetType().FullName ?? evt.GetType().Name,
+                    JsonSerializer.Serialize(evt, evt.GetType()));
+                var json = JsonSerializer.Serialize(entry);
+                File.AppendAllText(logFilePath, json + Environment.NewLine);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"EventLogger failed: {ex.Message}");
+            }
+        }
+    }
+}

--- a/Tools/EventViewer.Designer.cs
+++ b/Tools/EventViewer.Designer.cs
@@ -1,0 +1,50 @@
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace economy_sim
+{
+    public partial class EventViewer : Form
+    {
+        private ListBox eventsList;
+        private TrackBar scrubBar;
+        private Button buttonOpen;
+
+        private void InitializeComponent()
+        {
+            eventsList = new ListBox();
+            scrubBar = new TrackBar();
+            buttonOpen = new Button();
+            SuspendLayout();
+
+            // eventsList
+            eventsList.Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
+            eventsList.FormattingEnabled = true;
+            eventsList.ItemHeight = 15;
+            eventsList.Location = new Point(12, 41);
+            eventsList.Size = new Size(360, 274);
+
+            // scrubBar
+            scrubBar.Anchor = AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
+            scrubBar.Location = new Point(12, 321);
+            scrubBar.Size = new Size(360, 45);
+
+            // buttonOpen
+            buttonOpen.Location = new Point(12, 12);
+            buttonOpen.Size = new Size(75, 23);
+            buttonOpen.Text = "Open";
+            buttonOpen.UseVisualStyleBackColor = true;
+
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(384, 361);
+            Controls.Add(buttonOpen);
+            Controls.Add(eventsList);
+            Controls.Add(scrubBar);
+            Name = "EventViewer";
+            Text = "Event Viewer";
+
+            ResumeLayout(false);
+            PerformLayout();
+        }
+    }
+}

--- a/Tools/EventViewer.cs
+++ b/Tools/EventViewer.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Windows.Forms;
+
+namespace economy_sim
+{
+    public partial class EventViewer : Form
+    {
+        private class LogEntry
+        {
+            public DateTime Timestamp { get; set; }
+            public string Type { get; set; } = string.Empty;
+            public string Data { get; set; } = string.Empty;
+        }
+
+        private readonly List<LogEntry> events = new();
+
+        public EventViewer()
+        {
+            InitializeComponent();
+            buttonOpen.Click += ButtonOpen_Click;
+            scrubBar.Scroll += ScrubBar_Scroll;
+        }
+
+        private void ButtonOpen_Click(object? sender, EventArgs e)
+        {
+            using var ofd = new OpenFileDialog
+            {
+                Filter = "Event Logs (*.jsonl)|*.jsonl|All files|*.*",
+                InitialDirectory = Path.Combine(Directory.GetCurrentDirectory(), "logs")
+            };
+
+            if (ofd.ShowDialog() == DialogResult.OK)
+            {
+                LoadLog(ofd.FileName);
+            }
+        }
+
+        private void LoadLog(string path)
+        {
+            events.Clear();
+            foreach (var line in File.ReadLines(path))
+            {
+                try
+                {
+                    var entry = JsonSerializer.Deserialize<LogEntry>(line);
+                    if (entry != null)
+                        events.Add(entry);
+                }
+                catch
+                {
+                    // ignore parse errors
+                }
+            }
+
+            eventsList.Items.Clear();
+            foreach (var ev in events)
+            {
+                eventsList.Items.Add($"{ev.Timestamp:HH:mm:ss} {ev.Type}");
+            }
+
+            scrubBar.Minimum = 0;
+            scrubBar.Maximum = events.Count > 0 ? events.Count - 1 : 0;
+            scrubBar.Value = 0;
+            if (eventsList.Items.Count > 0)
+                eventsList.SelectedIndex = 0;
+        }
+
+        private void ScrubBar_Scroll(object? sender, EventArgs e)
+        {
+            int index = scrubBar.Value;
+            if (index >= 0 && index < eventsList.Items.Count)
+            {
+                eventsList.SelectedIndex = index;
+            }
+        }
+
+        protected override void OnFormClosing(FormClosingEventArgs e)
+        {
+            e.Cancel = true;
+            Hide();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- log all published events via new `Tools/EventLogger`
- expose `MessagePublished` event in `MessageBus`
- hook logger in `GameServices`
- add WinForms `EventViewer` for reading log files
- button to open EventViewer from MainGame

## Testing
- `dotnet build "Messaging/Messaging.csproj" -v minimal`
- `dotnet build "economy sim.sln" -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_687dcca1d9b08323a992f04de74e295a