### PR TITLE
Fix project duplication warnings

### DIFF
--- a/SchemaRegistryTests/SchemaRegistryTests.csproj
+++ b/SchemaRegistryTests/SchemaRegistryTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/economy sim.csproj
+++ b/economy sim.csproj
@@ -101,11 +101,6 @@
                 <ProjectReference Include="Messaging/Messaging.csproj" />
         </ItemGroup>
 
-        <!-- Generated FlatBuffers -->
-        <ItemGroup>
-                <Compile Include="Generated\**\*.cs" />
-        </ItemGroup>
-
-	<!-- Rely on SDK implicit Compile and EmbeddedResource items -->
+        <!-- Rely on SDK implicit Compile and EmbeddedResource items -->
 
 </Project>


### PR DESCRIPTION
## Summary
- remove explicit include of generated files so default SDK compile list doesn't complain
- target `net8.0-windows` in SchemaRegistryTests

## Testing
- `dotnet build "economy sim.sln" -v minimal` *(fails: could not resolve SDK `Microsoft.NET.Sdk.WindowsDesktop`)*

------
https://chatgpt.com/codex/tasks/task_e_687de0698ff48323834ef964c224eeb1