### PR TITLE
Integrate procedural city data into economy simulation

### DIFF
--- a/BuildingRefiner.cs
+++ b/BuildingRefiner.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Economy_sim
+{
+    /// <summary>
+    /// Derives gameplay-relevant building statistics from land value and land use.
+    /// </summary>
+    public static class BuildingRefiner
+    {
+        public static void RefineBuildings(City city, Dictionary<Parcel, double> landValueMap)
+        {
+            if (city?.ProceduralData == null)
+            {
+                return;
+            }
+
+            var proceduralData = city.ProceduralData;
+            var template = CityTemplateManager.GetTemplate(proceduralData.TemplateType);
+            int residentialParcels = Math.Max(1, proceduralData.CountBuildingsByLandUse(LandUseType.Residential));
+            int currentPopulation = Math.Max(1, city.PopClasses.Sum(p => p.Size));
+            int baselineResidentialCapacity = Math.Max(1500, currentPopulation / residentialParcels);
+
+            foreach (var (parcel, building) in proceduralData.ParcelBuildingPairs)
+            {
+                if (building == null)
+                {
+                    continue;
+                }
+
+                double landValue = landValueMap.TryGetValue(parcel, out var value)
+                    ? value
+                    : parcel.LandValue;
+
+                building.LandUse = parcel.LandUse;
+                building.Level = DetermineLevel(landValue);
+
+                switch (parcel.LandUse)
+                {
+                    case LandUseType.Residential:
+                        building.PopulationCapacity = CalculateResidentialCapacity(
+                            baselineResidentialCapacity,
+                            building.Level,
+                            landValue);
+                        building.EconomicOutput = Math.Round(
+                            building.Level * template.IncomeMultiplier * 40 + landValue * 6,
+                            MidpointRounding.AwayFromZero);
+                        building.PollutionOutput = Math.Max(0, building.Level - 2);
+                        break;
+                    case LandUseType.Commercial:
+                        building.PopulationCapacity = 0;
+                        building.EconomicOutput = Math.Round(
+                            (landValue * 8 + building.Level * 120) * template.IncomeMultiplier,
+                            MidpointRounding.AwayFromZero);
+                        building.PollutionOutput = Math.Max(0, building.Level * 0.5);
+                        break;
+                    case LandUseType.Industrial:
+                        building.PopulationCapacity = (int)Math.Round(landValue * 3 + building.Level * 150);
+                        building.EconomicOutput = Math.Round(
+                            (landValue * 12 + building.Level * 200) * template.IncomeMultiplier,
+                            MidpointRounding.AwayFromZero);
+                        building.PollutionOutput = Math.Max(5, building.Level * 5 + landValue * 0.5);
+                        break;
+                    case LandUseType.Park:
+                        building.PopulationCapacity = (int)Math.Round(landValue * 1.5);
+                        building.EconomicOutput = Math.Round(landValue * 2, MidpointRounding.AwayFromZero);
+                        building.PollutionOutput = -Math.Max(1, building.Level);
+                        break;
+                }
+            }
+        }
+
+        private static int DetermineLevel(double landValue)
+        {
+            if (landValue < 25) return 1;
+            if (landValue < 45) return 2;
+            if (landValue < 65) return 3;
+            if (landValue < 90) return 4;
+            return 5;
+        }
+
+        private static int CalculateResidentialCapacity(int baseline, int level, double landValue)
+        {
+            double levelFactor = 0.6 + level * 0.45;
+            double valueFactor = 0.8 + landValue / 120.0;
+            return (int)Math.Round(baseline * levelFactor * valueFactor, MidpointRounding.AwayFromZero);
+        }
+    }
+}

--- a/City.cs
+++ b/City.cs
@@ -31,6 +31,7 @@ namespace Economy_sim
         public List<Suburb> Suburbs { get; private set; } // Added Suburbs property
         public List<ConstructionProject> ActiveProjects { get; private set; } // Added to track active construction projects
         public List<ConstructionCompany> ConstructionCompanies { get; } = new();
