### PR TITLE
Add data-bound trade menu and proposal workflow

### DIFF
--- a/ViewModels/TradeDealParameters.cs
+++ b/ViewModels/TradeDealParameters.cs
@@ -1,0 +1,15 @@
+namespace Economy_sim
+{
+    public class TradeDealParameters
+    {
+        public bool IsExport { get; set; }
+        public string FromCountry { get; set; } = string.Empty;
+        public string ToCountry { get; set; } = string.Empty;
+        public string Resource { get; set; } = string.Empty;
+        public double Quantity { get; set; }
+        public double Price { get; set; }
+        public int Duration { get; set; } = 1;
+        public TariffType TariffType { get; set; } = TariffType.None;
+        public double TariffRate { get; set; }
+    }
+}

--- a/ViewModels/TradeMenuViewModel.cs
+++ b/ViewModels/TradeMenuViewModel.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Avalonia.Threading;
+
+namespace Economy_sim
+{
+    public class TradeMenuViewModel : INotifyPropertyChanged
+    {
+        private readonly Func<bool, Task> _createTradeCallback;
+
+        public ObservableCollection<string> Exports { get; } = new();
+        public ObservableCollection<string> Imports { get; } = new();
+        public ObservableCollection<string> RecentTradeEvents { get; } = new();
+        public ObservableCollection<string> Aggregates { get; } = new();
+
+        private string _tradeSummaryText = "No trade data available.";
+        public string TradeSummaryText
+        {
+            get => _tradeSummaryText;
+            private set
+            {
+                if (_tradeSummaryText != value)
+                {
+                    _tradeSummaryText = value;
+                    OnPropertyChanged(nameof(TradeSummaryText));
+                }
+            }
+        }
+
+        public ICommand CreateExportCommand { get; }
+        public ICommand CreateImportCommand { get; }
+
+        public TradeMenuViewModel(Func<bool, Task> createTradeCallback)
+        {
+            _createTradeCallback = createTradeCallback;
+            CreateExportCommand = new AsyncRelayCommand(_ => _createTradeCallback(true));
+            CreateImportCommand = new AsyncRelayCommand(_ => _createTradeCallback(false));
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public void Refresh(GlobalMarket? market, TradeRouteManager? tradeRouteManager, EnhancedTradeManager? enhancedTradeManager, string? focusCountry)
+        {
+            if (!Dispatcher.UIThread.CheckAccess())
+            {
+                Dispatcher.UIThread.Post(() => Refresh(market, tradeRouteManager, enhancedTradeManager, focusCountry));
+                return;
+            }
+
+            UpdateCollection(Exports, BuildTradeFlowStrings(market?.GetTopExports(focusCountry ?? string.Empty, 6)));
+            UpdateCollection(Imports, BuildTradeFlowStrings(market?.GetTopImports(focusCountry ?? string.Empty, 6)));
+            UpdateCollection(RecentTradeEvents, BuildRecentEventStrings(market));
+            UpdateCollection(Aggregates, BuildAggregates(market, tradeRouteManager, enhancedTradeManager, focusCountry));
+
+            TradeSummaryText = BuildSummaryText(market, focusCountry);
+        }
+
+        private static IEnumerable<string> BuildTradeFlowStrings(IEnumerable<KeyValuePair<string, int>>? flows)
+        {
+            if (flows == null)
+                yield break;
+
+            foreach (var flow in flows)
+            {
+                yield return $"{flow.Key}: {flow.Value:N0} units";
+            }
+        }
+
+        private static IEnumerable<string> BuildRecentEventStrings(GlobalMarket? market)
+        {
+            if (market?.RecentTradeEvents == null || market.RecentTradeEvents.Count == 0)
+            {
+                yield break;
+            }
+
+            foreach (var evt in market.RecentTradeEvents.Take(6))
+            {
+                var direction = string.IsNullOrWhiteSpace(evt.ExportingCountry) || string.IsNullOrWhiteSpace(evt.ImportingCountry)
+                    ? "Trade"
+                    : $"{evt.ExportingCountry} → {evt.ImportingCountry}";
+                yield return $"{direction}: {evt.Quantity:N0} {evt.GoodName} ({evt.TotalValue:C0})";
+            }
+        }
+
+        private static IEnumerable<string> BuildAggregates(GlobalMarket? market, TradeRouteManager? tradeRouteManager, EnhancedTradeManager? enhancedTradeManager, string? focusCountry)
+        {
+            var aggregates = new List<string>();
+
+            if (market != null)
+            {
+                aggregates.Add($"Global Trade Value: {market.GlobalTradeValue:C0}");
+            }
+
+            if (tradeRouteManager != null)
+            {
+                var routes = tradeRouteManager.AllTradeRoutes;
+                var totalCapacity = routes.Sum(r => r.Capacity);
+                var totalUsage = routes.Sum(r => r.CurrentUsage);
+                aggregates.Add($"Trade Routes: {routes.Count} active");
+                aggregates.Add($"Route Utilisation: {totalUsage:N0}/{totalCapacity:N0} units");
+            }
+
+            if (enhancedTradeManager != null)
+            {
+                var relevantDeals = enhancedTradeManager.EnhancedTradeAgreements
+                    .Where(a => a.Status == TradeStatus.Active)
+                    .Where(a => string.IsNullOrWhiteSpace(focusCountry) || a.ParticipatingCountries.Contains(focusCountry!))
+                    .ToList();
+
+                aggregates.Add($"Active Agreements: {relevantDeals.Count}");
+            }
+
+            return aggregates;
+        }
+
+        private static string BuildSummaryText(GlobalMarket? market, string? focusCountry)
+        {
+            if (market == null || string.IsNullOrWhiteSpace(focusCountry) || !market.CountryTradeFlows.TryGetValue(focusCountry, out var flows))
+            {
+                return "No trade data available.";
+            }
+
+            var totalExports = flows.Values.Sum(f => f.Exports);
+            var totalImports = flows.Values.Sum(f => f.Imports);
+
+            string balanceText = totalExports >= totalImports
+                ? $"Trade surplus of {totalExports - totalImports:N0} units"
+                : $"Trade deficit of {totalImports - totalExports:N0} units";
+
+            return $"{focusCountry} exports {totalExports:N0} units and imports {totalImports:N0} units ({balanceText}).";
+        }
+
+        private void UpdateCollection(ObservableCollection<string> target, IEnumerable<string> values)
+        {
+            target.Clear();
+            foreach (var value in values)
+            {
+                target.Add(value);
+            }
+        }
+
+        private void OnPropertyChanged(string propertyName) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
+        private sealed class AsyncRelayCommand : ICommand
+        {
+            private readonly Func<object?, Task> _execute;
+            private readonly Predicate<object?>? _canExecute;
+
+            public AsyncRelayCommand(Func<object?, Task> execute, Predicate<object?>? canExecute = null)
+            {
+                _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+                _canExecute = canExecute;
+            }
+
+            public event EventHandler? CanExecuteChanged
+            {
+                add { }
+                remove { }
+            }
+
+            public bool CanExecute(object? parameter) => _canExecute?.Invoke(parameter) ?? true;
+
+            public async void Execute(object? parameter)
+            {
+                await _execute(parameter);
+            }
+        }
+    }
+}

--- a/Views/GameView.axaml
+++ b/Views/GameView.axaml
@@ -272,11 +272,12 @@
 						Height="400"
 						HorizontalAlignment="Center"
 						VerticalAlignment="Center">
-					<Grid Margin="15">
-						<Grid.RowDefinitions>
-							<RowDefinition Height="Auto"/>
-							<RowDefinition Height="*"/>
-						</Grid.RowDefinitions>
+                                        <Grid Margin="15">
+                                                <Grid.RowDefinitions>
+                                                        <RowDefinition Height="Auto"/>
+                                                        <RowDefinition Height="*"/>
+                                                        <RowDefinition Height="Auto"/>
+                                                </Grid.RowDefinitions>
 
 						<!-- Header -->
 						<Grid Grid.Row="0" Margin="0,0,0,15">
@@ -352,40 +353,55 @@
 									Foreground="White"/>
 						</Grid>
 
-						<!-- Content -->
-						<Grid Grid.Row="1">
-							<Grid.ColumnDefinitions>
-								<ColumnDefinition Width="*"/>
-								<ColumnDefinition Width="*"/>
-							</Grid.ColumnDefinitions>
+                                                <!-- Content -->
+                                                <Grid Grid.Row="1">
+                                                        <Grid.ColumnDefinitions>
+                                                                <ColumnDefinition Width="*"/>
+                                                                <ColumnDefinition Width="*"/>
+                                                        </Grid.ColumnDefinitions>
 
-							<!-- Exports -->
-							<StackPanel Grid.Column="0" Margin="0,0,10,0">
-								<TextBlock Text="Exports" Foreground="#90EE90" FontWeight="Bold" FontSize="16"/>
-								<ListBox x:Name="ExportsList"
-										 Background="#1A1A1A"
-										 BorderBrush="#444444"
-										 Height="150"
-										 Margin="0,5,0,10">
-								</ListBox>
-								<Button x:Name="CreateExportButton" Content="Create Export Deal" Width="180"/>
-							</StackPanel>
+                                                        <!-- Exports -->
+                                                        <StackPanel Grid.Column="0" Margin="0,0,10,0">
+                                                                <TextBlock Text="Exports" Foreground="#90EE90" FontWeight="Bold" FontSize="16"/>
+                                                                <ListBox x:Name="ExportsList"
+                                                                                 ItemsSource="{Binding Exports}"
+                                                                                 Background="#1A1A1A"
+                                                                                 BorderBrush="#444444"
+                                                                                 Height="150"
+                                                                                 Margin="0,5,0,10">
+                                                                </ListBox>
+                                                                <Button x:Name="CreateExportButton" Content="Create Export Deal" Width="180" Command="{Binding CreateExportCommand}"/>
+                                                        </StackPanel>
 
-							<!-- Imports -->
-							<StackPanel Grid.Column="1" Margin="10,0,0,0">
-								<TextBlock Text="Imports" Foreground="#FFB6C1" FontWeight="Bold" FontSize="16"/>
-								<ListBox x:Name="ImportsList"
-									 Background="#1A1A1A"
-									 BorderBrush="#444444"
-									 Height="150"
-									 Margin="0,5,0,10">
-								</ListBox>
-								<Button x:Name="CreateImportButton" Content="Create Import Deal" Width="180"/>
-							</StackPanel>
-						</Grid>
-					</Grid>
-				</Border>
-			</Border>
+                                                        <!-- Imports -->
+                                                        <StackPanel Grid.Column="1" Margin="10,0,0,0">
+                                                                <TextBlock Text="Imports" Foreground="#FFB6C1" FontWeight="Bold" FontSize="16"/>
+                                                                <ListBox x:Name="ImportsList"
+                                                                         ItemsSource="{Binding Imports}"
+                                                                         Background="#1A1A1A"
+                                                                         BorderBrush="#444444"
+                                                                         Height="150"
+                                                                         Margin="0,5,0,10">
+                                                                </ListBox>
+                                                                <Button x:Name="CreateImportButton" Content="Create Import Deal" Width="180" Command="{Binding CreateImportCommand}"/>
+                                                        </StackPanel>
+                                                </Grid>
+
+                                                <StackPanel Grid.Row="2" Margin="0,15,0,0" Spacing="8">
+                                                        <TextBlock Text="{Binding TradeSummaryText}" Foreground="#FFFFFF" TextWrapping="Wrap"/>
+                                                        <ItemsControl ItemsSource="{Binding Aggregates}">
+                                                                <ItemsControl.ItemTemplate>
+                                                                        <DataTemplate>
+                                                                                <TextBlock Text="{Binding}" Foreground="#CCCCCC"/>
+                                                                        </DataTemplate>
+                                                                </ItemsControl.ItemTemplate>
+                                                        </ItemsControl>
+                                                        <TextBlock Text="Recent Trade Events" Foreground="#87CEFA" FontWeight="Bold" FontSize="14" Margin="0,10,0,0"/>
+                                                        <ListBox ItemsSource="{Binding RecentTradeEvents}" Background="#1A1A1A" BorderBrush="#444444" Height="120"/>
+                                                </StackPanel>
+                                        </Grid>
+                                </Border>
+                        </Border>
 
 			<!-- Construction Menu Popup -->
 			<Border x:Name="ConstructionMenuOverlay"
@@ -1095,9 +1111,22 @@
                         </StackPanel>
 
                         <!-- TRADE PANEL -->
-                        <StackPanel Name="SideTradePanel" IsVisible="False" Spacing="15">
-                            <!-- Content here -->
-                            <TextBlock Text="Trade panel content" Foreground="White"/>
+                        <StackPanel x:Name="SideTradePanel" IsVisible="False" Spacing="12">
+                            <TextBlock Text="Trade Overview" Foreground="#FFD700" FontWeight="Bold" FontSize="16"/>
+                            <TextBlock Text="{Binding TradeSummaryText}" Foreground="#FFFFFF" TextWrapping="Wrap"/>
+                            <ItemsControl ItemsSource="{Binding Aggregates}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding}" Foreground="#CCCCCC"/>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                            <TextBlock Text="Top Exports" Foreground="#90EE90" FontWeight="Bold"/>
+                            <ListBox x:Name="SideExportsList" ItemsSource="{Binding Exports}" Background="#1A1A1A" BorderBrush="#444444" Height="100"/>
+                            <TextBlock Text="Top Imports" Foreground="#FFB6C1" FontWeight="Bold"/>
+                            <ListBox x:Name="SideImportsList" ItemsSource="{Binding Imports}" Background="#1A1A1A" BorderBrush="#444444" Height="100"/>
+                            <TextBlock Text="Recent Trade Events" Foreground="#87CEFA" FontWeight="Bold"/>
+                            <ListBox x:Name="SideRecentEventsList" ItemsSource="{Binding RecentTradeEvents}" Background="#1A1A1A" BorderBrush="#444444" Height="120"/>
                         </StackPanel>
 
                         <!-- CONSTRUCTION PANEL -->

--- a/Views/GameView.axaml.cs
+++ b/Views/GameView.axaml.cs
@@ -64,6 +64,7 @@ namespace Economy_sim
         private bool _usedMapEconomy = false; // track if map based economy built
         private TradeRouteManager? _tradeRouteManager;
         private EnhancedTradeManager? _enhancedTradeManager;
+        private readonly TradeMenuViewModel _tradeMenuViewModel;
 
         private static readonly IReadOnlyDictionary<string, string> _needRemapping = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
@@ -77,6 +78,16 @@ namespace Economy_sim
         public GameView()
         {
             InitializeComponent();
+
+            _tradeMenuViewModel = new TradeMenuViewModel(HandleCreateTradeAsync);
+            if (TradeMenuOverlay != null)
+            {
+                TradeMenuOverlay.DataContext = _tradeMenuViewModel;
+            }
+            if (SideTradePanel != null)
+            {
+                SideTradePanel.DataContext = _tradeMenuViewModel;
+            }
 
             int baseW = ParseEnvOrDefault("ES_BASE_WIDTH", _baselineWidth);
             int baseH = ParseEnvOrDefault("ES_BASE_HEIGHT", _baselineHeight);
@@ -115,6 +126,8 @@ namespace Economy_sim
 
             // Run basic integration test for political borders (commented out for production)
             // Economy_sim.Testing.PoliticalBorderIntegrationTest.RunBasicTests();
+
+            RefreshTradeViewModel();
         }
 
         private void NormalizeInitialViewOffset(int baseW, int baseH)
@@ -1268,7 +1281,74 @@ namespace Economy_sim
             }
 
             _tradeRouteManager ??= new TradeRouteManager();
