### PR TITLE
Add style-aware color palettes for procedural city rendering

### DIFF
--- a/AestheticMappingLayer.cs
+++ b/AestheticMappingLayer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using SixLabors.ImageSharp.PixelFormats;
 
 namespace StrategyGame
 {
@@ -10,6 +11,26 @@ namespace StrategyGame
     {
         public BuildingStyle BuildingStyle { get; init; } = BuildingStyle.Traditional;
         public RoadNetworkType RoadNetworkType { get; init; } = RoadNetworkType.Organic;
+
+        public Dictionary<BuildingStyle, Dictionary<LandUseType, Rgba32>> BuildingPalettes { get; init; } = CreateDefaultPalettes();
+
+        private static Dictionary<BuildingStyle, Dictionary<LandUseType, Rgba32>> CreateDefaultPalettes() => new()
+        {
+            [BuildingStyle.Traditional] = new Dictionary<LandUseType, Rgba32>
+            {
+                [LandUseType.Commercial] = new Rgba32(200, 50, 50, 180),
+                [LandUseType.Residential] = new Rgba32(50, 50, 200, 180),
+                [LandUseType.Industrial] = new Rgba32(120, 120, 120, 180),
+                [LandUseType.Park] = new Rgba32(60, 160, 60, 180)
+            },
+            [BuildingStyle.Modern] = new Dictionary<LandUseType, Rgba32>
+            {
+                [LandUseType.Commercial] = new Rgba32(220, 80, 80, 180),
+                [LandUseType.Residential] = new Rgba32(80, 80, 220, 180),
+                [LandUseType.Industrial] = new Rgba32(150, 150, 150, 180),
+                [LandUseType.Park] = new Rgba32(80, 180, 80, 180)
+            }
+        };
     }
 
     /// <summary>

--- a/CityModelCache.cs
+++ b/CityModelCache.cs
@@ -11,7 +11,7 @@ namespace StrategyGame
     internal static class CityModelCache
     {
         private static readonly ConcurrentDictionary<TileKey, CachedRoads> _roads = new();
-        private static readonly ConcurrentDictionary<(Guid modelId, int cellSize, double minLon, double minLat, double maxLon, double maxLat), CachedBuildings> _buildings = new();
+        private static readonly ConcurrentDictionary<(Guid modelId, BuildingStyle style, int cellSize, double minLon, double minLat, double maxLon, double maxLat), CachedBuildings> _buildings = new();
 
         public static CachedRoads GetOrAddRoads(Guid modelId, int cellSize, int tileX, int tileY, IEnumerable<LineSegment> rawRoads, GeoBounds bounds)
         {
@@ -57,15 +57,15 @@ namespace StrategyGame
             });
         }
 
-        public static CachedBuildings GetOrAddBuildings(Guid modelId, int cellSize, GeoBounds bounds, IEnumerable<(NetTopologySuite.Geometries.Polygon Poly, LandUseType Use)> buildings)
+        public static CachedBuildings GetOrAddBuildings(Guid modelId, int cellSize, BuildingStyle style, GeoBounds bounds, IEnumerable<(NetTopologySuite.Geometries.Polygon Poly, LandUseType Use)> buildings)
         {
-            var key = (modelId, cellSize, bounds.MinLon, bounds.MinLat, bounds.MaxLon, bounds.MaxLat);
+            var key = (modelId, style, cellSize, bounds.MinLon, bounds.MinLat, bounds.MaxLon, bounds.MaxLat);
             return _buildings.GetOrAdd(key, _ =>
             {
                 var dict = new Dictionary<Rgba32, IPath>();
                 float sx = MultiResolutionMapManager.TileSizePx / (float)(bounds.MaxLon - bounds.MinLon);
                 float sy = MultiResolutionMapManager.TileSizePx / (float)(bounds.MaxLat - bounds.MinLat);
-                foreach (var group in buildings.GroupBy(b => ProceduralCityRenderer.GetBuildingColor(b.Use)))
+                foreach (var group in buildings.GroupBy(b => ProceduralCityRenderer.GetBuildingColor(b.Use, style)))
                 {
                     var pb = new PathBuilder();
                     foreach (var item in group)

--- a/ProceduralCityRenderer.cs
+++ b/ProceduralCityRenderer.cs
@@ -115,7 +115,8 @@ namespace StrategyGame
                     }
                 }
 
-                DrawBuildings(img, modelId.Value, toDraw, tileBounds, cellSize);
+                var style = model.GenerationParameters.BuildingStyle;
+                DrawBuildings(img, modelId.Value, toDraw, tileBounds, cellSize, style);
             }
 
             PerformanceTracker.Record("CityRenderer-RenderTile", sw.Elapsed);
@@ -123,7 +124,7 @@ namespace StrategyGame
         }
 
         // Batched building drawing with caching and dynamic LOD
