### PR TITLE
Align city population needs with market goods

### DIFF
--- a/City.cs
+++ b/City.cs
@@ -40,7 +40,7 @@ namespace Economy_sim
             Stockpile = new Dictionary<string, Good>();
             Happiness = 50; // Out of 100
             PopBudget = Population * 0.05; // Example: $0.05 per person per turn
-            PopClasses = new List<PopClass>();
+            PopClasses = InitializeDefaultPopClasses(Population);
             BuyOrders = new List<BuyOrder>();
             SellOrders = new List<SellOrder>();
             Suburbs = new List<Suburb>(); // Initialize suburbs
@@ -73,49 +73,57 @@ namespace Economy_sim
             }
 
             // Create population classes with names matching job types
+        }
+
+        private List<PopClass> InitializeDefaultPopClasses(int basePopulation)
+        {
             DebugLogger.Log($"[City] Creating population classes for city: {Name}", DebugLogger.LogCategory.Pop);
 
-            var laborers = new PopClass("Laborers", (int)(Population * 0.5), 0.03);
-            laborers.Needs["Food"] = 2.0;
-            laborers.Needs["Housing"] = 1.0;
-            laborers.Needs["Clothing"] = 0.5;
-            PopClasses.Add(laborers);
+            var classes = new List<PopClass>();
+
+            var laborers = new PopClass("Laborers", (int)(basePopulation * 0.5), 0.03);
+            laborers.Needs["Bread"] = 2.0;
+            laborers.Needs["Furniture"] = 1.0;
+            laborers.Needs["Cloth"] = 0.5;
+            classes.Add(laborers);
             DebugLogger.Log($"[City] Created Laborers class - Size: {laborers.Size}, Income: {laborers.IncomePerPerson}", DebugLogger.LogCategory.Pop);
 
-            var craftsmen = new PopClass("Craftsmen", (int)(Population * 0.25), 0.06);
-            craftsmen.Needs["Food"] = 3.0;
-            craftsmen.Needs["Housing"] = 1.5;
-            craftsmen.Needs["Clothing"] = 1.0;
-            craftsmen.Needs["Luxury"] = 0.2;
-            PopClasses.Add(craftsmen);
+            var craftsmen = new PopClass("Craftsmen", (int)(basePopulation * 0.25), 0.06);
+            craftsmen.Needs["Bread"] = 3.0;
+            craftsmen.Needs["Furniture"] = 1.5;
+            craftsmen.Needs["Cloth"] = 1.0;
+            craftsmen.Needs["Luxury Clothes"] = 0.2;
+            classes.Add(craftsmen);
             DebugLogger.Log($"[City] Created Craftsmen class - Size: {craftsmen.Size}, Income: {craftsmen.IncomePerPerson}", DebugLogger.LogCategory.Pop);
 
-            var engineers = new PopClass("Engineers", (int)(Population * 0.15), 0.12);
-            engineers.Needs["Food"] = 4.0;
-            engineers.Needs["Housing"] = 2.0;
-            engineers.Needs["Clothing"] = 1.5;
-            engineers.Needs["Luxury"] = 0.5;
-            engineers.Needs["Education"] = 1.0;
-            PopClasses.Add(engineers);
+            var engineers = new PopClass("Engineers", (int)(basePopulation * 0.15), 0.12);
+            engineers.Needs["Bread"] = 4.0;
+            engineers.Needs["Furniture"] = 2.0;
+            engineers.Needs["Cloth"] = 1.5;
+            engineers.Needs["Luxury Clothes"] = 0.5;
+            engineers.Needs["Books"] = 1.0;
+            classes.Add(engineers);
             DebugLogger.Log($"[City] Created Engineers class - Size: {engineers.Size}, Income: {engineers.IncomePerPerson}", DebugLogger.LogCategory.Pop);
 
-            var managers = new PopClass("Managers", (int)(Population * 0.07), 0.15);
-            managers.Needs["Food"] = 5.0;
-            managers.Needs["Housing"] = 3.0;
-            managers.Needs["Clothing"] = 2.0;
-            managers.Needs["Luxury"] = 1.0;
-            managers.Needs["Education"] = 1.5;
-            PopClasses.Add(managers);
+            var managers = new PopClass("Managers", (int)(basePopulation * 0.07), 0.15);
+            managers.Needs["Bread"] = 5.0;
+            managers.Needs["Furniture"] = 3.0;
+            managers.Needs["Cloth"] = 2.0;
+            managers.Needs["Luxury Clothes"] = 1.0;
+            managers.Needs["Books"] = 1.5;
+            classes.Add(managers);
             DebugLogger.Log($"[City] Created Managers class - Size: {managers.Size}, Income: {managers.IncomePerPerson}", DebugLogger.LogCategory.Pop);
 
-            var clerks = new PopClass("Clerks", (int)(Population * 0.03), 0.08);
-            clerks.Needs["Food"] = 3.5;
-            clerks.Needs["Housing"] = 2.0;
-            clerks.Needs["Clothing"] = 1.2;
-            clerks.Needs["Luxury"] = 0.3;
-            clerks.Needs["Education"] = 0.5;
-            PopClasses.Add(clerks);
+            var clerks = new PopClass("Clerks", (int)(basePopulation * 0.03), 0.08);
+            clerks.Needs["Bread"] = 3.5;
+            clerks.Needs["Furniture"] = 2.0;
+            clerks.Needs["Cloth"] = 1.2;
+            clerks.Needs["Luxury Clothes"] = 0.3;
+            clerks.Needs["Books"] = 0.5;
+            classes.Add(clerks);
             DebugLogger.Log($"[City] Created Clerks class - Size: {clerks.Size}, Income: {clerks.IncomePerPerson}", DebugLogger.LogCategory.Pop);
+
+            return classes;
         }
 
         public void SimulateGrowth()