-            _enhancedTradeManager = new EnhancedTradeManager(_allCountries);
+            _enhancedTradeManager ??= new EnhancedTradeManager(_allCountries);
+            RefreshTradeViewModel();
+        }
+
+        private void RefreshTradeViewModel()
+        {
+            var focusCountry = _currentCountry?.Name ?? _playerCountry?.Name ?? string.Empty;
+            _tradeMenuViewModel.Refresh(GlobalMarket.Instance, _tradeRouteManager, _enhancedTradeManager, focusCountry);
+        }
+
+        private async Task HandleCreateTradeAsync(bool isExport)
+        {
+            InitializeTradeSystemsForCurrentWorld();
+
+            if (_enhancedTradeManager == null)
+            {
+                _enhancedTradeManager = new EnhancedTradeManager(_allCountries);
+            }
+
+            var countryNames = (_allCountries != null && _allCountries.Count > 0)
+                ? _allCountries.Select(c => c.Name).Where(name => !string.IsNullOrWhiteSpace(name)).Distinct(StringComparer.OrdinalIgnoreCase).ToList()
+                : new List<string>();
+
+            var focusCountry = _currentCountry?.Name ?? _playerCountry?.Name;
+            if (!string.IsNullOrWhiteSpace(focusCountry) && !countryNames.Any(n => string.Equals(n, focusCountry, StringComparison.OrdinalIgnoreCase)))
+            {
+                countryNames.Add(focusCountry!);
+            }
+
+            if (countryNames.Count == 0)
+            {
+                countryNames.Add("Player Nation");
+            }
+
+            var goodsNames = Market.GoodDefinitions.Any()
+                ? Market.GoodDefinitions.Keys.ToList()
+                : new List<string> { "Generic Goods" };
+
+            string? partner = countryNames.FirstOrDefault(n => !string.Equals(n, focusCountry, StringComparison.OrdinalIgnoreCase));
+            string? defaultFrom = isExport ? focusCountry ?? partner : partner ?? focusCountry;
+            string? defaultTo = isExport ? partner ?? focusCountry : focusCountry ?? partner;
+
+            var proposalWindow = new TradeProposalWindow();
+            proposalWindow.Configure(isExport, countryNames, goodsNames, defaultFrom, defaultTo);
+            var result = await proposalWindow.ShowDialog<TradeDealParameters?>(this);
+
+            if (result == null)
+            {
+                return;
+            }
+
+            var agreement = _enhancedTradeManager!.CreateEnhancedTradeAgreement(
+                result.FromCountry,
+                result.ToCountry,
+                result.Resource,
+                result.Quantity,
+                result.Price,
+                result.Duration,
+                result.TariffType,
+                result.TariffRate);
+
+            agreement.Status = TradeStatus.Active;
+            if (!_enhancedTradeManager.AllTradeAgreements.Contains(agreement))
+            {
+                _enhancedTradeManager.AllTradeAgreements.Add(agreement);
+            }
+
+            RefreshTradeViewModel();
         }
         private void InitializeEconomyData()
         {
@@ -1520,6 +1600,8 @@ namespace Economy_sim
                     }
                 }
 
