### PR TITLE
Fix city construction budget handling

### DIFF
--- a/City.cs
+++ b/City.cs
@@ -205,6 +205,13 @@ namespace Economy_sim
 
             foreach (var project in ActiveProjects.ToList())
             {
+                if (project.IsComplete())
+                {
+                    ApplyProjectEffects(project);
+                    ActiveProjects.Remove(project);
+                    continue;
+                }
+
                 if (project.AssignedCompany != null)
                 {
                     companiesToUpdate.Add(project.AssignedCompany);
@@ -212,7 +219,13 @@ namespace Economy_sim
                 }
 
                 var dailyCost = CalculateDailyCost(project);
-                if ((decimal)Budget < dailyCost || project.BudgetRemaining < dailyCost)
+                if (dailyCost <= 0m)
+                {
+                    continue;
+                }
+
+                var cityBudget = (decimal)Budget;
+                if (cityBudget < dailyCost || project.BudgetRemaining < dailyCost)
                 {
                     continue;
                 }
@@ -220,12 +233,12 @@ namespace Economy_sim
                 if (project.ProgressProject(1, dailyCost))
                 {
                     Budget -= (double)dailyCost;
-                }
 
-                if (project.IsComplete())
-                {
-                    ApplyProjectEffects(project);
-                    ActiveProjects.Remove(project);
+                    if (project.IsComplete())
+                    {
+                        ApplyProjectEffects(project);
+                        ActiveProjects.Remove(project);
+                    }
                 }
             }
 
@@ -246,13 +259,7 @@ namespace Economy_sim
 
         private static decimal CalculateDailyCost(ConstructionProject project)
         {
-            if (project.Duration <= 0)
-            {
-                return Math.Max(project.Budget, ConstructionProject.MinimumDailyBudget);
-            }
-
-            var dailyCost = project.Budget / project.Duration;
-            return dailyCost < ConstructionProject.MinimumDailyBudget ? ConstructionProject.MinimumDailyBudget : dailyCost;
+            return project.Duration > 0 ? project.Budget / project.Duration : 0m;
         }
 
         private void ApplyProjectEffects(ConstructionProject project)

--- a/ViewModels/ConstructionMenuViewModel.cs
+++ b/ViewModels/ConstructionMenuViewModel.cs
@@ -325,24 +325,12 @@ namespace Economy_sim
 
         private static decimal CalculateDailyCost(ConstructionProject project)
         {
-            if (project.Duration <= 0)
-            {
-                return Math.Max(project.Budget, ConstructionProject.MinimumDailyBudget);
-            }
-
-            var dailyCost = project.Budget / project.Duration;
-            return dailyCost < ConstructionProject.MinimumDailyBudget ? ConstructionProject.MinimumDailyBudget : dailyCost;
+            return project.Duration > 0 ? project.Budget / project.Duration : 0m;
         }
 
         private static decimal CalculateDailyCost(ConstructionProjectConfig config)
         {
-            if (config.Duration <= 0)
-            {
-                return config.Budget;
-            }
-
-            var dailyCost = config.Budget / config.Duration;
-            return dailyCost < ConstructionProject.MinimumDailyBudget ? ConstructionProject.MinimumDailyBudget : dailyCost;
+            return config.Duration > 0 ? config.Budget / config.Duration : 0m;
         }
 
         private static Dictionary<ProjectType, ConstructionProjectConfig> CreateDefaultConfigs()
@@ -407,12 +395,16 @@ namespace Economy_sim
 
             public string Status => project.IsComplete() ? "Complete" : "In Progress";
 
+            public decimal DailyCost => CalculateDailyCost(project);
+
+            public string DailyCostDisplay => $"Daily Cost: {DailyCost:C0}";
+
             public string Summary
             {
                 get
                 {
                     var description = config?.Description ?? "Construction project";
-                    return $"{description}\nStatus: {Status}\n{ProgressText}\n{BudgetDisplay}\n{BudgetRemainingDisplay}\n{AssignedCompanyDisplay}";
+                    return $"{description}\nStatus: {Status}\n{ProgressText}\n{DailyCostDisplay}\n{BudgetDisplay}\n{BudgetRemainingDisplay}\n{AssignedCompanyDisplay}";
                 }
             }
 
@@ -426,6 +418,8 @@ namespace Economy_sim
                 OnPropertyChanged(nameof(Status));
                 OnPropertyChanged(nameof(Summary));
                 OnPropertyChanged(nameof(AssignedCompanyDisplay));
+                OnPropertyChanged(nameof(DailyCost));
+                OnPropertyChanged(nameof(DailyCostDisplay));
             }
 
             private void OnPropertyChanged(string propertyName) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));


### PR DESCRIPTION
## Summary
- adjust city construction progress to calculate daily costs with decimal math, guard zero-cost work, and only spend when both city and project budgets can cover the day
- remove completed projects before further processing and align the construction view model with the corrected daily cost calculation
- surface each project's daily spend in the construction UI summary for accurate reporting

## Testing
- `dotnet build -v minimal` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e48cde774883238fae18cf72c7485c