### PR TITLE
Fix MessageMonitorForm BeginInvoke

### DIFF
--- a/MessageMonitorForm.cs
+++ b/MessageMonitorForm.cs
@@ -25,6 +25,12 @@ namespace economy_sim
 
         private void HandleEvent<T>(T evt)
         {
+            if (!IsHandleCreated)
+            {
+                DebugLogger.Log($"MessageMonitorForm not yet created. Dropping event: {evt}");
+                return;
+            }
+
             BeginInvoke(() =>
             {
                 listBoxEvents.Items.Insert(0, evt?.ToString());


### PR DESCRIPTION
## Summary
- avoid invoking on a handle that hasn't been created
- log when events are dropped

## Testing
- `dotnet restore "economy sim.sln"` *(fails: Unable to find project to restore)*
- `dotnet build "economy sim.sln"` *(fails: SDK 'Microsoft.NET.Sdk.WindowsDesktop' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_687f641a299c8323a8773e6098b359db