### PR TITLE
Wire up construction management UI

### DIFF
--- a/City.cs
+++ b/City.cs
@@ -182,24 +182,77 @@ namespace Economy_sim
 
         public void StartConstructionProject(ConstructionProject project)
         {
-            ActiveProjects.Add(project);
+            if (project == null)
+            {
+                return;
+            }
+
+            if (!ActiveProjects.Contains(project))
+            {
+                project.OwningCity = this;
+                ActiveProjects.Add(project);
+            }
         }
 
         public void ProgressConstruction()
         {
+            if (ActiveProjects.Count == 0)
+            {
+                return;
+            }
+
+            var companiesToUpdate = new HashSet<ConstructionCompany>();
+
             foreach (var project in ActiveProjects.ToList())
             {
-                decimal dailyCost = 10 / project.Duration; //change this to your desired daily cost calculation
-                if ((decimal)Budget >= dailyCost && project.ProgressProject(1, (decimal)Budget))
+                if (project.AssignedCompany != null)
+                {
+                    companiesToUpdate.Add(project.AssignedCompany);
+                    continue;
+                }
+
+                var dailyCost = CalculateDailyCost(project);
+                if ((decimal)Budget < dailyCost || project.BudgetRemaining < dailyCost)
+                {
+                    continue;
+                }
+
+                if (project.ProgressProject(1, dailyCost))
                 {
                     Budget -= (double)dailyCost;
-                    if (project.IsComplete())
-                    {
-                        ApplyProjectEffects(project);
-                        ActiveProjects.Remove(project);
-                    }
+                }
+
+                if (project.IsComplete())
+                {
+                    ApplyProjectEffects(project);
+                    ActiveProjects.Remove(project);
                 }
             }
+
+            foreach (var company in companiesToUpdate)
+            {
+                company.WorkOnProjects(this);
+            }
+
+            foreach (var project in ActiveProjects.ToList())
+            {
+                if (project.AssignedCompany != null && project.IsComplete())
+                {
+                    ApplyProjectEffects(project);
+                    ActiveProjects.Remove(project);
+                }
+            }
+        }
+
+        private static decimal CalculateDailyCost(ConstructionProject project)
+        {
+            if (project.Duration <= 0)
+            {
+                return Math.Max(project.Budget, ConstructionProject.MinimumDailyBudget);
+            }
+
+            var dailyCost = project.Budget / project.Duration;
+            return dailyCost < ConstructionProject.MinimumDailyBudget ? ConstructionProject.MinimumDailyBudget : dailyCost;
         }
 
         private void ApplyProjectEffects(ConstructionProject project)
@@ -211,6 +264,21 @@ namespace Economy_sim
                     break;
                 case ProjectType.Railway:
                     IncreaseRailwayKilometers(project.Output);
+                    break;
+                case ProjectType.Factory:
+                    BoostIndustrialOutput(project.Output);
+                    break;
+                case ProjectType.Road:
+                    ImproveTransportation(project.Output);
+                    break;
+                case ProjectType.Bridge:
+                    ImproveTransportation(project.Output * 1.5);
+                    break;
+                case ProjectType.Port:
+                    EnhanceTradeCapacity(project.Output);
+                    break;
+                case ProjectType.Airport:
+                    EnhanceTradeCapacity(project.Output * 1.2);
                     break;
             }
         }
@@ -229,6 +297,21 @@ namespace Economy_sim
             {
                 suburb.RailwayKilometers += value / Suburbs.Count; // Distribute railway kilometers
             }
+        }
+
+        private void BoostIndustrialOutput(double factor)
+        {
+            Budget += factor * 5000;
+        }
+
+        private void ImproveTransportation(double factor)
+        {
+            CityExpenses = Math.Max(0, CityExpenses - factor * 10);
+        }
+
+        private void EnhanceTradeCapacity(double factor)
+        {
+            Budget += factor * 3500;
         }
     }
 }

