### PR TITLE
Fix project duplication warnings

### DIFF
--- a/SchemaRegistryTests/SchemaRegistryTests.csproj
+++ b/SchemaRegistryTests/SchemaRegistryTests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/economy sim.csproj
+++ b/economy sim.csproj
@@ -80,13 +80,14 @@
 		<PackageReference Include="NetTopologySuite.IO.ShapeFile" Version="2.1.0" />
 		<PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.6" />
 		<PackageReference Include="SkiaSharp" Version="3.119.0" />
-		<PackageReference Include="SkiaSharp.Views.WindowsForms" Version="2.88.3" />
-		<PackageReference Include="System.Buffers" Version="4.5.1" />
-		<PackageReference Include="System.IO.Pipelines" Version="9.0.4" />
-		<PackageReference Include="System.Memory" Version="4.5.5" />
-		<PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
-		<PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-		<PackageReference Include="System.Text.Encodings.Web" Version="9.0.4" />
+                <PackageReference Include="SkiaSharp.Views.WindowsForms" Version="2.88.3" />
+                <PackageReference Include="System.Buffers" Version="4.5.1" />
+                <PackageReference Include="System.IO.Pipelines" Version="9.0.4" />
+                <PackageReference Include="System.Memory" Version="4.5.5" />
+                <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+                <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+                <PackageReference Include="Google.FlatBuffers" Version="25.2.10" />
+                <PackageReference Include="System.Text.Encodings.Web" Version="9.0.4" />
 		<PackageReference Include="System.Text.Json" Version="9.0.4" />
 		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
                 <PackageReference Include="System.ValueTuple" Version="4.5.0" />

--- a/economy sim.csproj
+++ b/economy sim.csproj
@@ -101,11 +101,6 @@
                 <ProjectReference Include="Messaging/Messaging.csproj" />
         </ItemGroup>
 
-        <!-- Generated FlatBuffers -->
-        <ItemGroup>
-                <Compile Include="Generated\**\*.cs" />
-        </ItemGroup>
-
-	<!-- Rely on SDK implicit Compile and EmbeddedResource items -->
+        <!-- Rely on SDK implicit Compile and EmbeddedResource items -->
 
 </Project>


### PR DESCRIPTION
## Summary
- remove explicit include of generated files so default SDK compile list doesn't complain
- target `net8.0-windows` in SchemaRegistryTests

## Testing
- `dotnet build "economy sim.sln" -v minimal` *(fails: could not resolve SDK `Microsoft.NET.Sdk.WindowsDesktop`)*

------
https://chatgpt.com/codex/tasks/task_e_687de0698ff48323834ef964c224eeb1