### PR TITLE
Add IBusMessage and CityOrigin property to events

### DIFF
--- a/Generated/EconomySim/Protocols/EconomyUpdatedEvent.cs
+++ b/Generated/EconomySim/Protocols/EconomyUpdatedEvent.cs
@@ -8,8 +8,9 @@ namespace EconomySim.Protocols
 using global::System;
 using global::System.Collections.Generic;
 using global::FlatBuffers;
+using Messaging;
 
-public struct EconomyUpdatedEvent : IFlatbufferObject
+public partial struct EconomyUpdatedEvent : IFlatbufferObject, IBusMessage
 {
   private Table __p;
   public ByteBuffer ByteBuffer { get { return __p.bb; } }
@@ -54,6 +55,7 @@ public struct EconomyUpdatedEvent : IFlatbufferObject
   }
   public static void FinishEconomyUpdatedEventBuffer(FlatBufferBuilder builder, Offset<EconomySim.Protocols.EconomyUpdatedEvent> offset) { builder.Finish(offset.Value); }
   public static void FinishSizePrefixedEconomyUpdatedEventBuffer(FlatBufferBuilder builder, Offset<EconomySim.Protocols.EconomyUpdatedEvent> offset) { builder.FinishSizePrefixed(offset.Value); }
+  public string CityOrigin => CityId;
 }
 
 

--- a/Generated/EconomySim/Protocols/PopulationUpdatedEvent.cs
+++ b/Generated/EconomySim/Protocols/PopulationUpdatedEvent.cs
@@ -8,8 +8,9 @@ namespace EconomySim.Protocols
 using global::System;
 using global::System.Collections.Generic;
 using global::FlatBuffers;
+using Messaging;
 
-public struct PopulationUpdatedEvent : IFlatbufferObject
+public partial struct PopulationUpdatedEvent : IFlatbufferObject, IBusMessage
 {
   private Table __p;
   public ByteBuffer ByteBuffer { get { return __p.bb; } }
@@ -58,6 +59,7 @@ public struct PopulationUpdatedEvent : IFlatbufferObject
   }
   public static void FinishPopulationUpdatedEventBuffer(FlatBufferBuilder builder, Offset<EconomySim.Protocols.PopulationUpdatedEvent> offset) { builder.Finish(offset.Value); }
   public static void FinishSizePrefixedPopulationUpdatedEventBuffer(FlatBufferBuilder builder, Offset<EconomySim.Protocols.PopulationUpdatedEvent> offset) { builder.FinishSizePrefixed(offset.Value); }
+  public string CityOrigin => CityId;
 }
 
 

--- a/Messaging/IBusMessage.cs
+++ b/Messaging/IBusMessage.cs
@@ -1,0 +1,13 @@
+namespace Messaging
+{
+    /// <summary>
+    /// Marker interface for events published on the message bus.
+    /// </summary>
+    public interface IBusMessage
+    {
+        /// <summary>
+        /// Identifier for the city that originated the message.
+        /// </summary>
+        string CityOrigin { get; }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a `Messaging.IBusMessage` interface
- patch generated event classes to implement `IBusMessage`
- each event now exposes `CityOrigin` derived from `CityId`

## Testing
- `dotnet build "economy sim.sln"` *(fails: SDK 'Microsoft.NET.Sdk.WindowsDesktop' not found)*

------
https://chatgpt.com/codex/tasks/task_e_687dc02178e88323bdff2e353588ea69