### PR TITLE
Add event logging and replay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -261,6 +261,9 @@ UpgradeLog*.htm
 ServiceFabricBackup/
 *.rptproj.bak
 
+# Log files
+logs/
+
 # SQL Server files
 *.mdf
 *.ldf

--- a/EconomySim.Tests/WorldSimEventTests.cs
+++ b/EconomySim.Tests/WorldSimEventTests.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using StrategyGame;
+using System.IO;
 
 namespace EconomySim.Tests;
 
@@ -29,5 +30,27 @@ public class WorldSimEventTests
         MessageBus.Instance.Publish(new MajorInfrastructureBuiltEventData(city.Name, "Railway", 2.0));
         await Task.Delay(50);
         Assert.AreEqual(700, city.Budget, 0.001);
+    }
+
+    [TestMethod]
+    public async Task EventLoggerRecordsAndReplays()
+    {
+        var logCity = new City("LogCity") { Population = 1000, Budget = 1000 };
+        WorldSim.RegisterCity(logCity);
+        WorldSim.Initialize();
+
+        MessageBus.Instance.Publish(new DistrictDestroyedEventData(logCity.Name, "Old Town", 100));
+        await Task.Delay(50);
+
+        var logFile = EventLogger.LogFilePath;
+        Assert.IsTrue(File.Exists(logFile));
+
+        var replayCity = new City("ReplayCity") { Population = 1000, Budget = 1000 };
+        WorldSim.RegisterCity(replayCity);
+
+        EventReplayer.Replay(logFile);
+        await Task.Delay(50);
+
+        Assert.AreEqual(900, replayCity.Population);
     }
 }

--- a/EventLogger.cs
+++ b/EventLogger.cs
@@ -1,0 +1,60 @@
+using System;
+using System.IO;
+using System.Text.Json;
+
+namespace StrategyGame
+{
+    /// <summary>
+    /// Logs all events published on the MessageBus to a structured JSONL file.
+    /// </summary>
+    public static class EventLogger
+    {
+        private static readonly object locker = new();
+        private static readonly string logsDirectory;
+        private static readonly string logFilePath;
+
+        static EventLogger()
+        {
+            logsDirectory = Path.Combine(Directory.GetCurrentDirectory(), "logs");
+            if (!Directory.Exists(logsDirectory))
+            {
+                Directory.CreateDirectory(logsDirectory);
+            }
+            logFilePath = Path.Combine(logsDirectory, $"event_log_{DateTime.Now:yyyy-MM-dd_HH-mm-ss}.jsonl");
+        }
+
+        /// <summary>
+        /// Gets the current log file path.
+        /// </summary>
+        public static string LogFilePath => logFilePath;
+
+        /// <summary>
+        /// Record a published event instance to the log file.
+        /// </summary>
+        public static void Record<T>(T message)
+        {
+            var envelope = new EventEnvelope
+            {
+                Timestamp = DateTime.UtcNow,
+                Type = typeof(T).AssemblyQualifiedName ?? typeof(T).FullName!,
+                Data = JsonSerializer.SerializeToElement(message)
+            };
+
+            var json = JsonSerializer.Serialize(envelope);
+            lock (locker)
+            {
+                File.AppendAllText(logFilePath, json + Environment.NewLine);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Wrapper used for logging events to disk.
+    /// </summary>
+    public struct EventEnvelope
+    {
+        public DateTime Timestamp { get; set; }
+        public string Type { get; set; }
+        public JsonElement Data { get; set; }
+    }
+}

--- a/EventReplayer.cs
+++ b/EventReplayer.cs
@@ -1,0 +1,40 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using System.Reflection;
+
+namespace StrategyGame
+{
+    /// <summary>
+    /// Utility to replay logged events by publishing them back onto the MessageBus.
+    /// </summary>
+    public static class EventReplayer
+    {
+        public static void Replay(string logFilePath)
+        {
+            if (!File.Exists(logFilePath))
+                throw new FileNotFoundException($"Log file not found: {logFilePath}");
+
+            foreach (var line in File.ReadLines(logFilePath))
+            {
+                if (string.IsNullOrWhiteSpace(line))
+                    continue;
+
+                var envelope = JsonSerializer.Deserialize<EventEnvelope>(line);
+                if (envelope.Type == null)
+                    continue;
+
+                var type = Type.GetType(envelope.Type);
+                if (type == null)
+                    continue;
+
+                object? data = envelope.Data.Deserialize(type, new JsonSerializerOptions());
+                if (data == null)
+                    continue;
+
+                var method = typeof(MessageBus).GetMethod("Publish")!.MakeGenericMethod(type);
+                method.Invoke(MessageBus.Instance, new[] { data });
+            }
+        }
+    }
+}

--- a/MessageBus.cs
+++ b/MessageBus.cs
@@ -35,6 +35,7 @@ namespace StrategyGame
         /// </summary>
         public void Publish<T>(T message)
         {
+            EventLogger.Record(message);
             if (!handlers.TryGetValue(typeof(T), out var list))
                 return;
 

--- a/Program.cs
+++ b/Program.cs
@@ -8,6 +8,7 @@ namespace StrategyGame
         [STAThread]
         static void Main()
         {
+            SchemaValidator.Validate();
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
             WorldSim.Initialize();

--- a/SchemaValidator.cs
+++ b/SchemaValidator.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace StrategyGame
+{
+    /// <summary>
+    /// Validates that FlatBuffers schema versions match the registry.
+    /// </summary>
+    public static class SchemaValidator
+    {
+        private const string RegistryFile = "schema_registry.json";
+
+        public static void Validate()
+        {
+            if (!File.Exists(RegistryFile))
+                throw new FileNotFoundException($"Schema registry '{RegistryFile}' not found.");
+
+            var registry = JsonSerializer.Deserialize<Dictionary<string, ushort>>(File.ReadAllText(RegistryFile))
+                           ?? new Dictionary<string, ushort>();
+
+            foreach (var fbs in Directory.GetFiles("FlatBuffersSchemas", "*.fbs"))
+            {
+                var name = Path.GetFileNameWithoutExtension(fbs);
+                var text = File.ReadAllText(fbs);
+                var match = Regex.Match(text, @"version:ushort\s*=\s*(\d+)");
+                if (!match.Success)
+                    continue;
+                var version = ushort.Parse(match.Groups[1].Value);
+
+                if (!registry.TryGetValue(name, out var expected) || expected != version)
+                    throw new InvalidOperationException($"Schema version mismatch for {name}: expected {expected}, found {version}");
+            }
+        }
+    }
+}

--- a/schema_registry.json
+++ b/schema_registry.json
@@ -1,0 +1,6 @@
+{
+  "EconomyUpdatedEvent": 1,
+  "PopulationUpdatedEvent": 1,
+  "DistrictDestroyedEvent": 1,
+  "MajorInfrastructureBuiltEvent": 1
+}


### PR DESCRIPTION
## Summary
- log all bus events to structured JSONL files
- add a replay helper to push logged events back through the bus
- check FlatBuffers schemas against a simple registry at startup
- ignore log files in source control
- test event logging and replay

## Testing
- `dotnet build "economy sim.sln" -v minimal` *(fails: SDK 'Microsoft.NET.Sdk.WindowsDesktop' not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e104870bc83238820cb97c23032c4