### PR TITLE
Wire construction companies into city updates

### DIFF
--- a/City.cs
+++ b/City.cs
@@ -30,6 +30,7 @@ namespace Economy_sim
         public List<SellOrder> SellOrders { get; set; }
         public List<Suburb> Suburbs { get; private set; } // Added Suburbs property
         public List<ConstructionProject> ActiveProjects { get; private set; } // Added to track active construction projects
+        public List<ConstructionCompany> ConstructionCompanies { get; } = new();
 
         public City(string name)
         {
@@ -180,7 +181,20 @@ namespace Economy_sim
             return cityQoL;
         }
 
-        public void StartConstructionProject(ConstructionProject project)
+        public void RegisterConstructionCompany(ConstructionCompany company)
+        {
+            if (company == null)
+            {
+                return;
+            }
+
+            if (!ConstructionCompanies.Contains(company))
+            {
+                ConstructionCompanies.Add(company);
+            }
+        }
+
+        public void StartConstructionProject(ConstructionProject project, ConstructionCompany company = null)
         {
             if (project == null)
             {
@@ -190,6 +204,19 @@ namespace Economy_sim
             if (!ActiveProjects.Contains(project))
             {
                 project.OwningCity = this;
+                if (company != null)
+                {
+                    project.AssignedCompany = company;
+                    RegisterConstructionCompany(company);
+                    if (!company.Projects.Contains(project))
+                    {
+                        company.Projects.Add(project);
+                    }
+                }
+                else
+                {
+                    project.AssignedCompany = null;
+                }
                 ActiveProjects.Add(project);
             }
         }
@@ -201,20 +228,12 @@ namespace Economy_sim
                 return;
             }
 
-            var companiesToUpdate = new HashSet<ConstructionCompany>();
+            bool progressMade = false;
 
             foreach (var project in ActiveProjects.ToList())
             {
-                if (project.IsComplete())
-                {
-                    ApplyProjectEffects(project);
-                    ActiveProjects.Remove(project);
-                    continue;
-                }
-
                 if (project.AssignedCompany != null)
                 {
-                    companiesToUpdate.Add(project.AssignedCompany);
                     continue;
                 }
 
@@ -233,18 +252,15 @@ namespace Economy_sim
                 if (project.ProgressProject(1, dailyCost))
                 {
                     Budget -= (double)dailyCost;
+                    progressMade = true;
 
                     if (project.IsComplete())
                     {
                         ApplyProjectEffects(project);
                         ActiveProjects.Remove(project);
+                        progressMade = true;
                     }
                 }
-            }
-
-            foreach (var company in companiesToUpdate)
-            {
-                company.WorkOnProjects(this);
             }
 
             foreach (var project in ActiveProjects.ToList())
@@ -253,7 +269,13 @@ namespace Economy_sim
                 {
                     ApplyProjectEffects(project);
                     ActiveProjects.Remove(project);
+                    progressMade = true;
                 }
+            }
+
+            if (progressMade)
+            {
+                Economy.RaiseConstructionProgressed(this);
             }
         }
 

--- a/ConstructionCompany.cs
+++ b/ConstructionCompany.cs
@@ -34,6 +34,7 @@ namespace Economy_sim
             Budget += (double)project.Budget;
             project.AssignedCompany = this;
             Projects.Add(project);
+            city.RegisterConstructionCompany(this);
             return true;
         }
 

