### PR TITLE
Wire global market updates into economy tick

### DIFF
--- a/Economy.cs
+++ b/Economy.cs
@@ -450,9 +450,10 @@ namespace Economy_sim
                 city.LocalSupply[goodName] = quantity;
         }
 
-        public static void ResolveInterCityTrade(List<City> allCities, double baseTradeCostPerUnit = 0.1)
+        public static void ResolveInterCityTrade(List<City> allCities, List<Country> allCountries, double baseTradeCostPerUnit = 0.1)
         {
             if (allCities == null || allCities.Count < 2) return; // Need at least two cities for trade
+            if (allCountries == null || allCountries.Count == 0) return;
 
             foreach (var goodName in GoodDefinitions.Keys) // Iterate over all defined goods
             {
@@ -524,12 +525,13 @@ namespace Economy_sim
                             // Record the trade in the global market if available
                             if (Economy_sim.GlobalMarket.Instance != null)
                             {
-                                // Use default "Unknown" for country names - the global market will handle this
+                                string exporterCountry = GetCountryNameForCity(exporter, allCountries);
+                                string importerCountry = GetCountryNameForCity(importer, allCountries);
                                 Economy_sim.GlobalMarket.Instance.RecordTrade(
-                                    goodName, 
-                                    "Unknown", // Exporter country - this should be set by the GlobalMarket based on city relationships
-                                    "Unknown", // Importer country - this should be set by the GlobalMarket based on city relationships
-                                    quantityTraded, 
+                                    goodName,
+                                    exporterCountry,
+                                    importerCountry,
+                                    quantityTraded,
                                     quantityTraded * effectiveExportPrice);
                             }
                             

--- a/GlobalMarket.cs
+++ b/GlobalMarket.cs
@@ -27,7 +27,8 @@ namespace Economy_sim // Reverted from EconomySim
         public List<GlobalTradeEvent> RecentTradeEvents { get; private set; } // Major trade events
         public List<DetailedTradeRecord> TradeHistory { get; private set; } // Detailed history of all trades
         public double GlobalTradeValue { get; private set; } // Total value of all trade this turn
-          public static GlobalMarket Instance { get; private set; }
+        public static GlobalMarket Instance { get; private set; }
+        private bool _turnPrepared;
         
         public GlobalMarket()
         {
@@ -45,7 +46,8 @@ namespace Economy_sim // Reverted from EconomySim
             RecentTradeEvents = new List<GlobalTradeEvent>();
             TradeHistory = new List<DetailedTradeRecord>();
             GlobalTradeValue = 0;
-            
+            _turnPrepared = false;
+
             // Initialize with goods from the Market class
             foreach (var goodDef in Market.GoodDefinitions.Values)
             {
@@ -60,14 +62,13 @@ namespace Economy_sim // Reverted from EconomySim
         }
         
         // Method signature changed to reflect that it's part of EconomySim and might not need all these specific StrategyGame types directly if they are wrapped or accessed via a common interface.
-        public void UpdateGlobalMarket(List<Economy_sim.City> allCities, List<Economy_sim.Country> allCountries,
-                                     TradeRouteManager routeManager, EnhancedTradeManager tradeManager)
+        public void PrepareForNewTurn()
         {
-            // Clear previous turn trade volumes and flows
             foreach (var goodName in TradeVolumes.Keys)
             {
                 TradeVolumes[goodName].Clear();
             }
+
             foreach (var country in CountryTradeFlows.Values)
             {
                 foreach (var flow in country.Values)
@@ -76,13 +77,24 @@ namespace Economy_sim // Reverted from EconomySim
                     flow.Imports = 0;
                 }
             }
+
             GlobalTradeValue = 0;
 
-            // Update ageing of recent trade events
             RecentTradeEvents.RemoveAll(e => e.TurnsAgo > 5);
             foreach (var evt in RecentTradeEvents)
             {
                 evt.TurnsAgo++;
+            }
+
+            _turnPrepared = true;
+        }
+
+        public void UpdateGlobalMarket(List<Economy_sim.City> allCities, List<Economy_sim.Country> allCountries,
+                                     TradeRouteManager routeManager, EnhancedTradeManager tradeManager)
+        {
+            if (!_turnPrepared)
+            {
+                PrepareForNewTurn();
             }
 
             // Reset demand and supply
@@ -197,8 +209,7 @@ namespace Economy_sim // Reverted from EconomySim
                     }
                 }
             }
-            // Execute international trade between countries
-            InternationalTrade.ExecuteTradeTurn(allCountries, this, tradeManager);
+            _turnPrepared = false;
         }
           public void RecordTrade(string goodName, string exportingCountry, string importingCountry, 
                                int quantity, double totalValue)