+        public CityProceduralData ProceduralData { get; set; }
 
         public City(string name)
         {
@@ -130,20 +131,84 @@ namespace Economy_sim
         public void SimulateGrowth()
         {
             double surplus = Budget - CityExpenses;
-            if (surplus > 0)
+            if (surplus <= 0)
             {
-                int growth = (int)(surplus / 1000); // Example: population grows with surplus
-                Population += growth;
-
-                // Distribute growth among PopClasses proportionally
-                foreach (var pop in PopClasses)
-                {
-                    int popGrowth = (int)(growth * ((double)pop.Size / Population));
-                    pop.Size += popGrowth;
-                }
-
-                Budget += surplus * 0.05; // Example: reinvest surplus
+                HandleOvercrowding();
+                return;
             }
+
+            int baseGrowth = (int)(surplus / 1000);
+            if (baseGrowth <= 0)
+            {
+                HandleOvercrowding();
+                return;
+            }
+
+            int currentPopulation = Math.Max(1, PopClasses.Sum(p => p.Size));
+            int allowedGrowth = baseGrowth;
+
+            if (ProceduralData != null)
+            {
+                int maxPopulation = ProceduralData.TotalResidentialCapacity;
+                if (maxPopulation > 0)
+                {
+                    int availableCapacity = Math.Max(0, maxPopulation - currentPopulation);
+                    allowedGrowth = Math.Min(baseGrowth, availableCapacity);
+
+                    if (availableCapacity <= 0)
+                    {
+                        HandleOvercrowding();
+                        return;
+                    }
+                }
+            }
+
+            if (allowedGrowth <= 0)
+            {
+                HandleOvercrowding();
+                return;
+            }
+
+            Population = currentPopulation + allowedGrowth;
+
+            foreach (var pop in PopClasses)
+            {
+                int popGrowth = (int)Math.Round(allowedGrowth * (pop.Size / (double)currentPopulation));
+                pop.Size += popGrowth;
+            }
+
+            Budget += surplus * 0.05;
+        }
+
+        private void HandleOvercrowding()
+        {
+            if (ProceduralData == null)
+            {
+                return;
+            }
+
+            int totalCapacity = ProceduralData.TotalResidentialCapacity;
+            if (totalCapacity <= 0)
+            {
+                return;
+            }
+
+            int currentPopulation = PopClasses.Sum(p => p.Size);
+            if (currentPopulation <= totalCapacity)
+            {
+                return;
+            }
+
+            int overflow = currentPopulation - totalCapacity;
+            int reduction = Math.Max(1, overflow / Math.Max(1, PopClasses.Count));
+
+            foreach (var pop in PopClasses)
+            {
+                pop.Size = Math.Max(0, pop.Size - reduction);
+            }
+
+            Population = PopClasses.Sum(p => p.Size);
+            Happiness = Math.Max(0, Happiness - 2);
         }
 
         public void AddSuburb(Suburb suburb)

--- a/CityProceduralData.cs
+++ b/CityProceduralData.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Economy_sim
+{
+    /// <summary>
+    /// Holds the procedurally generated spatial data for a city and exposes
+    /// helper methods for the economy integration layer.
+    /// </summary>
+    public class CityProceduralData
+    {
+        private readonly Dictionary<Parcel, Building> parcelBuildings = new();
+
+        public CityProceduralData(CityType templateType, int seed)
+        {
+            TemplateType = templateType;
+            Seed = seed;
+        }
+
+        /// <summary>
+        /// Type of template that produced the city. Used to derive heuristics
+        /// when calculating land values or refining buildings.
+        /// </summary>
+        public CityType TemplateType { get; }
+
+        /// <summary>
+        /// Seed used for deterministic calculations that depend on randomness.
+        /// </summary>
+        public int Seed { get; }
+
+        /// <summary>
+        /// All parcels that make up the simulated city layout.
+        /// </summary>
+        public List<Parcel> Parcels { get; } = new();
+
+        /// <summary>
+        /// Returns the current building assigned to a parcel, if any.
+        /// </summary>
+        public Building? GetBuilding(Parcel parcel)
+        {
+            return parcelBuildings.TryGetValue(parcel, out var building) ? building : null;
+        }
+
+        /// <summary>
+        /// Assigns a building to the provided parcel, ensuring the land-use
+        /// information remains consistent between the two data structures.
+        /// </summary>
+        public void SetBuilding(Parcel parcel, Building building)
+        {
+            if (parcel == null || building == null)
+            {
+                return;
+            }
+
+            building.LandUse = parcel.LandUse;
+            parcelBuildings[parcel] = building;
+        }
+
+        /// <summary>
+        /// Removes a building assignment from a parcel.
+        /// </summary>
+        public void RemoveBuilding(Parcel parcel)
+        {
+            if (parcel == null)
+            {
+                return;
+            }
+
+            parcelBuildings.Remove(parcel);
+        }
+
+        /// <summary>
+        /// Enumerates parcel/building pairs in the city.
+        /// </summary>
+        public IEnumerable<(Parcel parcel, Building building)> ParcelBuildingPairs =>
+            parcelBuildings.Select(kvp => (kvp.Key, kvp.Value));
+
+        /// <summary>
+        /// Returns all buildings currently placed within the city.
+        /// </summary>
+        public IEnumerable<Building> Buildings => parcelBuildings.Values;
+
+        /// <summary>
+        /// Counts buildings by the provided land-use category.
+        /// </summary>
+        public int CountBuildingsByLandUse(LandUseType landUse) =>
+            parcelBuildings.Values.Count(b => b.LandUse == landUse);
+
+        /// <summary>
+        /// Calculates the total population capacity of residential buildings.
+        /// </summary>
+        public int TotalResidentialCapacity =>
+            parcelBuildings.Values
+                .Where(b => b.LandUse == LandUseType.Residential)
+                .Sum(b => b.PopulationCapacity);
+
+        /// <summary>
+        /// Retrieves parcels matching a land-use category.
+        /// </summary>
+        public IEnumerable<Parcel> GetParcelsByLandUse(LandUseType landUse) =>
+            Parcels.Where(p => p.LandUse == landUse);
+    }
+}

--- a/Economy.cs
+++ b/Economy.cs
@@ -138,7 +138,10 @@ namespace Economy_sim
                 totalCorporateProfits += (decimal)(corp.Budget * 0.1); // Simple profit approximation
             }
 
