### PR TITLE
Add AestheticMappingLayer and generation parameters

### DIFF
--- a/AestheticMappingLayer.cs
+++ b/AestheticMappingLayer.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+
+namespace StrategyGame
+{
+    public enum BuildingStyle { Traditional, Modern }
+    public enum RoadNetworkType { Organic, Grid }
+
+    public class CityGenerationParameters
+    {
+        public BuildingStyle BuildingStyle { get; init; } = BuildingStyle.Traditional;
+        public RoadNetworkType RoadNetworkType { get; init; } = RoadNetworkType.Organic;
+    }
+
+    /// <summary>
+    /// Maps high level simulation metrics to city generation parameters.
+    /// Listens to the message bus and updates parameters accordingly.
+    /// </summary>
+    public sealed class AestheticMappingLayer
+    {
+        private static readonly Lazy<AestheticMappingLayer> lazy = new(() => new AestheticMappingLayer());
+        public static AestheticMappingLayer Instance => lazy.Value;
+
+        private CityGenerationParameters currentParameters = new CityGenerationParameters();
+        public CityGenerationParameters CurrentParameters => currentParameters;
+
+        private AestheticMappingLayer()
+        {
+            MessageBus.Instance.Subscribe<EconomyUpdatedEventData>(OnEconomyUpdated);
+        }
+
+        private void OnEconomyUpdated(EconomyUpdatedEventData data)
+        {
+            var style = data.Gdp > 100000 ? BuildingStyle.Modern : BuildingStyle.Traditional;
+            var road = data.NewBudget > 5000 ? RoadNetworkType.Grid : RoadNetworkType.Organic;
+            currentParameters = new CityGenerationParameters
+            {
+                BuildingStyle = style,
+                RoadNetworkType = road
+            };
+        }
+    }
+}

--- a/CityDataModel.cs
+++ b/CityDataModel.cs
@@ -14,6 +14,11 @@ namespace StrategyGame
         public List<Parcel> Parcels { get; set; } = new();
         public List<Building> Buildings { get; set; } = new();
 
+        /// <summary>
+        /// Parameters controlling how this city's geometry is generated.
+        /// </summary>
+        public CityGenerationParameters GenerationParameters { get; set; } = new();
+
         // Spatial index of buildings for faster tile queries
         public STRtree<Building>? BuildingIndex { get; set; }
     }

--- a/CityGeneration.cs
+++ b/CityGeneration.cs
@@ -379,6 +379,12 @@ namespace StrategyGame
                     b.Level = 0;
                     break;
             }
+
+            var style = AestheticMappingLayer.Instance.CurrentParameters.BuildingStyle;
+            if (style == BuildingStyle.Modern)
+            {
+                b.Level += 1;
+            }
         }
     }
 
@@ -442,7 +448,8 @@ namespace StrategyGame
 
                 await Parallel.ForEachAsync(batch, new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount }, async (area, token) =>
                 {
-                    await RoadNetworkGenerator.GenerateModelAsync(area, 10).ConfigureAwait(false);
+                    var p = AestheticMappingLayer.Instance.CurrentParameters;
+                    await RoadNetworkGenerator.GenerateModelAsync(area, 10, p).ConfigureAwait(false);
                 }).ConfigureAwait(false);
             }
         }

--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -76,6 +76,10 @@ namespace StrategyGame
 
                 bw.Write(model.Id.ToByteArray());
 
+            // generation parameters
+            bw.Write((int)model.GenerationParameters.BuildingStyle);
+            bw.Write((int)model.GenerationParameters.RoadNetworkType);
+
             if (model.UrbanArea != null)
             {
                 bw.Write(true);
@@ -148,6 +152,9 @@ namespace StrategyGame
 
             var model = new CityDataModel();
             model.Id = new Guid(br.ReadBytes(16));
+            var style = (BuildingStyle)br.ReadInt32();
+            var roadType = (RoadNetworkType)br.ReadInt32();
+            model.GenerationParameters = new CityGenerationParameters { BuildingStyle = style, RoadNetworkType = roadType };
 
             if (br.ReadBoolean())
             {
@@ -218,7 +225,7 @@ namespace StrategyGame
             }
         }
 
