### PR TITLE
Implement city LOD switching

### DIFF
--- a/City.cs
+++ b/City.cs
@@ -6,9 +6,18 @@ using StrategyGame; // Ensure namespace for ProjectType and ConstructionProject 
 
 namespace StrategyGame
 {
+    public enum CityLOD
+    {
+        Full,
+        Simplified,
+        Dormant
+    }
+
     public class City
     {
         public string Name { get; set; }
+        public int Index { get; internal set; }
+        public CityLOD LOD { get; set; } = CityLOD.Full;
         public double Budget { get; set; }
         public int Population { get; set; }
         public double TaxRate { get; set; } // Percentage (e.g., 0.1 for 10%)

--- a/GameEvents.cs
+++ b/GameEvents.cs
@@ -31,4 +31,14 @@ namespace StrategyGame
     /// Event raised when major infrastructure is built in a city.
     /// </summary>
     public record MajorInfrastructureBuiltEventData(string CityName, string InfrastructureType, double Value);
+
+    /// <summary>
+    /// Event raised when a city's level of detail changes.
+    /// </summary>
+    public record CityLODChangedEventData(string CityName, CityLOD NewLOD);
+
+    /// <summary>
+    /// Summary event containing high level city data for low LOD rendering.
+    /// </summary>
+    public record CityStatusEventData(string CityName, int Population, double Budget, CityLOD LOD);
 }

--- a/LODSettings.cs
+++ b/LODSettings.cs
@@ -1,0 +1,8 @@
+namespace StrategyGame
+{
+    public static class LODSettings
+    {
+        public static double SimplifiedDistanceThreshold { get; set; } = 20;
+        public static double DormantDistanceThreshold { get; set; } = 60;
+    }
+}

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -796,6 +796,7 @@ namespace economy_sim
 
             StrategyGame.City cityCurrentlySelectedForUI = null;
             this.Invoke((Action)(() => { cityCurrentlySelectedForUI = GetSelectedCity(); }));
+            WorldSim.UpdateCityLODs(cityCurrentlySelectedForUI);
 
             // 1. Capture Previous Stats for the Selected City (if any, and not the first tick)
             if (cityCurrentlySelectedForUI != null && !firstTick)
@@ -1181,6 +1182,7 @@ namespace economy_sim
                     UpdateCountryStats();
 
                     var cityCurrentlySelectedForUI = GetSelectedCity();
+                    WorldSim.UpdateCityLODs(cityCurrentlySelectedForUI);
                     if (cityCurrentlySelectedForUI != null)
                     {
                         if (popStatsForm != null && popStatsForm.Visible)

--- a/WorldSim.cs
+++ b/WorldSim.cs
@@ -9,6 +9,8 @@ namespace StrategyGame
     public static class WorldSim
     {
         private static readonly Dictionary<string, City> cities = new();
+        private static readonly HashSet<string> focusedCities = new();
+        private static int nextIndex = 0;
 
         public static void Initialize()
         {
@@ -19,7 +21,22 @@ namespace StrategyGame
         public static void RegisterCity(City city)
         {
             if (city != null && !string.IsNullOrEmpty(city.Name))
+            {
+                city.Index = nextIndex++;
                 cities[city.Name] = city;
+            }
+        }
+
+        public static void AddNarrativeFocus(string cityName)
+        {
+            if (!string.IsNullOrEmpty(cityName))
+                focusedCities.Add(cityName);
+        }
+
+        public static void RemoveNarrativeFocus(string cityName)
+        {
+            if (!string.IsNullOrEmpty(cityName))
+                focusedCities.Remove(cityName);
         }
 
         private static void OnDistrictDestroyed(DistrictDestroyedEventData data)
@@ -36,6 +53,37 @@ namespace StrategyGame
             {
                 city.Budget += data.Value * 100;
             }
+        }
+
+        public static void UpdateCityLODs(City playerCity)
+        {
+            foreach (var city in cities.Values)
+            {
+                var previous = city.LOD;
+                if (city == playerCity || focusedCities.Contains(city.Name))
+                {
+                    city.LOD = CityLOD.Full;
+                }
+                else
+                {
+                    double distance = ComputeDistance(playerCity, city);
+                    if (distance < LODSettings.SimplifiedDistanceThreshold)
+                        city.LOD = CityLOD.Simplified;
+                    else
+                        city.LOD = CityLOD.Dormant;
+                }
+
+                if (previous != city.LOD)
+                    MessageBus.Instance.Publish(new CityLODChangedEventData(city.Name, city.LOD));
+
+                MessageBus.Instance.Publish(new CityStatusEventData(city.Name, city.Population, city.Budget, city.LOD));
+            }
+        }
+
+        private static double ComputeDistance(City a, City b)
+        {
+            if (a == null || b == null) return double.MaxValue;
+            return Math.Abs(a.Index - b.Index) * 10.0;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `CityLOD` enum and LOD fields on cities
- expose settings for LOD distance thresholds
- publish new events for LOD changes and city status snapshots
- manage city LODs in `WorldSim` and update them each tick

## Testing
- `dotnet build "economy sim.sln" -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e125d888083239ce70dc3086cb1a8