-            decimal totalLandValue = (decimal)country.States.Count * 1000000m; // Placeholder land value
+            decimal totalLandValue = (decimal)country.States
+                .SelectMany(s => s.Cities)
+                .SelectMany(c => c.ProceduralData?.Parcels ?? Enumerable.Empty<Parcel>())
+                .Sum(p => p.LandValue);
             decimal totalConsumptionValue = totalAssessablePopIncome * 0.6m; // Assume 60% consumed
 
             decimal taxRevenue = fs.CalculateTaxRevenue(popIncomeMap, totalCorporateProfits, totalLandValue, totalConsumptionValue, totalPopulation);
@@ -327,14 +330,17 @@ namespace Economy_sim
         public List<Good> InputGoods { get; set; }
         public List<Good> OutputGoods { get; set; }
         public int ProductionCapacity { get; set; }
+        public int BaseProductionCapacity { get; }
         public int WorkersEmployed { get; set; } // This might become a sum of employed from JobSlots or represent total workforce
         public Dictionary<string, int> JobSlots { get; set; }
         public Dictionary<string, int> ActualEmployed { get; set; } // Tracks actual number employed in each slot type
+        public Building BuildingData { get; set; }
 
         public Factory(string name, int productionCapacity)
         {
             Name = name;
             ProductionCapacity = productionCapacity;
+            BaseProductionCapacity = productionCapacity;
             InputGoods = new List<Good>();
             OutputGoods = new List<Good>();
             JobSlots = new Dictionary<string, int>();
@@ -345,60 +351,80 @@ namespace Economy_sim
         // Simulate production: consume inputs, produce outputs
         public void Produce(Dictionary<string, Good> cityStockpile, City city)
         {
-            if (this.OwnerCorporation == null) 
+            if (this.OwnerCorporation == null)
             {
-                return; 
+                return;
             }
+
+            if (BuildingData == null)
+            {
+                return;
+            }
+
+            int currentProductionCapacity = CalculateCurrentCapacity();
 
             double totalInputCost = 0;
             bool allInputsAvailableInStockpile = true;
             foreach (var input in InputGoods)
             {
-                if (!cityStockpile.ContainsKey(input.Name) || cityStockpile[input.Name].Quantity < input.Quantity * ProductionCapacity)
+                if (!cityStockpile.ContainsKey(input.Name) || cityStockpile[input.Name].Quantity < input.Quantity * currentProductionCapacity)
                 {
                     allInputsAvailableInStockpile = false;
                     break;
                 }
                 // Use city.LocalPrices for input cost calculation
-                totalInputCost += (input.Quantity * ProductionCapacity) * (city.LocalPrices.ContainsKey(input.Name) ? city.LocalPrices[input.Name] : input.BasePrice); 
+                totalInputCost += (input.Quantity * currentProductionCapacity) * (city.LocalPrices.ContainsKey(input.Name) ? city.LocalPrices[input.Name] : input.BasePrice);
             }
 
             if (!allInputsAvailableInStockpile) return;
-            if (this.OwnerCorporation.Budget < totalInputCost) return; 
+            if (this.OwnerCorporation.Budget < totalInputCost) return;
 
             this.OwnerCorporation.Budget -= totalInputCost;
             city.Budget += totalInputCost;
 
             foreach (var input in InputGoods)
             {
-                cityStockpile[input.Name].Quantity -= input.Quantity * ProductionCapacity;
+                cityStockpile[input.Name].Quantity -= input.Quantity * currentProductionCapacity;
                 // Update city.LocalDemand
                 if (city.LocalDemand.ContainsKey(input.Name))
-                    city.LocalDemand[input.Name] += input.Quantity * ProductionCapacity;
+                    city.LocalDemand[input.Name] += input.Quantity * currentProductionCapacity;
                 else
-                    city.LocalDemand[input.Name] = input.Quantity * ProductionCapacity;
+                    city.LocalDemand[input.Name] = input.Quantity * currentProductionCapacity;
             }
 
             double totalOutputValue = 0;
             foreach (var output in OutputGoods)
             {
                 if (!cityStockpile.ContainsKey(output.Name))
-                    cityStockpile[output.Name] = new Good(output.Name, output.BasePrice, output.Category); 
-                
-                cityStockpile[output.Name].Quantity += output.Quantity * ProductionCapacity;
+                    cityStockpile[output.Name] = new Good(output.Name, output.BasePrice, output.Category);
+
+                cityStockpile[output.Name].Quantity += output.Quantity * currentProductionCapacity;
                 // Use city.LocalPrices for output value calculation
                 double currentMarketPrice = city.LocalPrices.ContainsKey(output.Name) ? city.LocalPrices[output.Name] : output.BasePrice;
-                totalOutputValue += (output.Quantity * ProductionCapacity) * currentMarketPrice;
-                
+                totalOutputValue += (output.Quantity * currentProductionCapacity) * currentMarketPrice;
+
                 // Update city.LocalSupply
                 if (city.LocalSupply.ContainsKey(output.Name))
-                    city.LocalSupply[output.Name] += output.Quantity * ProductionCapacity;
+                    city.LocalSupply[output.Name] += output.Quantity * currentProductionCapacity;
                 else
-                    city.LocalSupply[output.Name] = output.Quantity * ProductionCapacity;
+                    city.LocalSupply[output.Name] = output.Quantity * currentProductionCapacity;
             }
 
             this.OwnerCorporation.Budget += totalOutputValue;
             city.Budget -= totalOutputValue;
+        }
+
+        private int CalculateCurrentCapacity()
+        {
+            if (BuildingData == null)
+            {
+                return ProductionCapacity;
+            }
+
+            double levelFactor = 0.6 + BuildingData.Level * 0.5;
+            double outputFactor = 1.0 + BuildingData.EconomicOutput / 500.0;
+            int capacity = (int)Math.Round(BaseProductionCapacity * levelFactor * outputFactor);
+            return Math.Max(1, capacity);
         }
     }
 
