### PR TITLE
Fix Shapefile reader disposal

### DIFF
--- a/PixelMapGenerator.cs
+++ b/PixelMapGenerator.cs
@@ -374,25 +374,27 @@ namespace StrategyGame
 
             SixLabors.ImageSharp.PixelFormats.Rgba32 borderColor = new SixLabors.ImageSharp.PixelFormats.Rgba32(0, 0, 0, 255); // black
 
-            var reader = new NetTopologySuite.IO.ShapefileDataReader(
-                ShpPath, NetTopologySuite.Geometries.GeometryFactory.Default);
-
-            while (reader.Read())
+            using (var reader = new NetTopologySuite.IO.ShapefileDataReader(
+                ShpPath, NetTopologySuite.Geometries.GeometryFactory.Default))
             {
-                var geometry = reader.Geometry;
-
-                if (geometry is NetTopologySuite.Geometries.MultiPolygon multi)
+                while (reader.Read())
                 {
-                    for (int i = 0; i < multi.NumGeometries; i++)
+                    var geometry = reader.Geometry;
+
+                    if (geometry is NetTopologySuite.Geometries.MultiPolygon multi)
                     {
-                        var poly = (NetTopologySuite.Geometries.Polygon)multi.GetGeometryN(i);
+                        for (int i = 0; i < multi.NumGeometries; i++)
+                        {
+                            var poly = (NetTopologySuite.Geometries.Polygon)multi.GetGeometryN(i);
+                            DrawPolygonOutline(result, poly, widthPx, heightPx, borderColor);
+                        }
+                    }
+                    else if (geometry is NetTopologySuite.Geometries.Polygon poly)
+                    {
                         DrawPolygonOutline(result, poly, widthPx, heightPx, borderColor);
                     }
                 }
-                else if (geometry is NetTopologySuite.Geometries.Polygon poly)
-                {
-                    DrawPolygonOutline(result, poly, widthPx, heightPx, borderColor);
-                }
+            }
             }
 
             return result;

--- a/UrbanAreaManager.cs
+++ b/UrbanAreaManager.cs
@@ -30,21 +30,23 @@ namespace StrategyGame
             if (!File.Exists(shp))
                 return;
 
-            var reader = new ShapefileDataReader(shp, Nts.GeometryFactory.Default);
-            while (reader.Read())
+            using (var reader = new ShapefileDataReader(shp, Nts.GeometryFactory.Default))
             {
-                var geom = reader.Geometry;
-                if (geom is Nts.MultiPolygon mp)
+                while (reader.Read())
                 {
-                    for (int i = 0; i < mp.NumGeometries; i++)
+                    var geom = reader.Geometry;
+                    if (geom is Nts.MultiPolygon mp)
                     {
-                        if (mp.GetGeometryN(i) is Nts.Polygon p)
-                            UrbanPolygons.Add(p);
+                        for (int i = 0; i < mp.NumGeometries; i++)
+                        {
+                            if (mp.GetGeometryN(i) is Nts.Polygon p)
+                                UrbanPolygons.Add(p);
+                        }
                     }
-                }
-                else if (geom is Nts.Polygon p)
-                {
-                    UrbanPolygons.Add(p);
+                    else if (geom is Nts.Polygon p)
+                    {
+                        UrbanPolygons.Add(p);
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- dispose `ShapefileDataReader` in `UrbanAreaManager`
- dispose `ShapefileDataReader` in `PixelMapGenerator`

## Testing
- `dotnet build "economy sim.sln"` *(fails: Could not resolve SDK 'Microsoft.NET.Sdk.WindowsDesktop')*

------
https://chatgpt.com/codex/tasks/task_e_687e2536b99483238bf52055016c2fa4