+                RefreshTradeViewModel();
+
                 foreach (var state in _currentCountry.States)
                 {
                     Economy.UpdateStateEconomy(state);
@@ -1628,10 +1710,6 @@ namespace Economy_sim
                     if (this.FindControl<TextBlock>("GlobalTradeText") is TextBlock globalTradeText)
                     {
                         globalTradeText.Text = $"${FormatCurrency(globalTradeValue)}";
-                    }
-                    if (this.FindControl<TextBlock>("SideGlobalTradeText") is TextBlock sideGlobalTradeText)
-                    {
-                        sideGlobalTradeText.Text = $"${FormatCurrency(globalTradeValue)}";
                     }
 
                     // Update industries list with real data
@@ -1901,37 +1979,6 @@ namespace Economy_sim
                 }
             }
 
-            // Initialize Trade menu content
-            if (this.FindControl<ListBox>("ExportsList") is ListBox exportsList)
-            {
-                var exports = new[]
-                {
-                    "💼 Manufactured Goods → UK ($2.5B)",
-                    "🌾 Agricultural Products → Japan ($1.8B)",
-                    "⚙️ Technology → Germany ($3.2B)",
-                    "🛢️ Oil Products → Various ($4.1B)"
-                };
-                foreach (var export in exports)
-                {
-                    exportsList.Items.Add(export);
-                }
-            }
-
-            if (this.FindControl<ListBox>("ImportsList") is ListBox importsList)
-            {
-                var imports = new[]
-                {
-                    "📱 Electronics ← China ($2.8B)",
-                    "☕ Coffee ← Brazil ($0.9B)",
-                    "💎 Rare Metals ← Africa ($1.5B)",
-                    "🏭 Machinery ← Germany ($2.2B)"
-                };
-                foreach (var import in imports)
-                {
-                    importsList.Items.Add(import);
-                }
-            }
-
             // Initialize Construction menu content
             if (this.FindControl<ListBox>("ActiveProjectsList") is ListBox projectsList)
             {
@@ -2013,32 +2060,6 @@ namespace Economy_sim
                     sideDip.Items.Add(relation);
             }
 