@@ -826,9 +852,24 @@ namespace Economy_sim
                     newFactory.OutputGoods.Add(new Good(chosenBlueprint.OutputGood.Name, chosenBlueprint.OutputGood.BasePrice, chosenBlueprint.OutputGood.Category));
 
                     newFactory.OwnerCorporation = this;
-                    
+
                     targetCity.Factories.Add(newFactory);
                     this.AddFactory(newFactory);
+
+                    if (targetCity.ProceduralData != null)
+                    {
+                        var newParcel = new Parcel { LandUse = LandUseType.Industrial };
+                        var newBuilding = new Building { LandUse = LandUseType.Industrial };
+                        targetCity.ProceduralData.Parcels.Add(newParcel);
+                        targetCity.ProceduralData.SetBuilding(newParcel, newBuilding);
+                        newFactory.BuildingData = newBuilding;
+
+                        var updatedLandValues = LandValueCalculator.Calculate(targetCity);
+                        LandUseSimulator.RunDeveloperAgentSimulation(targetCity, updatedLandValues);
+                        var refinedValues = LandValueCalculator.Calculate(targetCity);
+                        BuildingRefiner.RefineBuildings(targetCity, refinedValues);
+                    }
+
                     Console.WriteLine($"AI Corp '{Name}': SUCCESSFULLY BUILT {newFactory.Name} in {targetCity.Name}. New Budget: {Budget:C}");
                 }
             }

