### PR TITLE
Handle corrupted city model cache

### DIFF
--- a/RoadNetworkGenerator.cs
+++ b/RoadNetworkGenerator.cs
@@ -150,7 +150,7 @@ namespace StrategyGame
             }
         }
 
-        private static async Task<CityDataModel> LoadModelBinaryAsync(string path)
+        private static async Task<CityDataModel?> LoadModelBinaryAsync(string path)
         {
             var fileLock = GetFileLock(path);
             await fileLock.WaitAsync().ConfigureAwait(false);
@@ -230,6 +230,14 @@ namespace StrategyGame
 
             return model;
             }
+            catch (Exception ex) when (
+                ex is EndOfStreamException ||
+                ex is ArgumentOutOfRangeException ||
+                ex is NetTopologySuite.IO.ParseException)
+            {
+                Console.WriteLine($"[Error] Failed to read city model {path}: {ex.Message}");
+                return null;
+            }
             finally
             {
                 fileLock.Release();
@@ -257,8 +265,11 @@ namespace StrategyGame
                     if (File.Exists(modelPath))
                     {
                         var loaded = await LoadModelBinaryAsync(modelPath);
-                        AddToCache(hash, loaded);
-                        return loaded;
+                        if (loaded != null)
+                        {
+                            AddToCache(hash, loaded);
+                            return loaded;
+                        }
                     }
                 }
                 catch (Exception ex)
@@ -669,12 +680,16 @@ namespace StrategyGame
             try
             {
                 var model = await LoadModelBinaryAsync(modelPath).ConfigureAwait(false);
-                if (model.UrbanArea != null)
+                if (model != null)
                 {
-                    string hash = ComputeHash(model.UrbanArea);
-                    AddToCache(hash, model);
+                    if (model.UrbanArea != null)
+                    {
+                        string hash = ComputeHash(model.UrbanArea);
+                        AddToCache(hash, model);
+                    }
+                    return model;
                 }
-                return model;
+                return null;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary
- return `null` from `LoadModelBinaryAsync` when cached files are corrupted
- check for null in model-loading helpers

## Testing
- `dotnet restore "economy sim.csproj"` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*
- `dotnet build "economy sim.sln" -v minimal` *(fails: Microsoft.NET.Sdk.WindowsDesktop not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e39fd2e98832384eee667f11d31c9