--- a/ConstructionCompany.cs
+++ b/ConstructionCompany.cs
@@ -42,6 +42,11 @@ namespace Economy_sim
         {
             foreach (var project in Projects.ToList())
             {
+                if (project.OwningCity != null && project.OwningCity != city)
+                {
+                    continue;
+                }
+
                 if (project.IsComplete())
                 {
                     Projects.Remove(project);

--- a/ConstructionProject.cs
+++ b/ConstructionProject.cs
@@ -6,7 +6,12 @@ namespace Economy_sim
     public enum ProjectType
     {
         Housing,
-        Railway
+        Railway,
+        Factory,
+        Road,
+        Bridge,
+        Port,
+        Airport
     }
 
     public class ConstructionProject
@@ -28,6 +33,8 @@ namespace Economy_sim
         public int ResourcePerDay { get; private set; }
 
         public ConstructionCompany AssignedCompany { get; set; }
+
+        public City? OwningCity { get; internal set; }
 
         public const decimal MinimumDailyBudget = 100m;
 

--- a/ViewModels/ConstructionMenuViewModel.cs
+++ b/ViewModels/ConstructionMenuViewModel.cs
@@ -1,0 +1,454 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Windows.Input;
+using Avalonia.Threading;
+
+namespace Economy_sim
+{
+    public class ConstructionMenuViewModel : INotifyPropertyChanged
+    {
+        private readonly ObservableCollection<ConstructionProjectDisplay> activeProjects = new();
+        private readonly Dictionary<ConstructionProject, ConstructionProjectDisplay> displayLookup = new();
+        private readonly ObservableCollection<ConstructionCompanyOption> companyOptions = new();
+        private readonly RelayCommand buildFactoryCommand;
+        private readonly RelayCommand buildRoadCommand;
+        private readonly RelayCommand buildBridgeCommand;
+        private readonly RelayCommand buildPortCommand;
+        private readonly RelayCommand buildAirportCommand;
+        private readonly Dictionary<ProjectType, ConstructionProjectConfig> projectConfigs;
+
+        private City? city;
+        private ConstructionCompanyOption? selectedCompanyOption;
+        private ConstructionProjectDisplay? selectedProject;
+        private double cityBudget;
+        private decimal totalAllocatedBudget;
+        private decimal estimatedDailyCost;
+        private ConstructionProject? pendingFocusProject;
+
+        public ConstructionMenuViewModel()
+        {
+            projectConfigs = CreateDefaultConfigs();
+
+            buildFactoryCommand = new RelayCommand(_ => QueueProject(ProjectType.Factory), _ => CanQueueProject(ProjectType.Factory));
+            buildRoadCommand = new RelayCommand(_ => QueueProject(ProjectType.Road), _ => CanQueueProject(ProjectType.Road));
+            buildBridgeCommand = new RelayCommand(_ => QueueProject(ProjectType.Bridge), _ => CanQueueProject(ProjectType.Bridge));
+            buildPortCommand = new RelayCommand(_ => QueueProject(ProjectType.Port), _ => CanQueueProject(ProjectType.Port));
+            buildAirportCommand = new RelayCommand(_ => QueueProject(ProjectType.Airport), _ => CanQueueProject(ProjectType.Airport));
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public ObservableCollection<ConstructionProjectDisplay> ActiveProjects => activeProjects;
+
+        public ObservableCollection<ConstructionCompanyOption> CompanyOptions => companyOptions;
+
+        public ICommand BuildFactoryCommand => buildFactoryCommand;
+
+        public ICommand BuildRoadCommand => buildRoadCommand;
+
+        public ICommand BuildBridgeCommand => buildBridgeCommand;
+
+        public ICommand BuildPortCommand => buildPortCommand;
+
+        public ICommand BuildAirportCommand => buildAirportCommand;
+
+        public ConstructionCompanyOption? SelectedCompanyOption
+        {
+            get => selectedCompanyOption;
+            set
+            {
+                if (selectedCompanyOption != value)
+                {
+                    selectedCompanyOption = value;
+                    OnPropertyChanged(nameof(SelectedCompanyOption));
+                    UpdateCommandStates();
+                }
+            }
+        }
+
+        public ConstructionProjectDisplay? SelectedProject
+        {
+            get => selectedProject;
+            set
+            {
+                if (selectedProject != value)
+                {
+                    selectedProject = value;
+                    OnPropertyChanged(nameof(SelectedProject));
+                    OnPropertyChanged(nameof(SelectedProjectSummary));
+                }
+            }
+        }
+
+        public double CityBudget
+        {
+            get => cityBudget;
+            private set
+            {
+                if (Math.Abs(cityBudget - value) > 0.5)
+                {
+                    cityBudget = value;
+                    OnPropertyChanged(nameof(CityBudget));
+                    OnPropertyChanged(nameof(CityBudgetDisplay));
+                }
+            }
+        }
+
+        public string CityBudgetDisplay => $"City Budget: {CityBudget:C0}";
+
+        public decimal TotalAllocatedBudget
+        {
+            get => totalAllocatedBudget;
+            private set
+            {
+                if (totalAllocatedBudget != value)
+                {
+                    totalAllocatedBudget = value;
+                    OnPropertyChanged(nameof(TotalAllocatedBudget));
+                    OnPropertyChanged(nameof(TotalAllocatedBudgetDisplay));
+                }
+            }
+        }
+
+        public string TotalAllocatedBudgetDisplay => $"Allocated to Projects: {TotalAllocatedBudget:C0}";
+
+        public decimal EstimatedDailyCost
+        {
+            get => estimatedDailyCost;
+            private set
+            {
+                if (estimatedDailyCost != value)
+                {
+                    estimatedDailyCost = value;
+                    OnPropertyChanged(nameof(EstimatedDailyCost));
+                    OnPropertyChanged(nameof(EstimatedDailyCostDisplay));
+                }
+            }
+        }
+
+        public string EstimatedDailyCostDisplay => $"Estimated Daily Cost: {EstimatedDailyCost:C0}";
+
+        public string SelectedProjectSummary => SelectedProject?.Summary ?? "Select a project to view details";
+
+        public void BindToCity(City? targetCity, IEnumerable<ConstructionCompany>? companies)
+        {
+            city = targetCity;
+            UpdateCompanies(companies);
+            Refresh();
+        }
+
+        public void Refresh()
+        {
+            if (!Dispatcher.UIThread.CheckAccess())
+            {
+                Dispatcher.UIThread.Post(Refresh);
+                return;
+            }
+
+            CityBudget = city?.Budget ?? 0;
+            TotalAllocatedBudget = city?.ActiveProjects.Sum(p => p.Budget) ?? 0m;
+            EstimatedDailyCost = city?.ActiveProjects.Sum(p => CalculateDailyCost(p)) ?? 0m;
+
+            SyncActiveProjects();
+
+            UpdateCommandStates();
+        }
+
+        private void UpdateCommandStates()
+        {
+            buildFactoryCommand.RaiseCanExecuteChanged();
+            buildRoadCommand.RaiseCanExecuteChanged();
+            buildBridgeCommand.RaiseCanExecuteChanged();
+            buildPortCommand.RaiseCanExecuteChanged();
+            buildAirportCommand.RaiseCanExecuteChanged();
+        }
+
+        private void QueueProject(ProjectType type)
+        {
+            if (city == null || !projectConfigs.TryGetValue(type, out var config))
+            {
+                return;
+            }
+
+            var project = new ConstructionProject(type, config.Budget, config.Duration, config.Output, config.RequiredResource, config.ResourcePerDay);
+
+            bool assignedToCompany = false;
+            var company = SelectedCompanyOption?.Company;
+            if (company != null)
+            {
+                assignedToCompany = company.TakeProject(project, city);
+                if (!assignedToCompany)
+                {
+                    project.AssignedCompany = null;
+                }
+            }
+
+            city.StartConstructionProject(project);
+
+            if (!assignedToCompany && company != null && company.Projects.Contains(project))
+            {
+                company.Projects.Remove(project);
+            }
+
+            pendingFocusProject = project;
+            Refresh();
+            pendingFocusProject = null;
+
+            if (displayLookup.TryGetValue(project, out var display))
+            {
+                SelectedProject = display;
+            }
+        }
+
+        private bool CanQueueProject(ProjectType type)
+        {
+            if (city == null || !projectConfigs.TryGetValue(type, out var config))
+            {
+                return false;
+            }
+
+            if (SelectedCompanyOption?.Company != null)
+            {
+                return city.Budget >= (double)config.Budget;
+            }
+
+            var dailyCost = CalculateDailyCost(config);
+            return city.Budget >= (double)dailyCost;
+        }
+
+        private void UpdateCompanies(IEnumerable<ConstructionCompany>? companies)
+        {
+            var previouslySelectedCompany = selectedCompanyOption?.Company;
+            companyOptions.Clear();
+            companyOptions.Add(new ConstructionCompanyOption("City Works Department", null));
+
+            if (companies != null)
+            {
+                foreach (var company in companies)
+                {
+                    if (company == null)
+                    {
+                        continue;
+                    }
+
+                    companyOptions.Add(new ConstructionCompanyOption(company.Name, company));
+                }
+            }
+
+            var newSelection = companyOptions.FirstOrDefault(option => option.Company == previouslySelectedCompany);
+            if (newSelection == null)
+            {
+                newSelection = companyOptions.FirstOrDefault();
+            }
+
+            if (!ReferenceEquals(selectedCompanyOption, newSelection))
+            {
+                SelectedCompanyOption = newSelection;
+            }
+        }
+
+        private void SyncActiveProjects()
+        {
+            foreach (var kvp in displayLookup.ToList())
+            {
+                if (city?.ActiveProjects.Contains(kvp.Key) != true)
+                {
+                    kvp.Value.PropertyChanged -= OnProjectDisplayPropertyChanged;
+                    activeProjects.Remove(kvp.Value);
+                    displayLookup.Remove(kvp.Key);
+                    if (SelectedProject == kvp.Value)
+                    {
+                        SelectedProject = null;
+                    }
+                }
+            }
+
+            if (city?.ActiveProjects == null)
+            {
+                if (SelectedProject == null && activeProjects.Count > 0)
+                {
+                    SelectedProject = activeProjects[0];
+                }
+                return;
+            }
+
+            for (int i = 0; i < city.ActiveProjects.Count; i++)
+            {
+                var project = city.ActiveProjects[i];
+                if (!displayLookup.TryGetValue(project, out var display))
+                {
+                    projectConfigs.TryGetValue(project.Type, out var config);
+                    display = new ConstructionProjectDisplay(project, city.Name, config);
+                    display.PropertyChanged += OnProjectDisplayPropertyChanged;
+                    displayLookup[project] = display;
+                    if (i <= activeProjects.Count)
+                    {
+                        activeProjects.Insert(i, display);
+                    }
+                    else
+                    {
+                        activeProjects.Add(display);
+                    }
+                }
+                else
+                {
+                    display.Refresh();
+                    var currentIndex = activeProjects.IndexOf(display);
+                    if (currentIndex != i)
+                    {
+                        activeProjects.Move(currentIndex, i);
+                    }
+                }
+
+                if (pendingFocusProject == project)
+                {
+                    SelectedProject = display;
+                }
+            }
+
+            if (SelectedProject == null && activeProjects.Count > 0)
+            {
+                SelectedProject = activeProjects[0];
+            }
+        }
+
+        private void OnProjectDisplayPropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            if (sender == SelectedProject && (e.PropertyName == nameof(ConstructionProjectDisplay.Summary) || e.PropertyName == nameof(ConstructionProjectDisplay.ProgressPercentage)))
+            {
+                OnPropertyChanged(nameof(SelectedProjectSummary));
+            }
+        }
+
+        private static decimal CalculateDailyCost(ConstructionProject project)
+        {
+            if (project.Duration <= 0)
+            {
+                return Math.Max(project.Budget, ConstructionProject.MinimumDailyBudget);
+            }
+
+            var dailyCost = project.Budget / project.Duration;
+            return dailyCost < ConstructionProject.MinimumDailyBudget ? ConstructionProject.MinimumDailyBudget : dailyCost;
+        }
+
+        private static decimal CalculateDailyCost(ConstructionProjectConfig config)
+        {
+            if (config.Duration <= 0)
+            {
+                return config.Budget;
+            }
+
+            var dailyCost = config.Budget / config.Duration;
+            return dailyCost < ConstructionProject.MinimumDailyBudget ? ConstructionProject.MinimumDailyBudget : dailyCost;
+        }
+
+        private static Dictionary<ProjectType, ConstructionProjectConfig> CreateDefaultConfigs()
+        {
+            return new Dictionary<ProjectType, ConstructionProjectConfig>
+            {
+                [ProjectType.Factory] = new ConstructionProjectConfig(ProjectType.Factory, "Industrial Factory", "Boost city manufacturing capacity and jobs.", 500_000m, 180, 1.0, "Machine Parts", 2),
+                [ProjectType.Road] = new ConstructionProjectConfig(ProjectType.Road, "Major Roadway", "Improve local transport throughput and reduce congestion.", 120_000m, 120, 15.0, "Cement", 5),
+                [ProjectType.Bridge] = new ConstructionProjectConfig(ProjectType.Bridge, "River Bridge", "Connect districts separated by rivers to increase trade.", 220_000m, 150, 2.5, "Steel", 4),
+                [ProjectType.Port] = new ConstructionProjectConfig(ProjectType.Port, "Commercial Port", "Expand shipping capacity for imports and exports.", 350_000m, 200, 1.0, "Lumber", 6),
+                [ProjectType.Airport] = new ConstructionProjectConfig(ProjectType.Airport, "Regional Airport", "Open the city to rapid passenger and cargo travel.", 600_000m, 260, 1.0, "Refined Oil", 3)
+            };
+        }
+
+        private void OnPropertyChanged(string propertyName) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
+        private sealed record ConstructionProjectConfig(ProjectType Type, string DisplayName, string Description, decimal Budget, int Duration, double Output, string RequiredResource, int ResourcePerDay);
+
+        public sealed class ConstructionCompanyOption
+        {
+            public ConstructionCompanyOption(string displayName, ConstructionCompany? company)
+            {
+                DisplayName = displayName;
+                Company = company;
+            }
+
+            public string DisplayName { get; }
+
+            public ConstructionCompany? Company { get; }
+
+            public override string ToString() => DisplayName;
+        }
+
+        public sealed class ConstructionProjectDisplay : INotifyPropertyChanged
+        {
+            private readonly ConstructionProject project;
+            private readonly string cityName;
+            private readonly ConstructionProjectConfig? config;
+
+            public ConstructionProjectDisplay(ConstructionProject project, string cityName, ConstructionProjectConfig? config)
+            {
+                this.project = project;
+                this.cityName = cityName;
+                this.config = config;
+            }
+
+            public ConstructionProject Project => project;
+
+            public string Title => $"{config?.DisplayName ?? project.Type.ToString()} — {cityName}";
+
+            public double ProgressPercentage => project.Duration <= 0 ? 100 : Math.Clamp(project.Progress / (double)project.Duration * 100.0, 0, 100);
+
+            public string ProgressText => project.Duration <= 0
+                ? "Complete"
+                : $"{project.Progress}/{project.Duration} days ({ProgressPercentage:F1}%)";
+
+            public string BudgetDisplay => $"Budget: {project.Budget:C0}";
+
+            public string BudgetRemainingDisplay => $"Remaining: {project.BudgetRemaining:C0}";
+
+            public string AssignedCompanyDisplay => $"Company: {project.AssignedCompany?.Name ?? "City Works Department"}";
+
+            public string Status => project.IsComplete() ? "Complete" : "In Progress";
+
+            public string Summary
+            {
+                get
+                {
+                    var description = config?.Description ?? "Construction project";
+                    return $"{description}\nStatus: {Status}\n{ProgressText}\n{BudgetDisplay}\n{BudgetRemainingDisplay}\n{AssignedCompanyDisplay}";
+                }
+            }
+
+            public event PropertyChangedEventHandler? PropertyChanged;
+
+            public void Refresh()
+            {
+                OnPropertyChanged(nameof(ProgressPercentage));
+                OnPropertyChanged(nameof(ProgressText));
+                OnPropertyChanged(nameof(BudgetRemainingDisplay));
+                OnPropertyChanged(nameof(Status));
+                OnPropertyChanged(nameof(Summary));
+                OnPropertyChanged(nameof(AssignedCompanyDisplay));
+            }
+
+            private void OnPropertyChanged(string propertyName) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        private sealed class RelayCommand : ICommand
+        {
+            private readonly Action<object?> execute;
+            private readonly Predicate<object?>? canExecute;
+
+            public RelayCommand(Action<object?> execute, Predicate<object?>? canExecute = null)
+            {
+                this.execute = execute ?? throw new ArgumentNullException(nameof(execute));
+                this.canExecute = canExecute;
+            }
+
+            public event EventHandler? CanExecuteChanged;
+
+            public bool CanExecute(object? parameter) => canExecute?.Invoke(parameter) ?? true;
+
+            public void Execute(object? parameter) => execute(parameter);
+
+            public void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+}

--- a/Views/GameView.axaml
+++ b/Views/GameView.axaml
@@ -448,30 +448,57 @@
 
 							<!-- Project List -->
 							<StackPanel Grid.Column="0" Margin="0,0,15,0">
-								<TextBlock Text="Active Projects" Foreground="#DDDDDD" FontWeight="Bold" FontSize="16"/>
-								<ListBox x:Name="ActiveProjectsList"
-									 Background="#1A1A1A"
-									 BorderBrush="#444444"
-									 Height="250"
-									 Margin="0,5,0,0">
-								</ListBox>
-							</StackPanel>
+                                                                <TextBlock Text="Active Projects" Foreground="#DDDDDD" FontWeight="Bold" FontSize="16"/>
+                                                                <StackPanel Orientation="Vertical" Spacing="4" Margin="0,6,0,6">
+                                                                    <TextBlock Text="{Binding CityBudgetDisplay}" Foreground="#AAAAAA" FontSize="12"/>
+                                                                    <TextBlock Text="{Binding TotalAllocatedBudgetDisplay}" Foreground="#AAAAAA" FontSize="12"/>
+                                                                    <TextBlock Text="{Binding EstimatedDailyCostDisplay}" Foreground="#AAAAAA" FontSize="12"/>
+                                                                </StackPanel>
+                                                                <ListBox x:Name="ActiveProjectsList"
+                                                                         ItemsSource="{Binding ActiveProjects}"
+                                                                         SelectedItem="{Binding SelectedProject, Mode=TwoWay}"
+                                                                         Background="#1A1A1A"
+                                                                         BorderBrush="#444444"
+                                                                         Height="250"
+                                                                         Margin="0,5,0,0">
+                                                                    <ListBox.ItemTemplate>
+                                                                        <DataTemplate>
+                                                                            <Border BorderBrush="#333333" BorderThickness="1" Padding="8" Margin="0,0,0,6" Background="#202020">
+                                                                                <StackPanel Spacing="4">
+                                                                                    <TextBlock Text="{Binding Title}" Foreground="#FFFFFF" FontWeight="Bold"/>
+                                                                                    <ProgressBar Minimum="0" Maximum="100" Height="6" Value="{Binding ProgressPercentage}"/>
+                                                                                    <TextBlock Text="{Binding ProgressText}" Foreground="#CCCCCC" FontSize="12"/>
+                                                                                    <StackPanel Orientation="Horizontal" Spacing="10">
+                                                                                        <TextBlock Text="{Binding BudgetDisplay}" Foreground="#999999" FontSize="11"/>
+                                                                                        <TextBlock Text="{Binding BudgetRemainingDisplay}" Foreground="#999999" FontSize="11"/>
+                                                                                    </StackPanel>
+                                                                                    <TextBlock Text="{Binding AssignedCompanyDisplay}" Foreground="#888888" FontSize="11"/>
+                                                                                </StackPanel>
+                                                                            </Border>
+                                                                        </DataTemplate>
+                                                                    </ListBox.ItemTemplate>
+                                                                </ListBox>
+                                                        </StackPanel>
 
-							<!-- Project Actions -->
-							<StackPanel Grid.Column="1" Spacing="15">
+                                                        <!-- Project Actions -->
+                                                        <StackPanel Grid.Column="1" Spacing="15">
 								<TextBlock Text="New Projects" Foreground="#DDDDDD" FontWeight="Bold" FontSize="16"/>
-								<Button x:Name="BuildFactoryButton" Content="Build Factory" Width="160"/>
-								<Button x:Name="BuildRoadButton" Content="Build Road" Width="160"/>
-								<Button x:Name="BuildBridgeButton" Content="Build Bridge" Width="160"/>
-								<Button x:Name="BuildPortButton" Content="Build Port" Width="160"/>
-								<Button x:Name="BuildAirportButton" Content="Build Airport" Width="160"/>
+                                                                <ComboBox ItemsSource="{Binding CompanyOptions}"
+                                                                          SelectedItem="{Binding SelectedCompanyOption, Mode=TwoWay}"
+                                                                          Width="160"
+                                                                          HorizontalAlignment="Left"/>
+                                                                <Button x:Name="BuildFactoryButton" Content="Build Factory" Width="160" Command="{Binding BuildFactoryCommand}"/>
+                                                                <Button x:Name="BuildRoadButton" Content="Build Road" Width="160" Command="{Binding BuildRoadCommand}"/>
+                                                                <Button x:Name="BuildBridgeButton" Content="Build Bridge" Width="160" Command="{Binding BuildBridgeCommand}"/>
+                                                                <Button x:Name="BuildPortButton" Content="Build Port" Width="160" Command="{Binding BuildPortCommand}"/>
+                                                                <Button x:Name="BuildAirportButton" Content="Build Airport" Width="160" Command="{Binding BuildAirportCommand}"/>
 
-								<TextBlock Text="Project Info" Foreground="#DDDDDD" FontWeight="Bold" FontSize="16" Margin="0,20,0,0"/>
-								<TextBlock x:Name="ProjectInfoText"
-									   Text="Select a project to view details"
-									   Foreground="#AAAAAA"
-									   TextWrapping="Wrap"
-									   Width="160"/>
+                                                                <TextBlock Text="Project Info" Foreground="#DDDDDD" FontWeight="Bold" FontSize="16" Margin="0,20,0,0"/>
+                                                                <TextBlock x:Name="ProjectInfoText"
+                                                                           Text="{Binding SelectedProjectSummary}"
+                                                                           Foreground="#AAAAAA"
+                                                                           TextWrapping="Wrap"
+                                                                           Width="160"/>
 							</StackPanel>
 						</Grid>
 					</Grid>
@@ -1130,9 +1157,23 @@
                         </StackPanel>
 
                         <!-- CONSTRUCTION PANEL -->
-                        <StackPanel Name="SideConstructionPanel" IsVisible="False" Spacing="15">
-                            <!-- Content here -->
-                            <TextBlock Text="Construction panel content" Foreground="White"/>
+                        <StackPanel Name="SideConstructionPanel" IsVisible="False" Spacing="12">
+                            <TextBlock Text="City Construction" Foreground="#FFD700" FontWeight="Bold" FontSize="16"/>
+                            <TextBlock Text="{Binding CityBudgetDisplay}" Foreground="#FFFFFF"/>
+                            <TextBlock Text="{Binding TotalAllocatedBudgetDisplay}" Foreground="#FFFFFF"/>
+                            <TextBlock Text="{Binding EstimatedDailyCostDisplay}" Foreground="#FFFFFF"/>
+                            <ListBox ItemsSource="{Binding ActiveProjects}" SelectedItem="{Binding SelectedProject, Mode=TwoWay}" Background="#1A1A1A" BorderBrush="#444444" Height="220">
+                                <ListBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <StackPanel Spacing="4">
+                                            <TextBlock Text="{Binding Title}" Foreground="#FFFFFF" FontWeight="Bold"/>
+                                            <ProgressBar Minimum="0" Maximum="100" Height="4" Value="{Binding ProgressPercentage}"/>
+                                            <TextBlock Text="{Binding ProgressText}" Foreground="#CCCCCC" FontSize="12"/>
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </ListBox.ItemTemplate>
+                            </ListBox>
+                            <TextBlock Text="{Binding SelectedProjectSummary}" Foreground="#CCCCCC" TextWrapping="Wrap"/>
                         </StackPanel>
 
                         <!-- ECONOMY PANEL -->

--- a/Views/GameView.axaml.cs
+++ b/Views/GameView.axaml.cs
@@ -65,6 +65,9 @@ namespace Economy_sim
         private TradeRouteManager? _tradeRouteManager;
         private EnhancedTradeManager? _enhancedTradeManager;
         private readonly TradeMenuViewModel _tradeMenuViewModel;
+        private readonly ConstructionMenuViewModel _constructionMenuViewModel;
+
+        private City? _playerCity;
 
         private static readonly IReadOnlyDictionary<string, string> _needRemapping = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
@@ -87,6 +90,16 @@ namespace Economy_sim
             if (SideTradePanel != null)
             {
                 SideTradePanel.DataContext = _tradeMenuViewModel;
+            }
+
+            _constructionMenuViewModel = new ConstructionMenuViewModel();
+            if (this.FindControl<Border>("ConstructionMenuOverlay") is Border constructionOverlay)
+            {
+                constructionOverlay.DataContext = _constructionMenuViewModel;
+            }
+            if (this.FindControl<StackPanel>("SideConstructionPanel") is StackPanel sideConstructionPanel)
+            {
+                sideConstructionPanel.DataContext = _constructionMenuViewModel;
             }
 
             int baseW = ParseEnvOrDefault("ES_BASE_WIDTH", _baselineWidth);
@@ -1175,12 +1188,16 @@ namespace Economy_sim
             _allCorporations = new List<Corporation>();
             CreateInitialCorporationsFromCities();
 
+            var playerCities = _playerCountry.States.SelectMany(s => s.Cities).ToList();
+            EnsureConstructionCompanies(playerCities);
+
             Market.AllCorporations.Clear();
             Market.AllCorporations.AddRange(_allCorporations);
 
             InitializeTradeSystemsForCurrentWorld();
 
             _economyInitialized = true;
+            UpdateConstructionContext();
             return true;
         }
 
@@ -1283,6 +1300,66 @@ namespace Economy_sim
             _tradeRouteManager ??= new TradeRouteManager();
             _enhancedTradeManager ??= new EnhancedTradeManager(_allCountries);
             RefreshTradeViewModel();
+        }
+
+        private void EnsureConstructionCompanies(IReadOnlyList<City> cities)
+        {
+            if (cities == null || cities.Count == 0)
+            {
+                return;
+            }
+
+            if (Market.AllConstructionCompanies.Count == 0)
+            {
+                var orderedCities = cities.OrderByDescending(c => c.Population).ToList();
+                var primaryCity = orderedCities.First();
+                var secondaryCity = orderedCities.Skip(1).FirstOrDefault() ?? primaryCity;
+
+                var metroBuilders = new ConstructionCompany($"{primaryCity.Name} Builders Guild", 600, 500_000m)
+                {
+                    HomeCity = primaryCity
+                };
+
+                var infrastructureWorks = new ConstructionCompany($"{secondaryCity.Name} Infrastructure Works", 420, 400_000m)
+                {
+                    HomeCity = secondaryCity
+                };
+
+                Market.AllConstructionCompanies.Add(metroBuilders);
+                if (!ReferenceEquals(primaryCity, secondaryCity) || Market.AllConstructionCompanies.All(c => c != infrastructureWorks))
+                {
+                    Market.AllConstructionCompanies.Add(infrastructureWorks);
+                }
+            }
+
+            foreach (var company in Market.AllConstructionCompanies)
+            {
+                if (company.HomeCity == null)
+                {
+                    company.HomeCity = cities[0];
+                }
+
+                if (!_allCorporations.Contains(company))
+                {
+                    _allCorporations.Add(company);
+                }
+            }
+        }
+
+        private void UpdateConstructionContext()
+        {
+            if (_constructionMenuViewModel == null)
+            {
+                return;
+            }
+
+            var cities = _playerCountry?.States.SelectMany(s => s.Cities).ToList() ?? new List<City>();
+            if (_playerCity == null || (cities.Count > 0 && !cities.Contains(_playerCity)))
+            {
+                _playerCity = cities.OrderByDescending(c => c.Population).FirstOrDefault();
+            }
+
+            _constructionMenuViewModel.BindToCity(_playerCity, Market.AllConstructionCompanies);
         }
 
         private void RefreshTradeViewModel()
@@ -1539,6 +1616,10 @@ namespace Economy_sim
                 }
             }
 
+            var sampleCities = _currentCountry.States.SelectMany(s => s.Cities).ToList();
+            Market.AllConstructionCompanies.Clear();
+            EnsureConstructionCompanies(sampleCities);
+
             Market.AllCorporations.Clear();
             Market.AllCorporations.AddRange(_allCorporations);
 
@@ -1554,6 +1635,7 @@ namespace Economy_sim
             _playerCountry = _currentCountry;
 
             _economyInitialized = true;
+            UpdateConstructionContext();
             Debug.WriteLine($"[Economy Init] Economy initialized with {_currentCountry.States.Count} states, {_currentCountry.States.Sum(s => s.Cities.Count)} cities, and {_allCorporations.Count} corporations");
         }
         private void OnEconomyUpdateTick(object? sender, EventArgs e)
@@ -1583,6 +1665,7 @@ namespace Economy_sim
                 foreach (var city in playerCities)
                 {
                     Economy.UpdateCityEconomy(city);
+                    city.ProgressConstruction();
                 }
 
                 // Resolve inter-city trade before aggregating state/country metrics
@@ -1625,6 +1708,7 @@ namespace Economy_sim
                 // Update displays
                 UpdateEconomyDisplay();
                 UpdateHUDDisplay(null, null);
+                UpdateConstructionContext();
 
                 Debug.WriteLine($"[Economy Update] Country budget: ${_currentCountry.Budget:N0}, GDP estimate: ${CalculateGDP():N0}");
             }