--- a/LandUseSimulator.cs
+++ b/LandUseSimulator.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Economy_sim
+{
+    /// <summary>
+    /// Simplified developer-agent simulation that rebalances parcel land use based on economic pressures.
+    /// </summary>
+    public static class LandUseSimulator
+    {
+        public static void RunDeveloperAgentSimulation(City city, Dictionary<Parcel, double> landValueMap, Random? random = null)
+        {
+            if (city?.ProceduralData == null)
+            {
+                return;
+            }
+
+            random ??= new Random(city.ProceduralData.Seed);
+            EnsureIndustrialCapacity(city, landValueMap, random);
+            EnsureResidentialCapacity(city, landValueMap, random);
+            EnsureCommercialPresence(city, landValueMap, random);
+            EnsureCivicAmenities(city, landValueMap, random);
+        }
+
+        private static void EnsureIndustrialCapacity(City city, Dictionary<Parcel, double> landValueMap, Random random)
+        {
+            var data = city.ProceduralData;
+            int desiredIndustrial = city.Factories.Count;
+            int currentIndustrial = data.CountBuildingsByLandUse(LandUseType.Industrial);
+            if (currentIndustrial >= desiredIndustrial)
+            {
+                return;
+            }
+
+            foreach (var parcel in SelectConvertibleParcels(city, landValueMap, random)
+                .Where(p => data.GetBuilding(p)?.LandUse != LandUseType.Residential))
+            {
+                if (currentIndustrial >= desiredIndustrial)
+                {
+                    break;
+                }
+
+                parcel.LandUse = LandUseType.Industrial;
+                var building = data.GetBuilding(parcel) ?? new Building();
+                building.LandUse = LandUseType.Industrial;
+                data.SetBuilding(parcel, building);
+
+                var unassignedFactory = city.Factories.FirstOrDefault(f => f.BuildingData == null);
+                if (unassignedFactory != null)
+                {
+                    unassignedFactory.BuildingData = building;
+                }
+
+                currentIndustrial++;
+            }
+        }
+
+        private static void EnsureResidentialCapacity(City city, Dictionary<Parcel, double> landValueMap, Random random)
+        {
+            var data = city.ProceduralData;
+            int desiredResidential = Math.Max(3, (int)Math.Ceiling(city.PopClasses.Sum(p => p.Size) / 20000.0));
+            int currentResidential = data.CountBuildingsByLandUse(LandUseType.Residential);
+            if (currentResidential >= desiredResidential)
+            {
+                return;
+            }
+
+            foreach (var parcel in SelectConvertibleParcels(city, landValueMap, random)
+                .Where(p => !IsFactoryParcel(city, p)))
+            {
+                if (currentResidential >= desiredResidential)
+                {
+                    break;
+                }
+
+                parcel.LandUse = LandUseType.Residential;
+                var building = data.GetBuilding(parcel) ?? new Building();
+                building.LandUse = LandUseType.Residential;
+                data.SetBuilding(parcel, building);
+                currentResidential++;
+            }
+        }
+
+        private static void EnsureCommercialPresence(City city, Dictionary<Parcel, double> landValueMap, Random random)
+        {
+            var data = city.ProceduralData;
+            int desiredCommercial = Math.Max(2, data.CountBuildingsByLandUse(LandUseType.Residential) / 2);
+            int currentCommercial = data.CountBuildingsByLandUse(LandUseType.Commercial);
+            if (currentCommercial >= desiredCommercial)
+            {
+                return;
+            }
+
+            foreach (var parcel in SelectConvertibleParcels(city, landValueMap, random)
+                .Where(p => !IsFactoryParcel(city, p)))
+            {
+                if (currentCommercial >= desiredCommercial)
+                {
+                    break;
+                }
+
+                parcel.LandUse = LandUseType.Commercial;
+                var building = data.GetBuilding(parcel) ?? new Building();
+                building.LandUse = LandUseType.Commercial;
+                data.SetBuilding(parcel, building);
+                currentCommercial++;
+            }
+        }
+
+        private static void EnsureCivicAmenities(City city, Dictionary<Parcel, double> landValueMap, Random random)
+        {
+            var data = city.ProceduralData;
+            int desiredParks = Math.Max(1, data.CountBuildingsByLandUse(LandUseType.Residential) / 4);
+            int currentParks = data.CountBuildingsByLandUse(LandUseType.Park);
+            if (currentParks >= desiredParks)
+            {
+                return;
+            }
+
+            foreach (var parcel in SelectConvertibleParcels(city, landValueMap, random)
+                .Where(p => !IsFactoryParcel(city, p)))
+            {
+                if (currentParks >= desiredParks)
+                {
+                    break;
+                }
+
+                parcel.LandUse = LandUseType.Park;
+                var building = data.GetBuilding(parcel) ?? new Building();
+                building.LandUse = LandUseType.Park;
+                data.SetBuilding(parcel, building);
+                currentParks++;
+            }
+        }
+
+        private static IEnumerable<Parcel> SelectConvertibleParcels(City city, Dictionary<Parcel, double> landValueMap, Random random)
+        {
+            return city.ProceduralData.Parcels
+                .OrderByDescending(p => landValueMap.TryGetValue(p, out var value) ? value : p.LandValue)
+                .ThenBy(_ => random.Next());
+        }
+
+        private static bool IsFactoryParcel(City city, Parcel parcel)
+        {
+            var building = city.ProceduralData.GetBuilding(parcel);
+            if (building == null)
+            {
+                return false;
+            }
+
+            return city.Factories.Any(f => ReferenceEquals(f.BuildingData, building));
+        }
+    }
+}