--- a/Views/GameView.axaml.cs
+++ b/Views/GameView.axaml.cs
@@ -65,6 +65,15 @@ namespace Economy_sim
         private TradeRouteManager? _tradeRouteManager;
         private EnhancedTradeManager? _enhancedTradeManager;
 
+        private static readonly IReadOnlyDictionary<string, string> _needRemapping = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Food"] = "Bread",
+            ["Housing"] = "Furniture",
+            ["Clothing"] = "Cloth",
+            ["Luxury"] = "Luxury Clothes",
+            ["Education"] = "Books"
+        };
+
         public GameView()
         {
             InitializeComponent();
@@ -1128,6 +1137,7 @@ namespace Economy_sim
 
                         // Seed stockpile with core goods proportionally to population
                         SeedCityStockpile(city);
+                        NormalizeCityPopulationNeeds(city);
 
                         state.Cities.Add(city);
                     }
@@ -1177,6 +1187,41 @@ namespace Economy_sim
                     _ => city.Population / 50
                 };
                 city.Stockpile[g] = new Good(g, Market.GoodDefinitions[g].BasePrice, Market.GoodDefinitions[g].Category, qty);
+            }
+        }
+
+        private void NormalizeCityPopulationNeeds(City city)
+        {
+            if (city?.PopClasses == null || !city.PopClasses.Any()) return;
+            if (!Market.GoodDefinitions.Any()) return;
+
+            foreach (var popClass in city.PopClasses)
+            {
+                var needsToReview = popClass.Needs.Keys.ToList();
+                foreach (var needName in needsToReview)
+                {
+                    if (Market.GoodDefinitions.ContainsKey(needName)) continue;
+
+                    if (_needRemapping.TryGetValue(needName, out var mappedNeed) && Market.GoodDefinitions.ContainsKey(mappedNeed))
+                    {
+                        double amount = popClass.Needs[needName];
+                        popClass.Needs.Remove(needName);
+                        if (popClass.Needs.TryGetValue(mappedNeed, out var existing))
+                        {
+                            popClass.Needs[mappedNeed] = existing + amount;
+                        }
+                        else
+                        {
+                            popClass.Needs[mappedNeed] = amount;
+                        }
+                        Debug.WriteLine($"[Economy Init] Remapped need '{needName}' to '{mappedNeed}' for {popClass.Name} in {city.Name}.");
+                    }
+                    else
+                    {
+                        popClass.Needs.Remove(needName);
+                        Debug.WriteLine($"[Economy Init] Removed unsupported need '{needName}' for {popClass.Name} in {city.Name}.");
+                    }
+                }
             }
         }
 
@@ -1266,25 +1311,32 @@ namespace Economy_sim
             losAngeles.TaxRate = 0.02;
             losAngeles.CityExpenses = 5000;
 
