### PR TITLE
Add Message Monitor UI

### DIFF
--- a/GameEvents.cs
+++ b/GameEvents.cs
@@ -52,4 +52,9 @@ namespace StrategyGame
     /// Published when city generation for an area completes.
     /// </summary>
     public record CityGenerationCompletedEventData(Guid ModelId, Polygon Area);
+
+    /// <summary>
+    /// Simple debug event used for testing the message bus and monitor UI.
+    /// </summary>
+    public record CustomDebugEvent(string Message);
 }

--- a/MainGame.Designer.cs
+++ b/MainGame.Designer.cs
@@ -68,6 +68,7 @@
             buttonGenerateTileCache = new Button();
             buttonGenerateCityData = new Button();
             buttonShowPerformance = new Button();
+            buttonOpenMessageMonitor = new Button();
             tabPageDiplomacy = new TabPage();
             labelProposedTrades = new Label();
             listBoxProposedTradeAgreements = new ListBox();
@@ -272,6 +273,7 @@
             tabPageDebug.Controls.Add(buttonGenerateTileCache);
             tabPageDebug.Controls.Add(buttonGenerateCityData);
             tabPageDebug.Controls.Add(buttonShowPerformance);
+            tabPageDebug.Controls.Add(buttonOpenMessageMonitor);
             tabPageDebug.Controls.Add(buttonToggleDebugMode);
             tabPageDebug.Location = new Point(4, 29);
             tabPageDebug.Margin = new Padding(5, 4, 5, 4);
@@ -473,6 +475,16 @@
             buttonShowPerformance.Text = "Performance Stats";
             buttonShowPerformance.UseVisualStyleBackColor = true;
             buttonShowPerformance.Click += ButtonShowPerformance_Click;
+
+            // buttonOpenMessageMonitor
+            buttonOpenMessageMonitor.Location = new Point(692, 662);
+            buttonOpenMessageMonitor.Margin = new Padding(5, 4, 5, 4);
+            buttonOpenMessageMonitor.Name = "buttonOpenMessageMonitor";
+            buttonOpenMessageMonitor.Size = new Size(160, 36);
+            buttonOpenMessageMonitor.TabIndex = 19;
+            buttonOpenMessageMonitor.Text = "Message Monitor";
+            buttonOpenMessageMonitor.UseVisualStyleBackColor = true;
+            buttonOpenMessageMonitor.Click += ButtonOpenMessageMonitor_Click;
 
             // 
             // tabPageDiplomacy
@@ -769,6 +781,7 @@
         private System.Windows.Forms.Button buttonGenerateTileCache;
         private System.Windows.Forms.Button buttonGenerateCityData;
         private System.Windows.Forms.Button buttonShowPerformance;
+        private System.Windows.Forms.Button buttonOpenMessageMonitor;
         private System.Windows.Forms.TabPage tabPageDiplomacy;
         private System.Windows.Forms.Label labelProposedTrades;
         private System.Windows.Forms.ListBox listBoxProposedTradeAgreements;

--- a/MainGame.cs
+++ b/MainGame.cs
@@ -33,6 +33,7 @@ namespace economy_sim
         private FactoryStatsForm factoryStatsForm;
         private ConstructionForm constructionForm;
         private PerformanceStatsForm performanceStatsForm;
+        private MessageMonitorForm messageMonitorForm;
         private List<State> states;
         private PlayerRoleManager playerRoleManager;
         private Random random = new Random(); // Add a Random instance for AI and other uses
@@ -219,6 +220,7 @@ namespace economy_sim
             factoryStatsForm = new FactoryStatsForm();
             constructionForm = new ConstructionForm();
             performanceStatsForm = new PerformanceStatsForm();
+            messageMonitorForm = new MessageMonitorForm();
             tabControlMain.SelectedIndexChanged += TabControlMain_SelectedIndexChanged;
 
             this.listBoxCityStats.DrawMode = DrawMode.OwnerDrawFixed;
@@ -237,6 +239,9 @@ namespace economy_sim
 
             this.buttonShowPerformance.Location = new SD.Point(this.buttonShowConstruction.Right + 10, buttonsTargetY);
             this.buttonShowPerformance.Click += ButtonShowPerformance_Click;
+
+            this.buttonOpenMessageMonitor.Location = new SD.Point(this.buttonShowPerformance.Right + 10, buttonsTargetY);
+            this.buttonOpenMessageMonitor.Click += ButtonOpenMessageMonitor_Click;
 
             Console.WriteLine($"[Startup] TOTAL startup time: {totalSw.Elapsed.TotalSeconds:F2} seconds");
             this.Shown += (s, e) =>
