### PR TITLE
Fix MultiPolygon loop for building rendering

### DIFF
--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -107,9 +107,9 @@ namespace StrategyGame
                     }
                     else if (baseGeom is Nts.MultiPolygon mp)
                     {
-                        for (int j = 0; i < mp.NumGeometries; i++)
+                        for (int j = 0; j < mp.NumGeometries; j++)
                         {
-                            if (mp.GetGeometryN(i) is Nts.Polygon pp && !pp.IsEmpty)
+                            if (mp.GetGeometryN(j) is Nts.Polygon pp && !pp.IsEmpty)
                                 toDraw.Add((pp, b.LandUse, b));
                         }
                     }


### PR DESCRIPTION
## Summary
- correct loop counter usage when enumerating multipolygon geometries in `ProceduralCityRenderer`

## Testing
- `dotnet restore -p:EnableWindowsTargeting=true`
- `dotnet build "economy sim.sln" -v minimal -p:EnableWindowsTargeting=true` *(fails: PixelMapGenerator.cs errors)*

------
https://chatgpt.com/codex/tasks/task_e_687f6bdf284c832398a10cc310891c0d