--- a/LandValueCalculator.cs
+++ b/LandValueCalculator.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Economy_sim
+{
+    /// <summary>
+    /// Calculates parcel land values based on the current economic state of the city.
+    /// </summary>
+    public static class LandValueCalculator
+    {
+        public static Dictionary<Parcel, double> Calculate(City city)
+        {
+            var results = new Dictionary<Parcel, double>();
+            if (city?.ProceduralData == null)
+            {
+                return results;
+            }
+
+            var proceduralData = city.ProceduralData;
+            var template = CityTemplateManager.GetTemplate(proceduralData.TemplateType);
+
+            double populationPressure = Math.Log(Math.Max(1, city.PopClasses.Sum(p => p.Size) + 1)) * 8.0;
+            double wealthFactor = Math.Clamp(city.Budget / Math.Max(1, city.Population + 1), -25, 45);
+            double happinessFactor = city.Happiness * 0.35;
+
+            foreach (var parcel in proceduralData.Parcels)
+            {
+                double baseValue = 25 + populationPressure + wealthFactor;
+
+                switch (parcel.LandUse)
+                {
+                    case LandUseType.Residential:
+                        baseValue += happinessFactor * 0.8;
+                        baseValue += template.IncomeMultiplier * 6;
+                        break;
+                    case LandUseType.Commercial:
+                        baseValue += template.IncomeMultiplier * 12;
+                        baseValue += city.PopClasses.Count * 1.5;
+                        break;
+                    case LandUseType.Industrial:
+                        baseValue += template.FactoryWeights.Values.DefaultIfEmpty(1).Average() * 5;
+                        baseValue += city.Factories.Count * 1.2;
+                        baseValue -= Math.Max(0, 40 - happinessFactor); // pollution penalty
+                        break;
+                    case LandUseType.Park:
+                        baseValue += happinessFactor;
+                        baseValue += template.ExpenseMultiplier * 4;
+                        break;
+                }
+
+                if (proceduralData.GetBuilding(parcel) is { } existingBuilding)
+                {
+                    // Successful or high-level buildings push land value further up.
+                    baseValue += existingBuilding.Level * 3;
+                    baseValue += existingBuilding.EconomicOutput * 0.02;
+                }
+
+                baseValue = Math.Clamp(baseValue, 5, 120);
+                parcel.LandValue = baseValue;
+                results[parcel] = baseValue;
+            }
+
+            return results;
+        }
+    }
+}

