### PR TITLE
Add agent-based developer framework and ML road stub

### DIFF
--- a/AgentBasedDevelopment.cs
+++ b/AgentBasedDevelopment.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace StrategyGame
+{
+    /// <summary>
+    /// Extension of DeveloperAgent that allows agents to compete for parcels.
+    /// </summary>
+    public abstract class AgentDeveloper : DeveloperAgent
+    {
+        public string Name { get; }
+        public double Budget { get; set; }
+
+        protected AgentDeveloper(string name, LandUseType type, double startingBudget = 1000)
+            : base(type)
+        {
+            Name = name;
+            Budget = startingBudget;
+        }
+
+        /// <summary>
+        /// Returns the amount this developer is willing to bid for a parcel.
+        /// The bid is capped by the remaining budget.
+        /// </summary>
+        public virtual double Bid(Parcel parcel, EconomicData data)
+        {
+            double score = Evaluate(parcel);
+            return Math.Min(score, Budget);
+        }
+    }
+
+    /// <summary>
+    /// Coordinates parcel allocation among competing developers.
+    /// </summary>
+    public class AgentDevelopmentManager
+    {
+        private readonly List<AgentDeveloper> developers;
+
+        public AgentDevelopmentManager(IEnumerable<AgentDeveloper> devs)
+        {
+            developers = devs.ToList();
+        }
+
+        public void AllocateParcels(IEnumerable<Parcel> parcels, EconomicData data)
+        {
+            foreach (var parcel in parcels)
+            {
+                AgentDeveloper? winner = null;
+                double bestBid = double.MinValue;
+
+                foreach (var dev in developers)
+                {
+                    double bid = dev.Bid(parcel, data);
+                    if (bid > bestBid && dev.Budget >= bid)
+                    {
+                        winner = dev;
+                        bestBid = bid;
+                    }
+                }
+
+                if (winner != null)
+                {
+                    winner.Budget -= bestBid;
+                    parcel.LandUse = winner.LandUse;
+                }
+            }
+        }
+    }
+}

--- a/CityGeneration.cs
+++ b/CityGeneration.cs
@@ -266,6 +266,36 @@ namespace StrategyGame
             }
         }
 
+        public static void RunWithCompetition(CityDataModel model, AgentDevelopmentManager manager, EconomicData data)
+        {
+            if (model.Parcels == null || model.RoadNetwork == null)
+                return;
+
+            var env = new Nts.Envelope();
+            foreach (var seg in model.RoadNetwork)
+            {
+                env.ExpandToInclude(seg.X1, seg.Y1);
+                env.ExpandToInclude(seg.X2, seg.Y2);
+            }
+            if (env.IsNull) return;
+
+            var center = env.Centre;
+            var centerPt = new Nts.Point(center);
+            double maxDist = center.Distance(new Nts.Coordinate(env.MinX, env.MinY));
+            if (maxDist < 1e-6) maxDist = 1.0;
+
+            foreach (var parcel in model.Parcels)
+            {
+                var pCenter = parcel.Shape.Centroid;
+                double dist = pCenter.Distance(centerPt);
+                double landValue = Math.Max(0, 100 * (1 - dist / maxDist));
+                landValue += Rng.Value.NextDouble() * 20 - 10; // noise
+                parcel.LandValue = Math.Clamp(landValue, 0, 100);
+            }
+
+            manager.AllocateParcels(model.Parcels, data);
+        }
+
         private static LandUseType SelectLandUse(Dictionary<LandUseType, double> weights)
         {
             double total = weights.Values.Sum();

--- a/EconomicRoadModel.cs
+++ b/EconomicRoadModel.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace StrategyGame
+{
+    /// <summary>
+    /// Simple container of economic indicators used when generating road networks.
+    /// </summary>
+    public class EconomicData
+    {
+        public double Gdp { get; set; }
+        public double InfrastructureBudget { get; set; }
+    }
+
+    /// <summary>
+    /// Interface for models that estimate road density from economic data.
+    /// </summary>
+    public interface IEconomicRoadModel
+    {
+        double PredictRoadDensity(EconomicData data);
+    }
+
+    /// <summary>
+    /// Basic stub model. Returns a density factor based on GDP.
+    /// Replace with ML.NET or other ML framework in the future.
+    /// </summary>
+    public sealed class SimpleEconomicRoadModel : IEconomicRoadModel
+    {
+        public double PredictRoadDensity(EconomicData data)
+        {
+            if (data == null) return 1.0;
+            // Very rough scaling: more prosperous cities support denser roads.
+            return 1.0 + Math.Clamp(data.Gdp / 1_000_000.0, 0, 2.0);
+        }
+    }
+}

--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -25,6 +25,10 @@ namespace StrategyGame
         private static readonly ConcurrentDictionary<string, CityDataModel> modelCache = new();
         private static readonly ConcurrentDictionary<Guid, CityDataModel> modelCacheById = new();
 
+        // Economic model used to influence road generation.
+        public static IEconomicRoadModel EconomicModel { get; set; } = new SimpleEconomicRoadModel();
+        public static EconomicData EconomicData { get; set; } = new EconomicData();
+
         public static IReadOnlyDictionary<Guid, CityDataModel> ModelCacheById => modelCacheById;
         private static readonly ConcurrentDictionary<string, SemaphoreSlim> _fileLocks = new();
 
@@ -340,9 +344,10 @@ namespace StrategyGame
         private static List<Nts.LineString> GenerateLocalRoads(Nts.Polygon area, List<Nts.LineString> highways, RoadNetworkType roadType)
         {
             const double roadSegmentLength = 0.005;
-            // Make the iteration limit proportional to the area. Ensures small
-            // towns generate quickly while large cities have room to expand.
-            int maxIterations = (int)Math.Max(500, area.Area * 5000000);
+            // Allow the economic model to adjust how dense the local road network becomes.
+            double densityFactor = EconomicModel?.PredictRoadDensity(EconomicData) ?? 1.0;
+            // Make the iteration limit proportional to the area and scaled by the economy.
+            int maxIterations = (int)Math.Max(500, area.Area * 5000000 * densityFactor);
             var gf = Nts.GeometryFactory.Default;
             var random = new Random();
             var roadNetwork = new List<Nts.LineString>(highways);


### PR DESCRIPTION
## Summary
- add `EconomicRoadModel` to experiment with using simple ML driven road density predictions
- extend `RoadNetworkGenerator` to accept an economic model and data
- add `AgentDeveloper` and `AgentDevelopmentManager` classes for parcel bidding
- expose `RunWithCompetition` method in `LandUseSimulator` for agent based growth

## Testing
- `dotnet build "economy sim.sln"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e169ceed083238f28c7d9ea109d52