@@ -1368,6 +1373,12 @@ namespace economy_sim
         {
             performanceStatsForm.Show();
             performanceStatsForm.BringToFront();
+        }
+
+        private void ButtonOpenMessageMonitor_Click(object sender, EventArgs e)
+        {
+            messageMonitorForm.Show();
+            messageMonitorForm.BringToFront();
         }
 
         private void UpdateOrderLists()

--- a/MessageMonitorForm.Designer.cs
+++ b/MessageMonitorForm.Designer.cs
@@ -1,0 +1,49 @@
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace economy_sim
+{
+    public partial class MessageMonitorForm : Form
+    {
+        private ListBox listBoxEvents;
+        private TextBox textBoxMessage;
+        private Button buttonPublish;
+
+        private void InitializeComponent()
+        {
+            listBoxEvents = new ListBox();
+            textBoxMessage = new TextBox();
+            buttonPublish = new Button();
+            SuspendLayout();
+
+            // listBoxEvents
+            listBoxEvents.Dock = DockStyle.Top;
+            listBoxEvents.Height = 180;
+            listBoxEvents.FormattingEnabled = true;
+
+            // textBoxMessage
+            textBoxMessage.Anchor = AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right;
+            textBoxMessage.Location = new Point(10, 190);
+            textBoxMessage.Size = new Size(260, 23);
+
+            // buttonPublish
+            buttonPublish.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+            buttonPublish.Location = new Point(280, 188);
+            buttonPublish.Size = new Size(80, 27);
+            buttonPublish.Text = "Publish";
+            buttonPublish.Click += ButtonPublish_Click;
+
+            // MessageMonitorForm
+            AutoScaleDimensions = new SizeF(7F, 15F);
+            AutoScaleMode = AutoScaleMode.Font;
+            ClientSize = new Size(370, 230);
+            Controls.Add(listBoxEvents);
+            Controls.Add(textBoxMessage);
+            Controls.Add(buttonPublish);
+            Name = "MessageMonitorForm";
+            Text = "Message Monitor";
+            ResumeLayout(false);
+            PerformLayout();
+        }
+    }
+}

--- a/MessageMonitorForm.cs
+++ b/MessageMonitorForm.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Windows.Forms;
+using StrategyGame;
+
+namespace economy_sim
+{
+    public partial class MessageMonitorForm : Form
+    {
+        public MessageMonitorForm()
+        {
+            InitializeComponent();
+
+            MessageBus.Instance.Subscribe<ConstructionCompletedEvent>(HandleEvent);
+            MessageBus.Instance.Subscribe<TradeRecordedEvent>(HandleEvent);
+            MessageBus.Instance.Subscribe<EconomyUpdatedEventData>(HandleEvent);
+            MessageBus.Instance.Subscribe<PopulationUpdatedEventData>(HandleEvent);
+            MessageBus.Instance.Subscribe<DistrictDestroyedEventData>(HandleEvent);
+            MessageBus.Instance.Subscribe<MajorInfrastructureBuiltEventData>(HandleEvent);
+            MessageBus.Instance.Subscribe<CityLODChangedEventData>(HandleEvent);
+            MessageBus.Instance.Subscribe<CityStatusEventData>(HandleEvent);
+            MessageBus.Instance.Subscribe<CityGenerationRequestEventData>(HandleEvent);
+            MessageBus.Instance.Subscribe<CityGenerationCompletedEventData>(HandleEvent);
+            MessageBus.Instance.Subscribe<CustomDebugEvent>(HandleEvent);
+        }
+
+        private void HandleEvent<T>(T evt)
+        {
+            BeginInvoke(() =>
+            {
+                listBoxEvents.Items.Insert(0, evt?.ToString());
+                if (listBoxEvents.Items.Count > 100)
+                    listBoxEvents.Items.RemoveAt(listBoxEvents.Items.Count - 1);
+            });
+        }
+
+        private void ButtonPublish_Click(object? sender, EventArgs e)
+        {
+            var text = textBoxMessage.Text;
+            if (!string.IsNullOrWhiteSpace(text))
+            {
+                MessageBus.Instance.Publish(new CustomDebugEvent(text));
+                textBoxMessage.Clear();
+            }
+        }
+
+        protected override void OnFormClosing(FormClosingEventArgs e)
+        {
+            e.Cancel = true;
+            Hide();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `MessageMonitorForm` to inspect events from `MessageBus`
- hook the form to a new button in `MainGame`
- include a simple debug event type for testing

## Testing
- `dotnet build "economy sim.sln"` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f5f10fd2c8323b3f4297758304991