--- a/ProceduralCityBuilder.cs
+++ b/ProceduralCityBuilder.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Economy_sim
+{
+    /// <summary>
+    /// Helper responsible for seeding the procedural city layer and linking it with the economic simulation.
+    /// </summary>
+    public static class ProceduralCityBuilder
+    {
+        public static void InitializeCityData(City city, CityTemplate template, Random random)
+        {
+            if (city == null)
+            {
+                return;
+            }
+
+            var seed = random.Next();
+            var proceduralData = new CityProceduralData(template.Type, seed);
+            city.ProceduralData = proceduralData;
+
+            CreateBaseParcels(city, template, random, proceduralData);
+            AssignFactoriesToBuildings(city, proceduralData);
+
+            // First pass land values to inform the bidding simulation.
+            var initialLandValues = LandValueCalculator.Calculate(city);
+            LandUseSimulator.RunDeveloperAgentSimulation(city, initialLandValues, new Random(seed));
+
+            // Recalculate after land use adjustments to capture the latest configuration.
+            var refinedLandValues = LandValueCalculator.Calculate(city);
+            BuildingRefiner.RefineBuildings(city, refinedLandValues);
+        }
+
+        private static void CreateBaseParcels(City city, CityTemplate template, Random random, CityProceduralData proceduralData)
+        {
+            int population = Math.Max(1, city.PopClasses.Sum(p => p.Size));
+            int residentialParcels = Math.Max(6, population / 12000);
+            int industrialParcels = Math.Max(city.Factories.Count, residentialParcels / 3);
+            int commercialParcels = Math.Max(3, residentialParcels / 2);
+            int parkParcels = Math.Max(2, residentialParcels / 4);
+            int flexibleParcels = Math.Max(2, residentialParcels / 5);
+
+            foreach (var parcel in CreateParcels(residentialParcels, LandUseType.Residential))
+            {
+                var building = new Building { LandUse = LandUseType.Residential };
+                proceduralData.Parcels.Add(parcel);
+                proceduralData.SetBuilding(parcel, building);
+            }
+
+            foreach (var parcel in CreateParcels(commercialParcels, LandUseType.Commercial))
+            {
+                var building = new Building { LandUse = LandUseType.Commercial };
+                proceduralData.Parcels.Add(parcel);
+                proceduralData.SetBuilding(parcel, building);
+            }
+
+            foreach (var parcel in CreateParcels(industrialParcels, LandUseType.Industrial))
+            {
+                var building = new Building { LandUse = LandUseType.Industrial };
+                proceduralData.Parcels.Add(parcel);
+                proceduralData.SetBuilding(parcel, building);
+            }
+
+            foreach (var parcel in CreateParcels(parkParcels, LandUseType.Park))
+            {
+                var building = new Building { LandUse = LandUseType.Park };
+                proceduralData.Parcels.Add(parcel);
+                proceduralData.SetBuilding(parcel, building);
+            }
+
+            foreach (var parcel in CreateParcels(flexibleParcels, random.NextDouble() > 0.5 ? LandUseType.Commercial : LandUseType.Park))
+            {
+                proceduralData.Parcels.Add(parcel);
+                // Leave these parcels without buildings initially so the simulator can claim them.
+            }
+        }
+
+        private static IEnumerable<Parcel> CreateParcels(int count, LandUseType landUse)
+        {
+            for (int i = 0; i < count; i++)
+            {
+                yield return new Parcel
+                {
+                    LandUse = landUse
+                };
+            }
+        }
+
+        private static void AssignFactoriesToBuildings(City city, CityProceduralData data)
+        {
+            var industrialBuildings = data.ParcelBuildingPairs
+                .Where(pair => pair.building.LandUse == LandUseType.Industrial)
+                .Select(pair => pair.building)
+                .ToList();
+
+            int index = 0;
+            foreach (var factory in city.Factories)
+            {
+                if (factory.BuildingData != null)
+                {
+                    continue;
+                }
+
+                if (index >= industrialBuildings.Count)
+                {
+                    var extraParcel = new Parcel { LandUse = LandUseType.Industrial };
+                    var extraBuilding = new Building { LandUse = LandUseType.Industrial };
+                    data.Parcels.Add(extraParcel);
+                    data.SetBuilding(extraParcel, extraBuilding);
+                    industrialBuildings.Add(extraBuilding);
+                }
+
+                var building = industrialBuildings[index++];
+                factory.BuildingData = building;
+            }
+        }
+    }
+}

--- a/ProceduralWorldGenerator.cs
+++ b/ProceduralWorldGenerator.cs
@@ -122,6 +122,7 @@ namespace Economy_sim
 
             // Generate population classes based on template
             GeneratePopulationClasses(city, data.InitialPopulation, template, random);
+            city.Population = city.PopClasses.Sum(p => p.Size);
 
             // Generate factories based on template
             GenerateFactories(city, data, template, random, corporationPool);
@@ -131,6 +132,9 @@ namespace Economy_sim
 
             // Initialize local prices
             InitializeLocalPrices(city);
+
+            // Link procedural city data to the economic simulation
+            ProceduralCityBuilder.InitializeCityData(city, template, random);
 
             return city;
         }


### PR DESCRIPTION
## Summary
- link cities and factories to procedurally generated parcels and buildings
- calculate land values, run a simplified land-use simulation, and refine building stats from the generated city data
- seed procedural city layers during world generation and update AI factory construction to attach new industrial buildings

## Testing
- `dotnet build -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e4d9d5df08832395c2135549d84b0f