--- a/Economy.cs
+++ b/Economy.cs
@@ -25,6 +25,13 @@ namespace Economy_sim
 
     public static class Economy
     {
+        public static event Action<City> ConstructionProgressed;
+
+        internal static void RaiseConstructionProgressed(City city)
+        {
+            ConstructionProgressed?.Invoke(city);
+        }
+
         public static void UpdateCountryEconomy(Country country)
         {
             // === New Financial System Integration ===
@@ -136,6 +143,51 @@ namespace Economy_sim
 
             // Process detailed city economy including buy/sell order generation
             CityEconomy.ProcessCityEconomy(city);
+
+            var companiesToWork = new HashSet<ConstructionCompany>();
+
+            foreach (var company in city.ConstructionCompanies)
+            {
+                if (company == null)
+                {
+                    continue;
+                }
+
+                if (company.Projects.Any(p => p.OwningCity == city))
+                {
+                    companiesToWork.Add(company);
+                }
+            }
+
+            foreach (var project in city.ActiveProjects)
+            {
+                if (project.AssignedCompany != null)
+                {
+                    companiesToWork.Add(project.AssignedCompany);
+                }
+            }
+
+            if (companiesToWork.Count == 0)
+            {
+                foreach (var company in Market.AllConstructionCompanies.Where(c => c.HomeCity == city))
+                {
+                    if (company != null)
+                    {
+                        city.RegisterConstructionCompany(company);
+                        companiesToWork.Add(company);
+                    }
+                }
+            }
+
+            foreach (var company in companiesToWork)
+            {
+                company.WorkOnProjects(city);
+            }
+
+            if (companiesToWork.Count > 0)
+            {
+                RaiseConstructionProgressed(city);
+            }
         }
 
         public static void UpdatePopGrowth(PopClass pop)

--- a/ViewModels/ConstructionMenuViewModel.cs
+++ b/ViewModels/ConstructionMenuViewModel.cs
@@ -45,6 +45,8 @@ namespace Economy_sim
 
         public ObservableCollection<ConstructionCompanyOption> CompanyOptions => companyOptions;
 
+        public City? BoundCity => city;
+
         public ICommand BuildFactoryCommand => buildFactoryCommand;
 
         public ICommand BuildRoadCommand => buildRoadCommand;
@@ -186,7 +188,7 @@ namespace Economy_sim
                 }
             }
 
-            city.StartConstructionProject(project);
+            city.StartConstructionProject(project, assignedToCompany ? company : null);
 
             if (!assignedToCompany && company != null && company.Projects.Contains(project))
             {

--- a/Views/GameView.axaml.cs
+++ b/Views/GameView.axaml.cs
@@ -90,6 +90,8 @@ namespace Economy_sim
                 sideConstructionPanel.DataContext = _constructionMenuViewModel;
             }
 
+            Economy.ConstructionProgressed += OnConstructionProgressed;
+
             int baseW = ParseEnvOrDefault("ES_BASE_WIDTH", _baselineWidth);
             int baseH = ParseEnvOrDefault("ES_BASE_HEIGHT", _baselineHeight);
             int defaultPolW = checked(baseW * 2);
@@ -177,6 +179,8 @@ namespace Economy_sim
             {
                 this.Loaded -= OnWindowLoaded;
                 this.SizeChanged -= OnSizeChanged;
+
+                Economy.ConstructionProgressed -= OnConstructionProgressed;
 
                 CancelStateCulling();
 
@@ -1091,15 +1095,42 @@ namespace Economy_sim
 
                     Market.AllConstructionCompanies.Add(company);
                     _allCorporations.Add(company);
+                    city.RegisterConstructionCompany(company);
                 }
             }
 
             foreach (var company in Market.AllConstructionCompanies)
             {
+                company.HomeCity?.RegisterConstructionCompany(company);
                 if (!_allCorporations.Contains(company))
                 {
                     _allCorporations.Add(company);
                 }
+            }
+        }
+
+        private void OnConstructionProgressed(City updatedCity)
+        {
+            if (_constructionMenuViewModel == null)
+            {
+                return;
+            }
+
+            void Refresh()
+            {
+                if (_constructionMenuViewModel.BoundCity == null || _constructionMenuViewModel.BoundCity == updatedCity)
+                {
+                    _constructionMenuViewModel.Refresh();
+                }
+            }
+
+            if (!Dispatcher.UIThread.CheckAccess())
+            {
+                Dispatcher.UIThread.Post(Refresh);
+            }
+            else
+            {
+                Refresh();
             }
         }
 
@@ -1127,7 +1158,24 @@ namespace Economy_sim
                     break;
             }
 
-            var companies = Market.AllConstructionCompanies.ToList();
+            List<ConstructionCompany>? companies = null;
+            if (focusCity != null)
+            {
+                if (focusCity.ConstructionCompanies.Count > 0)
+                {
+                    companies = focusCity.ConstructionCompanies.ToList();
+                }
+                else
+                {
+                    companies = Market.AllConstructionCompanies
+                        .Where(c => c.HomeCity == focusCity)
+                        .ToList();
+                }
+            }
+            else
+            {
+                companies = Market.AllConstructionCompanies.ToList();
+            }
 
             if (!Dispatcher.UIThread.CheckAccess())
             {


### PR DESCRIPTION
## Summary
- track construction companies per city and keep project assignments in sync when launched from the UI
- run company work loops during city economy updates and emit construction progress notifications
- scope available construction companies by city and refresh the construction menu automatically after work completes

## Testing
- dotnet build *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e48f3974088323adb7e8e013a1f7c3