@@ -1979,22 +2063,6 @@ namespace Economy_sim
                 }
             }
 
-            // Initialize Construction menu content
-            if (this.FindControl<ListBox>("ActiveProjectsList") is ListBox projectsList)
-            {
-                var projects = new[]
-                {
-                    "🏭 Steel Factory - Los Angeles (Progress: 75%)",
-                    "🛣️ Interstate Highway - Texas (Progress: 45%)",
-                    "🌉 Golden Gate Bridge Maintenance (Progress: 20%)",
-                    "✈️ Airport Expansion - New York (Progress: 90%)"
-                };
-                foreach (var project in projects)
-                {
-                    projectsList.Items.Add(project);
-                }
-            }
-
             // Initialize Economy menu content
             if (this.FindControl<ListBox>("IndustriesList") is ListBox industriesList)
             {
@@ -2058,20 +2126,6 @@ namespace Economy_sim
                 };
                 foreach (var relation in relations)
                     sideDip.Items.Add(relation);
-            }
-
-            // Construction
-            if (this.FindControl<ListBox>("SideActiveProjectsList") is ListBox sideProjects)
-            {
-                var projects = new[]
-                {
-                    "🏭 Steel Factory - Los Angeles (Progress: 75%)",
-                    "🛣️ Interstate Highway - Texas (Progress: 45%)",
-                    "🌉 Golden Gate Bridge Maintenance (Progress: 20%)",
-                    "✈️ Airport Expansion - New York (Progress: 90%)"
-                };
-                foreach (var project in projects)
-                    sideProjects.Items.Add(project);
             }
 
             // Economy


### PR DESCRIPTION
## Summary
- add a construction menu view model that surfaces active projects, budget details, and build commands for the player city
- bind the construction popup and side panel to the new view model and share observable collections for synchronized progress displays
- extend city, project, and construction company logic so projects advance each tick, support new project types, and optionally assign companies

## Testing
- `dotnet build -v minimal` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e481617e4c8323b26c5ffdc31bdbc8