-        private static void DrawBuildings(Image<Rgba32> img, Guid modelId, List<(Nts.Polygon Poly, LandUseType Use, Building Bld)> buildings, GeoBounds bounds, int cellSize)
+        private static void DrawBuildings(Image<Rgba32> img, Guid modelId, List<(Nts.Polygon Poly, LandUseType Use, Building Bld)> buildings, GeoBounds bounds, int cellSize, BuildingStyle style)
         {
             var sw = Stopwatch.StartNew();
 
@@ -181,7 +182,7 @@ namespace StrategyGame
                 }
             }
 
-            var cached = CityModelCache.GetOrAddBuildings(modelId, cellSize, bounds, reduced);
+            var cached = CityModelCache.GetOrAddBuildings(modelId, cellSize, style, bounds, reduced);
 
             img.Mutate(ctx =>
             {
@@ -326,6 +327,19 @@ namespace StrategyGame
                 (float)((lon - b.MinLon) / (b.MaxLon - b.MinLon) * MultiResolutionMapManager.TileSizePx),
                 (float)((b.MaxLat - lat) / (b.MaxLat - b.MinLat) * MultiResolutionMapManager.TileSizePx));
         private static Nts.Polygon ToPolygon(GeoBounds b) => new Nts.Polygon(new Nts.LinearRing(new[] { new Nts.Coordinate(b.MinLon, b.MinLat), new Nts.Coordinate(b.MaxLon, b.MinLat), new Nts.Coordinate(b.MaxLon, b.MaxLat), new Nts.Coordinate(b.MinLon, b.MaxLat), new Nts.Coordinate(b.MinLon, b.MinLat) }));
-        internal static Rgba32 GetBuildingColor(LandUseType use) => use switch { LandUseType.Commercial => new Rgba32(200, 50, 50, 180), LandUseType.Residential => new Rgba32(50, 50, 200, 180), LandUseType.Industrial => new Rgba32(120, 120, 120, 180), _ => new Rgba32(60, 160, 60, 180) };
+        internal static Rgba32 GetBuildingColor(LandUseType use, BuildingStyle style, int level = 0)
+        {
+            var palettes = AestheticMappingLayer.Instance.CurrentParameters.BuildingPalettes;
+            if (palettes.TryGetValue(style, out var palette) && palette.TryGetValue(use, out var color))
+                return color;
+
+            return use switch
+            {
+                LandUseType.Commercial => new Rgba32(200, 50, 50, 180),
+                LandUseType.Residential => new Rgba32(50, 50, 200, 180),
+                LandUseType.Industrial => new Rgba32(120, 120, 120, 180),
+                _ => new Rgba32(60, 160, 60, 180)
+            };
+        }
     }
 }


### PR DESCRIPTION
## Summary
- support color palettes per `BuildingStyle` in `CityGenerationParameters`
- make `GetBuildingColor` style-aware
- include style parameter when grouping and caching building paths
- tile cache keys now vary by building style so style changes trigger regeneration

## Testing
- `dotnet restore` *(fails: project uses Microsoft.NET.Sdk.WindowsDesktop)*
- `dotnet build "economy sim.sln" -v minimal` *(fails: SDK 'Microsoft.NET.Sdk.WindowsDesktop' not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f6d124bc0832388bdf09c7fa5304e