### PR TITLE
Add schema registry and verification test

### DIFF
--- a/Protocols/SchemaRegistry.cs
+++ b/Protocols/SchemaRegistry.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+
+namespace EconomySim.Protocols
+{
+    public record SchemaInfo(string FileName, string Checksum, int Version);
+
+    /// <summary>
+    /// Registry holding known schema checksums so tests can verify generated
+    /// classes are up to date with their .fbs definitions.
+    /// </summary>
+    public static class SchemaRegistry
+    {
+        private static readonly SchemaInfo[] Schemas = new[]
+        {
+            new SchemaInfo("EconomyUpdatedEvent.fbs", "09b1b2596921e25d39cab761f78f82c7967b279a1c05aaa98e25c4e351f295a0", 1),
+            new SchemaInfo("PopulationUpdatedEvent.fbs", "d1dcfc421f31aa142d81bedc73c06601f9b90cc924f69f6e2e21c82b40dac8f1", 1)
+        };
+
+        public static IEnumerable<SchemaInfo> All => Schemas.AsEnumerable();
+
+        public static void ValidateCurrentSchemas(string schemaDirectory = "Protocols")
+        {
+            foreach (var schema in Schemas)
+            {
+                var path = Path.Combine(schemaDirectory, schema.FileName);
+                if (!File.Exists(path))
+                    throw new FileNotFoundException($"Schema file not found: {path}");
+
+                var checksum = ComputeChecksum(path);
+                if (!checksum.Equals(schema.Checksum, StringComparison.OrdinalIgnoreCase))
+                    throw new InvalidOperationException($"Schema {schema.FileName} checksum mismatch. Expected {schema.Checksum} but found {checksum}. Run generate_flatbuffers to update generated files.");
+
+                var generated = Path.Combine("Generated", "EconomySim", "Protocols",
+                    Path.GetFileNameWithoutExtension(schema.FileName) + ".cs");
+                if (!File.Exists(generated))
+                    throw new FileNotFoundException($"Generated file missing for {schema.FileName}: {generated}");
+            }
+        }
+
+        private static string ComputeChecksum(string filePath)
+        {
+            using var sha = SHA256.Create();
+            using var stream = File.OpenRead(filePath);
+            var hash = sha.ComputeHash(stream);
+            return Convert.ToHexString(hash).ToLowerInvariant();
+        }
+    }
+}

--- a/SchemaRegistryTests/SchemaRegistryTests.cs
+++ b/SchemaRegistryTests/SchemaRegistryTests.cs
@@ -1,0 +1,14 @@
+using EconomySim.Protocols;
+using Xunit;
+
+namespace SchemaRegistryTests
+{
+    public class SchemaRegistryTests
+    {
+        [Fact]
+        public void SchemasAreUpToDate()
+        {
+            SchemaRegistry.ValidateCurrentSchemas();
+        }
+    }
+}

--- a/SchemaRegistryTests/SchemaRegistryTests.csproj
+++ b/SchemaRegistryTests/SchemaRegistryTests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\economy sim.csproj" />
+  </ItemGroup>
+</Project>

--- a/economy sim.sln
+++ b/economy sim.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "economy sim", "economy sim.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Messaging", "Messaging/Messaging.csproj", "{670D0D3B-5109-469E-88DD-4F8C9D5966E2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SchemaRegistryTests", "SchemaRegistryTests/SchemaRegistryTests.csproj", "{23B34947-92AD-43ED-831B-52E5E3BE50A1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -31,6 +33,14 @@ Global
                 {670D0D3B-5109-469E-88DD-4F8C9D5966E2}.Release|Any CPU.Build.0 = Release|Any CPU
                 {670D0D3B-5109-469E-88DD-4F8C9D5966E2}.Release|x64.ActiveCfg = Release|x64
                 {670D0D3B-5109-469E-88DD-4F8C9D5966E2}.Release|x64.Build.0 = Release|x64
+                {23B34947-92AD-43ED-831B-52E5E3BE50A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {23B34947-92AD-43ED-831B-52E5E3BE50A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {23B34947-92AD-43ED-831B-52E5E3BE50A1}.Debug|x64.ActiveCfg = Debug|x64
+                {23B34947-92AD-43ED-831B-52E5E3BE50A1}.Debug|x64.Build.0 = Debug|x64
+                {23B34947-92AD-43ED-831B-52E5E3BE50A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {23B34947-92AD-43ED-831B-52E5E3BE50A1}.Release|Any CPU.Build.0 = Release|Any CPU
+                {23B34947-92AD-43ED-831B-52E5E3BE50A1}.Release|x64.ActiveCfg = Release|x64
+                {23B34947-92AD-43ED-831B-52E5E3BE50A1}.Release|x64.Build.0 = Release|x64
         EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- keep checksums for `.fbs` schemas
- add SchemaRegistryTests project
- validate schema checksums in unit test

## Testing
- `dotnet restore`
- `dotnet test --no-restore` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_687dd08ebea08323a796d33e6508f3c6