### PR TITLE
Add economy update event

### DIFF
--- a/Economy.cs
+++ b/Economy.cs
@@ -82,6 +82,9 @@ namespace StrategyGame
             decimal currentGdp = totalAssessablePopIncome + totalCorporateProfits; // Highly simplified GDP
             fs.UpdateFinancialIndicators(currentGdp);
 
+            MessageBus.Instance.Publish(
+                new EconomyUpdatedEventData(country.Name, country.Budget, (double)currentGdp));
+
             // The old fund distribution to states is now in Country.DistributeFunds(), which can be called separately if needed.
             // country.DistributeFunds(); // This call can be made here or as part of a different game phase.
 


### PR DESCRIPTION
## Summary
- publish `EconomyUpdatedEventData` in `UpdateCountryEconomy`

## Testing
- `dotnet restore "economy sim.csproj"` *(fails: could not resolve SDK)*
- `dotnet build "economy sim.sln"` *(fails: SDK 'Microsoft.NET.Sdk.WindowsDesktop' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_687f6a2453e483238f4d82f51a968b32