### PR TITLE
Improve file validation for map data

### DIFF
--- a/CountryMaskGenerator.cs
+++ b/CountryMaskGenerator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using OSGeo.GDAL;
 using OSGeo.OGR;
 
@@ -28,6 +29,11 @@ namespace StrategyGame
                     Ogr.RegisterAll();
                     _gdalRegistered = true;
                 }
+
+            if (!File.Exists(demPath))
+                throw new FileNotFoundException($"DEM file not found: {demPath}");
+            if (!File.Exists(shpPath))
+                throw new FileNotFoundException($"Shapefile not found: {shpPath}");
 
             Dataset dem = Gdal.Open(demPath, Access.GA_ReadOnly);
             if (dem == null)
@@ -98,6 +104,10 @@ namespace StrategyGame
                     _gdalRegistered = true;
                 }
 
+            if (!File.Exists(demPath))
+                throw new FileNotFoundException($"DEM file not found: {demPath}");
+            if (!File.Exists(shpPath))
+                throw new FileNotFoundException($"Shapefile not found: {shpPath}");
             Dataset dem = Gdal.Open(demPath, Access.GA_ReadOnly);
             if (dem == null)
                 throw new ApplicationException($"Failed to open {demPath}");

--- a/NaturalEarth_FullWorldSimGuide.md
+++ b/NaturalEarth_FullWorldSimGuide.md
@@ -131,6 +131,10 @@ Overlay each layer dynamically based on zoom level.
 - No need to parse OSM or large vector maps
 - Easy to LOD filter towns and provinces by relevance
 - Works offline and loads fast
+## Data Setup
+
+Download the Natural Earth shapefiles and DEM GeoTIFFs into `Documents/data/` before running the game. If using Git LFS, run `git lfs pull` to fetch them. The engine expects files like `ne_10m_admin_0_countries.shp` and `NE1_HR_LC.tif` to exist in that folder.
+
 
 ---
 

--- a/PixelMapGenerator.cs
+++ b/PixelMapGenerator.cs
@@ -374,9 +374,10 @@ namespace StrategyGame
 
             SixLabors.ImageSharp.PixelFormats.Rgba32 borderColor = new SixLabors.ImageSharp.PixelFormats.Rgba32(0, 0, 0, 255); // black
 
-            using (var reader = new NetTopologySuite.IO.ShapefileDataReader(
-                ShpPath, NetTopologySuite.Geometries.GeometryFactory.Default))
+            try
             {
+                using var reader = new NetTopologySuite.IO.ShapefileDataReader(
+                    ShpPath, NetTopologySuite.Geometries.GeometryFactory.Default);
                 while (reader.Read())
                 {
                     var geometry = reader.Geometry;
@@ -394,6 +395,14 @@ namespace StrategyGame
                         DrawPolygonOutline(result, poly, widthPx, heightPx, borderColor);
                     }
                 }
+            }
+            catch (NetTopologySuite.IO.ParseException ex)
+            {
+                throw new InvalidDataException("The shapefile may be missing or corrupted.", ex);
+            }
+            catch (EndOfStreamException ex)
+            {
+                throw new InvalidDataException("The shapefile may be missing or corrupted.", ex);
             }
             }
 


### PR DESCRIPTION
## Summary
- verify DEM and shapefile paths in `CountryMaskGenerator`
- report corrupted shapefile in `DrawBordersLarge`
- note the Natural Earth files must exist in `Documents/data/`

## Testing
- `dotnet build "economy sim.sln" -v minimal` *(fails: Could not resolve SDK)*

------
https://chatgpt.com/codex/tasks/task_e_687e2e34282883239c94232c61263a81