### PR TITLE
Add event-driven city generation queue

### DIFF
--- a/CityGeneration.cs
+++ b/CityGeneration.cs
@@ -389,69 +389,75 @@ namespace StrategyGame
     }
 
     // Manager used during generation time
-    public class CityGenerationManager
+    public class CityGenerationManager : IDisposable
     {
-        private readonly Queue<Nts.Polygon> queue = new();
+        private readonly ConcurrentQueue<Nts.Polygon> queue = new();
+        private readonly SemaphoreSlim signal = new(0);
+        private readonly CancellationTokenSource cts = new();
         private readonly CityGenerationData data;
-        private bool processing;
+        private int activeWorkers;
+        private readonly Task worker;
 
         public CityGenerationManager(CityGenerationData data)
         {
             this.data = data;
             RoadNetworkGenerator.Data = data;
+            MessageBus.Instance.Subscribe<CityGenerationRequestEventData>(OnRequest);
+            worker = Task.Run(ProcessQueueAsync);
+        }
+
+        private void OnRequest(CityGenerationRequestEventData req)
+        {
+            QueueArea(req.Area);
         }
 
         public void QueueArea(Nts.Polygon area)
         {
-            lock (queue)
+            queue.Enqueue(area);
+            signal.Release();
+        }
+
+        public bool IsProcessing() => !queue.IsEmpty || Volatile.Read(ref activeWorkers) > 0;
+
+        public int GetQueueCount() => queue.Count;
+
+        private async Task ProcessQueueAsync()
+        {
+            while (!cts.IsCancellationRequested)
             {
-                queue.Enqueue(area);
-                if (!processing)
+                try
                 {
-                    processing = true;
-                    _ = ProcessQueue();
+                    await signal.WaitAsync(cts.Token).ConfigureAwait(false);
                 }
-            }
-        }
-
-        public bool IsProcessing()
-        {
-            lock (queue)
-            {
-                return processing || queue.Count > 0;
-            }
-        }
-
-        public int GetQueueCount()
-        {
-            lock (queue)
-            {
-                return queue.Count;
-            }
-        }
-
-        private async Task ProcessQueue()
-        {
-            while (true)
-            {
-                List<Nts.Polygon> batch;
-                lock (queue)
+                catch (OperationCanceledException)
                 {
-                    if (queue.Count == 0)
-                    {
-                        processing = false;
-                        return;
-                    }
-                    batch = new List<Nts.Polygon>(queue);
-                    queue.Clear();
+                    break;
                 }
 
-                await Parallel.ForEachAsync(batch, new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount }, async (area, token) =>
+                if (!queue.TryDequeue(out var area))
+                    continue;
+
+                Interlocked.Increment(ref activeWorkers);
+                try
                 {
                     var p = AestheticMappingLayer.Instance.CurrentParameters;
-                    await RoadNetworkGenerator.GenerateModelAsync(area, 10, p).ConfigureAwait(false);
-                }).ConfigureAwait(false);
+                    var model = await RoadNetworkGenerator.GenerateModelAsync(area, 10, p).ConfigureAwait(false);
+                    MessageBus.Instance.Publish(new CityGenerationCompletedEventData(model.Id, area));
+                }
+                finally
+                {
+                    Interlocked.Decrement(ref activeWorkers);
+                }
             }
+        }
+
+        public void Cancel() => cts.Cancel();
+
+        public void Dispose()
+        {
+            Cancel();
+            signal.Dispose();
+            cts.Dispose();
         }
     }
 

--- a/GameEvents.cs
+++ b/GameEvents.cs
@@ -1,4 +1,5 @@
 using System;
+using NetTopologySuite.Geometries;
 
 namespace StrategyGame
 {
@@ -41,4 +42,14 @@ namespace StrategyGame
     /// Summary event containing high level city data for low LOD rendering.
     /// </summary>
     public record CityStatusEventData(string CityName, int Population, double Budget, CityLOD LOD);
+
+    /// <summary>
+    /// Request to generate city data for the given urban area.
+    /// </summary>
+    public record CityGenerationRequestEventData(Polygon Area);
+
+    /// <summary>
+    /// Published when city generation for an area completes.
+    /// </summary>
+    public record CityGenerationCompletedEventData(Guid ModelId, Polygon Area);
 }

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -147,6 +147,7 @@ namespace economy_sim
 
             InitializeComponent();
             LoadGlobalData();
+            MessageBus.Instance.Subscribe<CityGenerationCompletedEventData>(OnCityGenerationCompleted);
             // In your constructor, after InitializeComponent():
             panelMap.TabStop = true;                        // make panel focusable
             panelMap.MouseEnter += (s, e) => panelMap.Focus();
@@ -2563,6 +2564,14 @@ namespace economy_sim
             // Log to console for debugging
             Console.WriteLine($"[Urban Area Status] {statusMessage}");
             Console.WriteLine($"[Cache Stats] In-Memory: {inMemoryCount}, Disk: {diskCount}, Unique: {totalUnique}");
+        }
+
+        private void OnCityGenerationCompleted(CityGenerationCompletedEventData data)
+        {
+            if (IsHandleCreated)
+            {
+                BeginInvoke((Action)(UpdateUrbanAreaStatus));
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- respond to new `CityGenerationRequestEventData` messages
- use a dedicated worker queue in `CityGenerationManager`
- publish `CityGenerationCompletedEventData` when done
- update `MainGame` UI on completion

## Testing
- `dotnet build "economy sim.sln"` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e14c1867c8323adc4c547ad45cbad