-            // Trade
-            if (this.FindControl<ListBox>("SideExportsList") is ListBox sideExports)
-            {
-                var exports = new[]
-                {
-                    "💼 Manufactured Goods → UK ($2.5B)",
-                    "🌾 Agricultural Products → Japan ($1.8B)",
-                    "⚙️ Technology → Germany ($3.2B)",
-                    "🛢️ Oil Products → Various ($4.1B)"
-                };
-                foreach (var export in exports)
-                    sideExports.Items.Add(export);
-            }
-            if (this.FindControl<ListBox>("SideImportsList") is ListBox sideImports)
-            {
-                var imports = new[]
-                {
-                    "📱 Electronics ← China ($2.8B)",
-                    "☕ Coffee ← Brazil ($0.9B)",
-                    "💎 Rare Metals ← Africa ($1.5B)",
-                    "🏭 Machinery ← Germany ($2.2B)"
-                };
-                foreach (var import in imports)
-                    sideImports.Items.Add(import);
-            }
-
             // Construction
             if (this.FindControl<ListBox>("SideActiveProjectsList") is ListBox sideProjects)
             {
@@ -2060,8 +2081,6 @@ namespace Economy_sim
                 unemp.Text = "4.2%";
             if (this.FindControl<TextBlock>("SideInflationText") is TextBlock infl)
                 infl.Text = "2.1%";
-            if (this.FindControl<TextBlock>("SideGlobalTradeText") is TextBlock sideTrade)
-                sideTrade.Text = "$0";
             if (this.FindControl<ListBox>("SideIndustriesList") is ListBox sideIndustries)
             {
                 var industries = new[]

--- a/Views/TradeProposalWindow.axaml
+++ b/Views/TradeProposalWindow.axaml
@@ -1,7 +1,64 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="Economy_sim.TradeProposalWindow"
-        Width="400" Height="300"
-        Title="TradeProposal">
-    <TextBlock Text="TradeProposal content" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+        Width="480"
+        Height="520"
+        Title="Trade Proposal"
+        Background="#2D2D30">
+    <Border Background="#2D2D30" Padding="16">
+        <Grid RowDefinitions="Auto,* ,Auto" RowSpacing="12">
+            <StackPanel Orientation="Vertical" Spacing="4">
+                <TextBlock Text="Configure Trade Agreement"
+                           FontSize="20"
+                           FontWeight="Bold"
+                           Foreground="#FFD700"/>
+                <TextBlock x:Name="DirectionText"
+                           Text=""
+                           Foreground="#CCCCCC"
+                           FontSize="13"/>
+            </StackPanel>
+
+            <Grid Grid.Row="1" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" RowSpacing="10">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+
+                <TextBlock Text="From Country" Foreground="#FFFFFF" Grid.Row="0" Grid.Column="0" Margin="0,0,8,0"/>
+                <ComboBox x:Name="FromCountryComboBox" Grid.Row="0" Grid.Column="1" MinWidth="180"/>
+
+                <TextBlock Text="To Country" Foreground="#FFFFFF" Grid.Row="1" Grid.Column="0" Margin="0,0,8,0"/>
+                <ComboBox x:Name="ToCountryComboBox" Grid.Row="1" Grid.Column="1" MinWidth="180"/>
+
+                <TextBlock Text="Resource" Foreground="#FFFFFF" Grid.Row="2" Grid.Column="0" Margin="0,0,8,0"/>
+                <ComboBox x:Name="ResourceComboBox" Grid.Row="2" Grid.Column="1" MinWidth="180"/>
+
+                <TextBlock Text="Quantity" Foreground="#FFFFFF" Grid.Row="3" Grid.Column="0" Margin="0,0,8,0"/>
+                <TextBox x:Name="QuantityTextBox" Grid.Row="3" Grid.Column="1" MinWidth="120"/>
+
+                <TextBlock Text="Price per Unit" Foreground="#FFFFFF" Grid.Row="4" Grid.Column="0" Margin="0,0,8,0"/>
+                <TextBox x:Name="PriceTextBox" Grid.Row="4" Grid.Column="1" MinWidth="120"/>
+
+                <TextBlock Text="Duration (turns)" Foreground="#FFFFFF" Grid.Row="5" Grid.Column="0" Margin="0,0,8,0"/>
+                <TextBox x:Name="DurationTextBox" Grid.Row="5" Grid.Column="1" MinWidth="120"/>
+
+                <TextBlock Text="Tariff Type" Foreground="#FFFFFF" Grid.Row="6" Grid.Column="0" Margin="0,0,8,0"/>
+                <ComboBox x:Name="TariffTypeComboBox" Grid.Row="6" Grid.Column="1" MinWidth="180"/>
+
+                <TextBlock Text="Tariff Rate" Foreground="#FFFFFF" Grid.Row="7" Grid.Column="0" Margin="0,0,8,0"/>
+                <TextBox x:Name="TariffRateTextBox" Grid.Row="7" Grid.Column="1" MinWidth="120"/>
+            </Grid>
+
+            <StackPanel Grid.Row="2" Orientation="Vertical" Spacing="8">
+                <TextBlock x:Name="ValidationText"
+                           Foreground="#FF6B6B"
+                           Text=""
+                           FontSize="12"/>
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Spacing="10">
+                    <Button x:Name="CancelButton" Content="Cancel" Width="90"/>
+                    <Button x:Name="SubmitButton" Content="Create Deal" Width="120" Background="#3A8D3A" Foreground="White"/>
+                </StackPanel>
+            </StackPanel>
+        </Grid>
+    </Border>
 </Window>

--- a/Views/TradeProposalWindow.axaml.cs
+++ b/Views/TradeProposalWindow.axaml.cs
@@ -1,12 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Avalonia.Controls;
 
 namespace Economy_sim
 {
     public partial class TradeProposalWindow : Window
     {
+        private bool _isExport;
+
         public TradeProposalWindow()
         {
             InitializeComponent();
+            ConfigureControls();
+        }
+
+        public void Configure(bool isExport, IEnumerable<string> countries, IEnumerable<string> goods, string? defaultFrom, string? defaultTo)
+        {
+            _isExport = isExport;
+            DirectionText.Text = isExport
+                ? "Create an export agreement from your country to a partner."
+                : "Create an import agreement to bring goods into your country.";
+
+            var countryList = countries.ToList();
+            FromCountryComboBox.Items = countryList;
+            ToCountryComboBox.Items = countryList;
+            var goodsList = goods.ToList();
+            ResourceComboBox.Items = goodsList;
+
+            if (!string.IsNullOrWhiteSpace(defaultFrom) && countryList.Contains(defaultFrom))
+            {
+                FromCountryComboBox.SelectedItem = defaultFrom;
+            }
+
+            if (!string.IsNullOrWhiteSpace(defaultTo) && countryList.Contains(defaultTo))
+            {
+                ToCountryComboBox.SelectedItem = defaultTo;
+            }
+
+            if (goodsList.Count > 0)
+            {
+                ResourceComboBox.SelectedIndex = 0;
+            }
+        }
+
+        private void ConfigureControls()
+        {
+            if (TariffTypeComboBox != null)
+            {
+                TariffTypeComboBox.Items = Enum.GetValues(typeof(TariffType)).Cast<TariffType>().ToList();
+                TariffTypeComboBox.SelectedItem = TariffType.None;
+            }
+
+            if (DurationTextBox != null)
+            {
+                DurationTextBox.Text = "12";
+            }
+
+            if (TariffRateTextBox != null)
+            {
+                TariffRateTextBox.Text = "0";
+            }
+
+            if (SubmitButton != null)
+            {
+                SubmitButton.Click += (_, __) => Submit();
+            }
+
+            if (CancelButton != null)
+            {
+                CancelButton.Click += (_, __) => Close(null);
+            }
+        }
+
+        private void Submit()
+        {
+            if (!double.TryParse(QuantityTextBox.Text, out var quantity) || quantity <= 0)
+            {
+                ValidationText.Text = "Enter a valid quantity.";
+                return;
+            }
+
+            if (!double.TryParse(PriceTextBox.Text, out var price) || price <= 0)
+            {
+                ValidationText.Text = "Enter a valid price.";
+                return;
+            }
+
+            if (!int.TryParse(DurationTextBox.Text, out var duration) || duration <= 0)
+            {
+                ValidationText.Text = "Enter a valid duration.";
+                return;
+            }
+
+            if (!double.TryParse(TariffRateTextBox.Text, out var tariffRate) || tariffRate < 0)
+            {
+                ValidationText.Text = "Enter a valid tariff rate.";
+                return;
+            }
+
+            var fromCountry = FromCountryComboBox.SelectedItem as string ?? FromCountryComboBox.Text;
+            var toCountry = ToCountryComboBox.SelectedItem as string ?? ToCountryComboBox.Text;
+            var resource = ResourceComboBox.SelectedItem as string ?? ResourceComboBox.Text;
+
+            if (string.IsNullOrWhiteSpace(fromCountry) || string.IsNullOrWhiteSpace(toCountry) || string.IsNullOrWhiteSpace(resource))
+            {
+                ValidationText.Text = "Please provide from/to countries and a resource.";
+                return;
+            }
+
+            var parameters = new TradeDealParameters
+            {
+                IsExport = _isExport,
+                FromCountry = fromCountry,
+                ToCountry = toCountry,
+                Resource = resource,
+                Quantity = quantity,
+                Price = price,
+                Duration = duration,
+                TariffRate = tariffRate,
+                TariffType = TariffTypeComboBox.SelectedItem is TariffType tariff ? tariff : TariffType.None
+            };
+
+            Close(parameters);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a TradeMenuViewModel that exposes export/import/event collections and wraps command hooks for creating deals
- data-bind the trade popup and side panel to the new view model instead of seeding list boxes manually
- expand TradeProposalWindow to collect agreement parameters and register enhanced agreements, refreshing trade data after each tick

## Testing
- dotnet build *(fails: `dotnet` command is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e47e40820c8323bed4169a30c8527e