### PR TITLE
Integrate land value step into simulation

### DIFF
--- a/LandValueCalculator.cs
+++ b/LandValueCalculator.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Linq;
+using System.Threading;
+using Nts = NetTopologySuite.Geometries;
+
+namespace StrategyGame
+{
+    /// <summary>
+    /// Calculates land value for each parcel in a city model.
+    /// </summary>
+    public static class LandValueCalculator
+    {
+        private static readonly ThreadLocal<Random> Rng = new(() => new Random());
+
+        /// <summary>
+        /// Assigns a land value between 0 and 100 to each parcel based on
+        /// distance from the road network centre. Placeholder implementation.
+        /// </summary>
+        public static void Calculate(CityDataModel model)
+        {
+            if (model?.Parcels == null || model.RoadNetwork == null)
+                return;
+
+            var env = new Nts.Envelope();
+            foreach (var seg in model.RoadNetwork)
+            {
+                env.ExpandToInclude(seg.X1, seg.Y1);
+                env.ExpandToInclude(seg.X2, seg.Y2);
+            }
+            if (env.IsNull)
+                return;
+
+            var center = env.Centre;
+            var centerPt = new Nts.Point(center);
+            double maxDist = center.Distance(new Nts.Coordinate(env.MinX, env.MinY));
+            if (maxDist < 1e-6)
+                maxDist = 1.0;
+
+            foreach (var parcel in model.Parcels)
+            {
+                var pCenter = parcel.Shape.Centroid;
+                double dist = pCenter.Distance(centerPt);
+                double landValue = Math.Max(0, 100 * (1 - dist / maxDist));
+                landValue += Rng.Value.NextDouble() * 20 - 10;
+                parcel.LandValue = Math.Clamp(landValue, 0, 100);
+            }
+        }
+    }
+}

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -881,12 +881,22 @@ namespace economy_sim
                 {
                     if (SimulationLODManager.Instance.ShouldSimulateHighFidelity(city))
                     {
+                        // --- Land value & land use update ---
+                        if (city.ProceduralData != null)
+                        {
+                            LandValueCalculator.Calculate(city.ProceduralData);
+                            LandUseSimulator.Run(city.ProceduralData);
+                            BuildingRefiner.RefineBuildings(city.ProceduralData);
+                        }
+
                         Market.ResetCitySupplyDemand(city);
                         foreach (var factory in city.Factories)
                         {
                             factory.Produce(city.Stockpile, city);
                         }
+
                         StrategyGame.Economy.UpdateCityEconomy(city); // Populates ImportNeeds and ExportableSurplus
+
                         city.ProgressConstruction();
                         if (constructionForm.Visible && constructionForm.CurrentCity == city)
                         {


### PR DESCRIPTION
## Summary
- add a basic `LandValueCalculator` for parcel valuation
- update `TimerSim_Tick` to calculate land value, simulate land use, refine buildings and then update economies

## Testing
- `dotnet build "economy sim.sln" -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ddbfe6dd08323950896802c35ebeb