-        public static async Task<CityDataModel> GenerateModelAsync(Nts.Polygon urbanArea, int cellSize)
+        public static async Task<CityDataModel> GenerateModelAsync(Nts.Polygon urbanArea, int cellSize, CityGenerationParameters parameters)
         {
             string hash = ComputeHash(urbanArea);
             string cacheDir = GetCacheDir();
@@ -255,9 +262,10 @@ namespace StrategyGame
             var result = new CityDataModel
             {
                 Id = Guid.NewGuid(),
-                UrbanArea = urbanArea
+                UrbanArea = urbanArea,
+                GenerationParameters = parameters
             };
-            var roadGeometries = GetOrGenerateFor(urbanArea, cellSize);
+            var roadGeometries = GetOrGenerateFor(urbanArea, cellSize, parameters.RoadNetworkType);
 
             result.RoadNetwork = roadGeometries
                 .SelectMany(tuple => tuple.Line.Coordinates.Zip(tuple.Line.Coordinates.Skip(1), (s, e) =>
@@ -296,14 +304,14 @@ namespace StrategyGame
             return result;
         }
 
-        public static List<(Nts.LineString Line, RoadType Type)> GetOrGenerateFor(Nts.Polygon urbanArea, int cellSize)
+        public static List<(Nts.LineString Line, RoadType Type)> GetOrGenerateFor(Nts.Polygon urbanArea, int cellSize, RoadNetworkType roadType)
         {
             string key = ComputeHash(urbanArea);
             if (networkCache.TryGetValue(key, out var cachedNet))
                 return cachedNet;
 
             var highways = GenerateHighways(urbanArea).ToList();
-            var localRoads = GenerateLocalRoads(urbanArea, highways);
+            var localRoads = GenerateLocalRoads(urbanArea, highways, roadType);
 
             var allRoads = highways.Select(h => (h, RoadType.Primary))
                                  .Concat(localRoads.Select(l => (l, RoadType.Secondary)))
@@ -329,7 +337,7 @@ namespace StrategyGame
             }
         }
 
-        private static List<Nts.LineString> GenerateLocalRoads(Nts.Polygon area, List<Nts.LineString> highways)
+        private static List<Nts.LineString> GenerateLocalRoads(Nts.Polygon area, List<Nts.LineString> highways, RoadNetworkType roadType)
         {
             const double roadSegmentLength = 0.005;
             // Make the iteration limit proportional to the area. Ensures small
@@ -353,8 +361,17 @@ namespace StrategyGame
                     double baseAngle = Math.Atan2(
                         highway.EndPoint.Y - highway.StartPoint.Y,
                         highway.EndPoint.X - highway.StartPoint.X);
-                    queue.Enqueue((pt, baseAngle + Math.PI / 2));
-                    queue.Enqueue((pt, baseAngle - Math.PI / 2));
+                    if (roadType == RoadNetworkType.Grid)
+                    {
+                        queue.Enqueue((pt, baseAngle + Math.PI / 2));
+                        queue.Enqueue((pt, baseAngle - Math.PI / 2));
+                    }
+                    else
+                    {
+                        double a = random.NextDouble() * Math.PI;
+                        queue.Enqueue((pt, baseAngle + a));
+                        queue.Enqueue((pt, baseAngle - a));
+                    }
                 }
             }
             if (queue.Count == 0 && area.EnvelopeInternal.Width > 0)
@@ -440,11 +457,13 @@ namespace StrategyGame
                     // Branch left/right
                     if (random.NextDouble() < (0.2 + density * 0.5)) // Branching probability
                     {
-                        queue.Enqueue((endPoint, angle + Math.PI / 2));
+                        double a = roadType == RoadNetworkType.Grid ? Math.PI / 2 : random.NextDouble() * Math.PI;
+                        queue.Enqueue((endPoint, angle + a));
                     }
                     if (random.NextDouble() < (0.2 + density * 0.5))
                     {
-                        queue.Enqueue((endPoint, angle - Math.PI / 2));
+                        double a = roadType == RoadNetworkType.Grid ? Math.PI / 2 : random.NextDouble() * Math.PI;
+                        queue.Enqueue((endPoint, angle - a));
                     }
                 }
             }

--- a/UrbanAreaManager.cs
+++ b/UrbanAreaManager.cs
@@ -62,7 +62,8 @@ namespace StrategyGame
 
             Parallel.ForEach(UrbanPolygons, urbanArea =>
             {
-                RoadNetworkGenerator.GetOrGenerateFor(urbanArea, 40);
+                var p = AestheticMappingLayer.Instance.CurrentParameters;
+                RoadNetworkGenerator.GetOrGenerateFor(urbanArea, 40, p.RoadNetworkType);
             });
 
             sw.Stop();


### PR DESCRIPTION
## Summary
- create `AestheticMappingLayer` to translate economy events into generation parameters
- store generation parameters in `CityDataModel`
- adjust building rules and road generation to respect new parameters
- wire new parameters through city generation and caching

## Testing
- `dotnet build "economy sim.sln" -v minimal` *(fails: Could not resolve SDK 'Microsoft.NET.Sdk.WindowsDesktop')*


------
https://chatgpt.com/codex/tasks/task_e_687e09d3a4988323837643cb31eb80d0