--- a/Views/GameView.axaml
+++ b/Views/GameView.axaml
@@ -555,13 +555,13 @@
 										</StackPanel>
 									</Border>
 
-									<Border Grid.Column="2" Background="#1A1A4A" Padding="12" Margin="5,0,0,0" CornerRadius="3">
-										<StackPanel>
-											<TextBlock Text="Stock Market" Foreground="#ADD8E6" FontWeight="Bold" FontSize="13"/>
-											<TextBlock x:Name="StockMarketIndexText" Text="15,420 pts" Foreground="White" FontSize="18" FontWeight="Bold"/>
-											<TextBlock Text="Today: +1.2%" Foreground="#90EE90" FontSize="11"/>
-										</StackPanel>
-									</Border>
+                                                                        <Border Grid.Column="2" Background="#1A1A4A" Padding="12" Margin="5,0,0,0" CornerRadius="3">
+                                                                                <StackPanel>
+                                                                                        <TextBlock Text="Global Trade" Foreground="#ADD8E6" FontWeight="Bold" FontSize="13"/>
+                                                                                        <TextBlock x:Name="GlobalTradeText" Text="$0" Foreground="White" FontSize="18" FontWeight="Bold"/>
+                                                                                        <TextBlock Text="Total value traded this turn" Foreground="#90EE90" FontSize="11"/>
+                                                                                </StackPanel>
+                                                                        </Border>
 								</Grid>
 
 								<!-- Companies List and Industries -->
@@ -1108,8 +1108,12 @@
 
                         <!-- ECONOMY PANEL -->
                         <StackPanel Name="SideEconomyPanel" IsVisible="False" Spacing="15">
-                            <!-- Content here -->
-                            <TextBlock Text="Economy panel content" Foreground="White"/>
+                            <TextBlock Text="Economy Overview" Foreground="White" FontWeight="Bold" FontSize="16"/>
+                            <StackPanel Orientation="Horizontal" Spacing="8">
+                                <TextBlock Text="Global Trade:" Foreground="#ADD8E6"/>
+                                <TextBlock x:Name="SideGlobalTradeText" Text="$0" Foreground="White" FontWeight="Bold"/>
+                            </StackPanel>
+                            <TextBlock Text="Live indicators update each tick" Foreground="#CCCCCC" FontSize="12"/>
                         </StackPanel>
 
                         <!-- STATS PANEL -->

--- a/Views/GameView.axaml.cs
+++ b/Views/GameView.axaml.cs
@@ -62,6 +62,8 @@ namespace Economy_sim
         private DispatcherTimer? _economyUpdateTimer;
         private bool _economyInitialized = false;
         private bool _usedMapEconomy = false; // track if map based economy built