+            losAngeles.PopClasses.Clear();
+
             // Add some population classes with needs
             var laborers = new PopClass("Laborers", 1000000, 15.0);
             laborers.Needs["Bread"] = 2.0;   // 2 units per 1000 people
+            laborers.Needs["Furniture"] = 1.0;
             laborers.Needs["Cloth"] = 1.0;   // 1 unit per 1000 people
 
             var craftsmen = new PopClass("Craftsmen", 500000, 25.0);
             craftsmen.Needs["Bread"] = 2.0;
             craftsmen.Needs["Cloth"] = 1.5;
             craftsmen.Needs["Furniture"] = 0.5;
+            craftsmen.Needs["Luxury Clothes"] = 0.2;
 
             var engineers = new PopClass("Engineers", 200000, 50.0);
             engineers.Needs["Bread"] = 2.0;
             engineers.Needs["Cloth"] = 2.0;
             engineers.Needs["Furniture"] = 1.0;
             engineers.Needs["Books"] = 1.0;
+            engineers.Needs["Luxury Clothes"] = 0.5;
 
             losAngeles.PopClasses.Add(laborers);
             losAngeles.PopClasses.Add(craftsmen);
             losAngeles.PopClasses.Add(engineers);
+
+            NormalizeCityPopulationNeeds(losAngeles);
 
             california.Cities.Add(losAngeles);
 
@@ -1295,17 +1347,23 @@ namespace Economy_sim
             sanFrancisco.TaxRate = 0.02;
             sanFrancisco.CityExpenses = 4000;
 
+            sanFrancisco.PopClasses.Clear();
+
             var sfLaborers = new PopClass("Laborers", 300000, 18.0);
             sfLaborers.Needs["Bread"] = 2.0;
             sfLaborers.Needs["Cloth"] = 1.0;
+            sfLaborers.Needs["Furniture"] = 1.0;
 
             var sfCraftsmen = new PopClass("Craftsmen", 200000, 28.0);
             sfCraftsmen.Needs["Bread"] = 2.0;
             sfCraftsmen.Needs["Cloth"] = 1.5;
             sfCraftsmen.Needs["Furniture"] = 0.5;
+            sfCraftsmen.Needs["Luxury Clothes"] = 0.2;
 
             sanFrancisco.PopClasses.Add(sfLaborers);
             sanFrancisco.PopClasses.Add(sfCraftsmen);
+
+            NormalizeCityPopulationNeeds(sanFrancisco);
 
             california.Cities.Add(sanFrancisco);
             _currentCountry.States.Add(california);
@@ -1322,11 +1380,15 @@ namespace Economy_sim
             houston.TaxRate = 0.02;
             houston.CityExpenses = 4500;
 
+            houston.PopClasses.Clear();
+
             var houstonLaborers = new PopClass("Laborers", 800000, 16.0);
             houstonLaborers.Needs["Bread"] = 2.0;
             houstonLaborers.Needs["Cloth"] = 1.0;
+            houstonLaborers.Needs["Furniture"] = 1.0;
 
             houston.PopClasses.Add(houstonLaborers);
+            NormalizeCityPopulationNeeds(houston);
             texas.Cities.Add(houston);
 
             var dallas = new City("Dallas");
@@ -1335,11 +1397,15 @@ namespace Economy_sim
             dallas.TaxRate = 0.02;
             dallas.CityExpenses = 3500;
 
+            dallas.PopClasses.Clear();
+
             var dallasLaborers = new PopClass("Laborers", 500000, 17.0);
             dallasLaborers.Needs["Bread"] = 2.0;
             dallasLaborers.Needs["Cloth"] = 1.0;
+            dallasLaborers.Needs["Furniture"] = 1.0;
 
             dallas.PopClasses.Add(dallasLaborers);
+            NormalizeCityPopulationNeeds(dallas);
             texas.Cities.Add(dallas);
 
             _currentCountry.States.Add(texas);


### PR DESCRIPTION
## Summary
- replace default city population needs with goods that exist in Market.GoodDefinitions
- normalize population class needs during map and fallback initialization and prevent duplicate class seeding
- update fallback sample cities to use the same goods and apply validation after custom population seeding

## Testing
- dotnet build *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3d36b2f088323ae3f63d352e84e9e