### PR TITLE
Implement MessageBus for async events

### DIFF
--- a/ConstructionCompany.cs
+++ b/ConstructionCompany.cs
@@ -44,7 +44,7 @@ namespace StrategyGame
             {
                 if (project.IsComplete())
                 {
-                    Projects.Remove(project);
+                    CompleteProject(project, city);
                     continue;
                 }
 
@@ -81,15 +81,16 @@ namespace StrategyGame
 
                 if (project.IsComplete())
                 {
-                    Projects.Remove(project);
+                    CompleteProject(project, city);
                 }
             }
         }
 
-        private void CompleteProject(ConstructionProject project)
+        private void CompleteProject(ConstructionProject project, City city)
         {
             Projects.Remove(project);
             Console.WriteLine($"Project {project.Type} completed with output: {project.Output}");
+            MessageBus.Instance.Publish(new ConstructionCompletedEvent(project, city));
             // TODO: Deliver the output to the city or state that issued the contract
         }
     }

--- a/GameEvents.cs
+++ b/GameEvents.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace StrategyGame
+{
+    /// <summary>
+    /// Event raised when a construction project is completed.
+    /// </summary>
+    public record ConstructionCompletedEvent(ConstructionProject Project, City City);
+
+    /// <summary>
+    /// Event raised whenever a trade is recorded on the global market.
+    /// </summary>
+    public record TradeRecordedEvent(string GoodName, string ExportingCountry, string ImportingCountry, int Quantity, double TotalValue);
+}

--- a/GlobalMarket.cs
+++ b/GlobalMarket.cs
@@ -261,7 +261,7 @@ namespace StrategyGame // Reverted from EconomySim
             
             // Accumulate global trade value
             GlobalTradeValue += totalValue;
-            
+
             // Record significant trade events
             if (quantity > 100 || totalValue > 10000)
             {
@@ -275,6 +275,8 @@ namespace StrategyGame // Reverted from EconomySim
                     TurnsAgo = 0
                 });
             }
+
+            MessageBus.Instance.Publish(new TradeRecordedEvent(goodName, exportingCountry, importingCountry, quantity, totalValue));
         }
         
         private void EnsureCountryInTradeFlows(string countryName)

--- a/MessageBus.cs
+++ b/MessageBus.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace StrategyGame
+{
+    /// <summary>
+    /// Simple thread-safe message bus for publishing and subscribing to game events.
+    /// </summary>
+    public class MessageBus
+    {
+        private static readonly Lazy<MessageBus> lazyInstance = new Lazy<MessageBus>(() => new MessageBus());
+        public static MessageBus Instance => lazyInstance.Value;
+
+        private readonly ConcurrentDictionary<Type, List<Delegate>> handlers = new ConcurrentDictionary<Type, List<Delegate>>();
+
+        private MessageBus() { }
+
+        /// <summary>
+        /// Register a handler for the specified event type.
+        /// </summary>
+        public void Subscribe<T>(Action<T> handler)
+        {
+            var list = handlers.GetOrAdd(typeof(T), _ => new List<Delegate>());
+            lock (list)
+            {
+                list.Add(handler);
+            }
+        }
+
+        /// <summary>
+        /// Publish a message to all subscribed handlers. Handlers are executed asynchronously.
+        /// </summary>
+        public void Publish<T>(T message)
+        {
+            if (!handlers.TryGetValue(typeof(T), out var list))
+                return;
+
+            List<Delegate> copy;
+            lock (list)
+            {
+                copy = list.ToList();
+            }
+
+            foreach (var handler in copy.Cast<Action<T>>())
+            {
+                Task.Run(() => handler(message));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a new `MessageBus` singleton for async publish/subscribe
- add `ConstructionCompletedEvent` and `TradeRecordedEvent`
- publish construction completion and trade recording events

## Testing
- `dotnet build "economy sim.sln"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e0534a8588323adfc2f103fedcd3a