+        private TradeRouteManager? _tradeRouteManager;
+        private EnhancedTradeManager? _enhancedTradeManager;
 
         public GameView()
         {
@@ -984,6 +986,11 @@ namespace Economy_sim
 
         private void InitializeHUD()
         {
+            if (GlobalMarket.Instance == null)
+            {
+                _ = new GlobalMarket();
+            }
+
             // Initialize real economy state
             if (!_economyInitialized)
             {
@@ -1137,6 +1144,7 @@ namespace Economy_sim
             // Select the largest population country as player
             _playerCountry = _allCountries.OrderByDescending(c => c.Population).FirstOrDefault();
             if (_playerCountry == null) return false;
+            _currentCountry = _playerCountry;
             _playerRoleManager = new PlayerRoleManager();
             _playerRoleManager.AssumeRolePrimeMinister(_playerCountry);
 
@@ -1146,6 +1154,8 @@ namespace Economy_sim
 
             Market.AllCorporations.Clear();
             Market.AllCorporations.AddRange(_allCorporations);
+
+            InitializeTradeSystemsForCurrentWorld();
 
             _economyInitialized = true;
             return true;
@@ -1203,6 +1213,17 @@ namespace Economy_sim
                 _allCorporations.Add(corp);
                 corpCounter++;
             }
+        }
+
+        private void InitializeTradeSystemsForCurrentWorld()
+        {
+            if (_allCountries == null || _allCountries.Count == 0)
+            {
+                return;
+            }
+
+            _tradeRouteManager ??= new TradeRouteManager();
+            _enhancedTradeManager = new EnhancedTradeManager(_allCountries);
         }
         private void InitializeEconomyData()
         {
@@ -1377,6 +1398,8 @@ namespace Economy_sim
 
             _allCountries = new List<Country> { _currentCountry };
 
+            InitializeTradeSystemsForCurrentWorld();
+
             // Set up player as Prime Minister BEFORE the HUD tries to access it
             _playerRoleManager = new PlayerRoleManager();
             _playerRoleManager.AssumeRolePrimeMinister(_currentCountry);
@@ -1395,10 +1418,40 @@ namespace Economy_sim
             {
                 Debug.WriteLine("[Economy Update] Running economy simulation tick...");
 
-                // Run the economy update cycle
-                foreach (var city in _currentCountry.States.SelectMany(s => s.Cities))
+                var activeCountries = (_allCountries != null && _allCountries.Count > 0)
+                    ? _allCountries
+                    : new List<Country> { _currentCountry };
+
+                var playerCities = _currentCountry.States.SelectMany(s => s.Cities).ToList();
+                var allCities = activeCountries.SelectMany(c => c.States).SelectMany(s => s.Cities).ToList();
+
+                _tradeRouteManager ??= new TradeRouteManager();
+                if (_enhancedTradeManager == null)
+                {
+                    _enhancedTradeManager = new EnhancedTradeManager(activeCountries);
+                }
+
+                GlobalMarket.Instance?.PrepareForNewTurn();
+
+                // Run the economy update cycle for city-level data
+                foreach (var city in playerCities)
                 {
                     Economy.UpdateCityEconomy(city);
+                }
+
+                // Resolve inter-city trade before aggregating state/country metrics
+                Economy.ResolveInterCityTrade(allCities, activeCountries);
+
+                _tradeRouteManager?.UpdateAllRoutes();
+
+                if (GlobalMarket.Instance != null)
+                {
+                    GlobalMarket.Instance.UpdateGlobalMarket(allCities, activeCountries, _tradeRouteManager, _enhancedTradeManager);
+
+                    if (_enhancedTradeManager != null)
+                    {
+                        InternationalTrade.ExecuteTradeTurn(activeCountries, GlobalMarket.Instance, _enhancedTradeManager);
+                    }
                 }
 
                 foreach (var state in _currentCountry.States)
@@ -1415,8 +1468,7 @@ namespace Economy_sim
                 var random = new Random();
                 foreach (var corp in _allCorporations)
                 {
-                    var allCities = _currentCountry.States.SelectMany(s => s.Cities).ToList();
-                    corp.UpdateAI(allCities, Market.GoodDefinitions.Values.ToList(), random);
+                    corp.UpdateAI(playerCities, Market.GoodDefinitions.Values.ToList(), random);
                 }
 
                 // Simulate monetary effects
@@ -1504,6 +1556,16 @@ namespace Economy_sim
                     if (this.FindControl<TextBlock>("SideInflationText") is TextBlock sideInflText)
                     {
                         sideInflText.Text = $"{inflationRate:F1}%";
+                    }
+
+                    double globalTradeValue = GlobalMarket.Instance?.GlobalTradeValue ?? 0;
+                    if (this.FindControl<TextBlock>("GlobalTradeText") is TextBlock globalTradeText)
+                    {
+                        globalTradeText.Text = $"${FormatCurrency(globalTradeValue)}";
+                    }
+                    if (this.FindControl<TextBlock>("SideGlobalTradeText") is TextBlock sideGlobalTradeText)
+                    {
+                        sideGlobalTradeText.Text = $"${FormatCurrency(globalTradeValue)}";
                     }
 
                     // Update industries list with real data
@@ -1932,6 +1994,8 @@ namespace Economy_sim
                 unemp.Text = "4.2%";
             if (this.FindControl<TextBlock>("SideInflationText") is TextBlock infl)
                 infl.Text = "2.1%";
+            if (this.FindControl<TextBlock>("SideGlobalTradeText") is TextBlock sideTrade)
+                sideTrade.Text = "$0";
             if (this.FindControl<ListBox>("SideIndustriesList") is ListBox sideIndustries)
             {
                 var industries = new[]
@@ -2250,12 +2314,6 @@ namespace Economy_sim
             if (!_economyInitialized) return;
             var corpList = this.FindControl<ListBox>("CorporationsList");
             var industriesList = this.FindControl<ListBox>("IndustriesList");
-            var stockIdx = this.FindControl<TextBlock>("StockMarketIndexText");
-            if (stockIdx != null)
-            {
-                var r = new Random();
-                stockIdx.Text = $"{15000 + r.Next(-400, 400):N0} pts";
-            }
             if (corpList != null)
             {
                 corpList.Items.Clear();


### PR DESCRIPTION
## Summary
- instantiate the global market before initializing the economy so the singleton is ready for use
- run inter-city trade resolution, global market refresh, and international trade flows each economy tick while keeping trade stats intact
- show the resulting global trade totals on both the main HUD and side economy panel

## Testing
- dotnet build *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ce9b407c8323a42a22244d0f8c66